### PR TITLE
[cleanup] Automatically organize imports on save in VS Code

### DIFF
--- a/frontend/.vscode/settings.json
+++ b/frontend/.vscode/settings.json
@@ -3,10 +3,10 @@
   "editor.formatOnSave": true,
   "editor.formatOnPaste": false,
   "editor.codeActionsOnSave": {
-    "source.organizeImports": false
+    "source.organizeImports": true
   },
   "[javascript]": {
-  "editor.formatOnSave": true
+    "editor.formatOnSave": true
   },
   "editor.defaultFormatter": "esbenp.prettier-vscode"
 }


### PR DESCRIPTION
This prevents some build errors when iterating in frontend source, and by normalizing the imports order automatically for everyone should make merge conflicts on these parts less frequent and easier to deal with.

Signed-off-by: Pierre-Charles David <pierre-charles.david@obeo.fr>