### PR TITLE
Support for delete edge from diagram tool

### DIFF
--- a/backend/sirius-web-collaborative-diagrams-api/src/main/java/org/eclipse/sirius/web/collaborative/diagrams/api/IDiagramDescriptionService.java
+++ b/backend/sirius-web-collaborative-diagrams-api/src/main/java/org/eclipse/sirius/web/collaborative/diagrams/api/IDiagramDescriptionService.java
@@ -16,6 +16,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import org.eclipse.sirius.web.diagrams.description.DiagramDescription;
+import org.eclipse.sirius.web.diagrams.description.EdgeDescription;
 import org.eclipse.sirius.web.diagrams.description.NodeDescription;
 
 /**
@@ -26,5 +27,7 @@ import org.eclipse.sirius.web.diagrams.description.NodeDescription;
 public interface IDiagramDescriptionService {
 
     Optional<NodeDescription> findNodeDescriptionById(DiagramDescription diagramDescription, UUID nodeDescriptionId);
+
+    Optional<EdgeDescription> findEdgeDescriptionById(DiagramDescription diagramDescription, UUID edgeDescriptionId);
 
 }

--- a/backend/sirius-web-collaborative-diagrams-api/src/main/java/org/eclipse/sirius/web/collaborative/diagrams/api/IDiagramService.java
+++ b/backend/sirius-web-collaborative-diagrams-api/src/main/java/org/eclipse/sirius/web/collaborative/diagrams/api/IDiagramService.java
@@ -16,6 +16,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import org.eclipse.sirius.web.diagrams.Diagram;
+import org.eclipse.sirius.web.diagrams.Edge;
 import org.eclipse.sirius.web.diagrams.Node;
 
 /**
@@ -29,5 +30,7 @@ public interface IDiagramService {
     Optional<Diagram> findById(UUID diagramId);
 
     Optional<Node> findNodeById(Diagram diagram, String nodeId);
+
+    Optional<Edge> findEdgeById(Diagram diagram, String edgeId);
 
 }

--- a/backend/sirius-web-collaborative-diagrams-api/src/main/java/org/eclipse/sirius/web/collaborative/diagrams/api/dto/DeleteFromDiagramInput.java
+++ b/backend/sirius-web-collaborative-diagrams-api/src/main/java/org/eclipse/sirius/web/collaborative/diagrams/api/dto/DeleteFromDiagramInput.java
@@ -13,6 +13,7 @@
 package org.eclipse.sirius.web.collaborative.diagrams.api.dto;
 
 import java.text.MessageFormat;
+import java.util.List;
 import java.util.UUID;
 
 import org.eclipse.sirius.web.annotations.graphql.GraphQLField;
@@ -22,9 +23,10 @@ import org.eclipse.sirius.web.annotations.graphql.GraphQLNonNull;
 import org.eclipse.sirius.web.collaborative.diagrams.api.IDiagramInput;
 
 /**
- * The input for the "Delete from diagram" mutation.
+ * The class of the inputs for the "Delete from diagram" mutation.
  *
  * @author pcdavid
+ * @author hmarchadour
  */
 @GraphQLInputObjectType
 public final class DeleteFromDiagramInput implements IDiagramInput {
@@ -32,7 +34,9 @@ public final class DeleteFromDiagramInput implements IDiagramInput {
 
     private UUID representationId;
 
-    private String diagramElementId;
+    private List<String> nodeIds;
+
+    private List<String> edgeIds;
 
     @GraphQLID
     @GraphQLField
@@ -49,16 +53,21 @@ public final class DeleteFromDiagramInput implements IDiagramInput {
         return this.representationId;
     }
 
-    @GraphQLID
     @GraphQLField
     @GraphQLNonNull
-    public String getDiagramElementId() {
-        return this.diagramElementId;
+    public List<@GraphQLNonNull String> getNodeIds() {
+        return this.nodeIds;
+    }
+
+    @GraphQLField
+    @GraphQLNonNull
+    public List<@GraphQLNonNull String> getEdgeIds() {
+        return this.edgeIds;
     }
 
     @Override
     public String toString() {
-        String pattern = "{0} '{'projectId: {1}, representationId: {2}, diagramElementId: {3}'}'"; //$NON-NLS-1$
-        return MessageFormat.format(pattern, this.getClass().getSimpleName(), this.projectId, this.representationId, this.diagramElementId);
+        String pattern = "{0} '{'projectId: {1}, representationId: {2}'}'"; //$NON-NLS-1$
+        return MessageFormat.format(pattern, this.getClass().getSimpleName(), this.projectId, this.representationId);
     }
 }

--- a/backend/sirius-web-compatibility/src/main/java/org/eclipse/sirius/web/compat/services/diagrams/DiagramDescriptionConverter.java
+++ b/backend/sirius-web-compatibility/src/main/java/org/eclipse/sirius/web/compat/services/diagrams/DiagramDescriptionConverter.java
@@ -104,7 +104,7 @@ public class DiagramDescriptionConverter implements IDiagramDescriptionConverter
         nodeDescriptions.addAll(containerDescriptions);
 
         // @formatter:off
-        EdgeMappingConverter edgeMappingConverter = new EdgeMappingConverter(this.objectService, interpreter, this.identifierProvider, id2NodeDescriptions);
+        EdgeMappingConverter edgeMappingConverter = new EdgeMappingConverter(this.objectService, this.editService, interpreter, this.identifierProvider, id2NodeDescriptions);
         List<EdgeDescription> edgeDescriptions = layers.stream()
                 .flatMap(layer -> layer.getEdgeMappings().stream())
                 .map(edgeMappingConverter::convert)

--- a/backend/sirius-web-compatibility/src/test/java/org/eclipse/sirius/web/compat/diagrams/EdgeMappingConverterTestCases.java
+++ b/backend/sirius-web-compatibility/src/test/java/org/eclipse/sirius/web/compat/diagrams/EdgeMappingConverterTestCases.java
@@ -52,8 +52,8 @@ public class EdgeMappingConverterTestCases {
     };
 
     /**
-     * Non-regression test for the create edges issue. This test will ensure that a container description can be used as a valid
-     * target for an edge.
+     * Non-regression test for the create edges issue. This test will ensure that a container description can be used as
+     * a valid target for an edge.
      */
     @Test
     public void testEdgeFromNodeToContainer() {
@@ -73,7 +73,8 @@ public class EdgeMappingConverterTestCases {
                 containerMappingUUID, this.createNodeDescription(containerMappingUUID)
         );
         // @formatter:on
-        EdgeMappingConverter edgeMappingConverter = new EdgeMappingConverter(new NoOpObjectService(), new AQLInterpreter(List.of(), List.of()), this.identifierProvider, id2NodeDescriptions);
+        EdgeMappingConverter edgeMappingConverter = new EdgeMappingConverter(new NoOpObjectService(), new NoOpEditService(), new AQLInterpreter(List.of(), List.of()), this.identifierProvider,
+                id2NodeDescriptions);
 
         EdgeDescription edgeDescription = edgeMappingConverter.convert(edgeMapping);
         assertThat(edgeDescription.getTargetNodeDescriptions()).contains(id2NodeDescriptions.get(containerMappingUUID));
@@ -115,8 +116,8 @@ public class EdgeMappingConverterTestCases {
     }
 
     /**
-     * Non-regression test for the create edges issue. This test will ensure that a container description can be used as a valid
-     * source for an edge.
+     * Non-regression test for the create edges issue. This test will ensure that a container description can be used as
+     * a valid source for an edge.
      */
     @Test
     public void testEdgeFromContainerToNode() {
@@ -136,15 +137,16 @@ public class EdgeMappingConverterTestCases {
                 containerMappingUUID, this.createNodeDescription(containerMappingUUID)
         );
         // @formatter:on
-        EdgeMappingConverter edgeMappingConverter = new EdgeMappingConverter(new NoOpObjectService(), new AQLInterpreter(List.of(), List.of()), this.identifierProvider, id2NodeDescriptions);
+        EdgeMappingConverter edgeMappingConverter = new EdgeMappingConverter(new NoOpObjectService(), new NoOpEditService(), new AQLInterpreter(List.of(), List.of()), this.identifierProvider,
+                id2NodeDescriptions);
 
         EdgeDescription edgeDescription = edgeMappingConverter.convert(edgeMapping);
         assertThat(edgeDescription.getSourceNodeDescriptions()).contains(id2NodeDescriptions.get(containerMappingUUID));
     }
 
     /**
-     * Non-regression test for the create edges issue. This test will ensure that a container description can be used as both a valid
-     * source and a valid target for an edge.
+     * Non-regression test for the create edges issue. This test will ensure that a container description can be used as
+     * both a valid source and a valid target for an edge.
      */
     @Test
     public void testEdgeFromContainerToContainer() {
@@ -164,7 +166,8 @@ public class EdgeMappingConverterTestCases {
                 targetContainerMappingUUID, this.createNodeDescription(targetContainerMappingUUID)
         );
         // @formatter:on
-        EdgeMappingConverter edgeMappingConverter = new EdgeMappingConverter(new NoOpObjectService(), new AQLInterpreter(List.of(), List.of()), this.identifierProvider, id2NodeDescriptions);
+        EdgeMappingConverter edgeMappingConverter = new EdgeMappingConverter(new NoOpObjectService(), new NoOpEditService(), new AQLInterpreter(List.of(), List.of()), this.identifierProvider,
+                id2NodeDescriptions);
 
         EdgeDescription edgeDescription = edgeMappingConverter.convert(edgeMapping);
         edgeDescription.getSourceNodeDescriptions().contains(id2NodeDescriptions.get(sourceContainerMappingUUID));

--- a/backend/sirius-web-compatibility/src/test/java/org/eclipse/sirius/web/compat/diagrams/NoOpEditService.java
+++ b/backend/sirius-web-compatibility/src/test/java/org/eclipse/sirius/web/compat/diagrams/NoOpEditService.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2020 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.compat.diagrams;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.eclipse.sirius.web.services.api.objects.ChildCreationDescription;
+import org.eclipse.sirius.web.services.api.objects.IEditService;
+import org.eclipse.sirius.web.services.api.objects.IEditingContext;
+import org.eclipse.sirius.web.services.api.objects.Namespace;
+
+/**
+ * Implementation of the edit service which does nothing.
+ *
+ * @author sbegaudeau
+ */
+public class NoOpEditService implements IEditService {
+
+    @Override
+    public Optional<Object> findClass(String classId) {
+        return Optional.empty();
+    }
+
+    @Override
+    public List<ChildCreationDescription> getChildCreationDescriptions(String classId) {
+        return new ArrayList<>();
+    }
+
+    @Override
+    public Optional<Object> createChild(IEditingContext editingContext, Object object, String childCreationDescriptionId) {
+        return Optional.empty();
+    }
+
+    @Override
+    public void delete(Object object) {
+        // Do nothing
+    }
+
+    @Override
+    public List<Namespace> getNamespaces() {
+        return new ArrayList<>();
+    }
+
+    @Override
+    public List<ChildCreationDescription> getRootCreationDescriptions(String namespaceId, boolean suggested) {
+        return new ArrayList<>();
+    }
+
+    @Override
+    public Optional<Object> createRootObject(IEditingContext editingContext, UUID documentId, String namespaceId, String rootObjectCreationDescriptionId) {
+        return Optional.empty();
+    }
+
+    @Override
+    public void editLabel(Object object, String labelField, String newValue) {
+        // Do nothing
+    }
+}

--- a/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/description/EdgeDescription.java
+++ b/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/description/EdgeDescription.java
@@ -23,6 +23,7 @@ import org.eclipse.sirius.web.annotations.Immutable;
 import org.eclipse.sirius.web.components.Element;
 import org.eclipse.sirius.web.diagrams.EdgeStyle;
 import org.eclipse.sirius.web.diagrams.Label;
+import org.eclipse.sirius.web.representations.Status;
 import org.eclipse.sirius.web.representations.VariableManager;
 
 /**
@@ -66,6 +67,8 @@ public final class EdgeDescription {
     private Function<VariableManager, List<Element>> targetNodesProvider;
 
     private Function<VariableManager, EdgeStyle> styleProvider;
+
+    private Function<VariableManager, Status> deleteHandler;
 
     private EdgeDescription() {
         // Prevent instantiation
@@ -127,6 +130,10 @@ public final class EdgeDescription {
         return this.styleProvider;
     }
 
+    public Function<VariableManager, Status> getDeleteHandler() {
+        return this.deleteHandler;
+    }
+
     public static Builder newEdgeDescription(UUID id) {
         return new Builder(id);
     }
@@ -171,6 +178,8 @@ public final class EdgeDescription {
         private Function<VariableManager, List<Element>> targetNodesProvider;
 
         private Function<VariableManager, EdgeStyle> styleProvider;
+
+        private Function<VariableManager, Status> deleteHandler;
 
         private Builder(UUID id) {
             this.id = Objects.requireNonNull(id);
@@ -242,6 +251,11 @@ public final class EdgeDescription {
             return this;
         }
 
+        public Builder deleteHandler(Function<VariableManager, Status> deleteHandler) {
+            this.deleteHandler = Objects.requireNonNull(deleteHandler);
+            return this;
+        }
+
         public EdgeDescription build() {
             EdgeDescription edgeDescription = new EdgeDescription();
             edgeDescription.id = Objects.requireNonNull(this.id);
@@ -258,6 +272,7 @@ public final class EdgeDescription {
             edgeDescription.sourceNodesProvider = Objects.requireNonNull(this.sourceNodesProvider);
             edgeDescription.targetNodesProvider = Objects.requireNonNull(this.targetNodesProvider);
             edgeDescription.styleProvider = Objects.requireNonNull(this.styleProvider);
+            edgeDescription.deleteHandler = Objects.requireNonNull(this.deleteHandler);
             return edgeDescription;
         }
     }

--- a/backend/sirius-web-diagrams/src/test/java/org/eclipse/sirius/web/diagrams/renderer/DiagramRendererEdgeTestCases.java
+++ b/backend/sirius-web-diagrams/src/test/java/org/eclipse/sirius/web/diagrams/renderer/DiagramRendererEdgeTestCases.java
@@ -271,6 +271,7 @@ public class DiagramRendererEdgeTestCases {
                 .targetObjectKindProvider(variableManager -> "") //$NON-NLS-1$
                 .targetObjectLabelProvider(variableManager -> "")//$NON-NLS-1$
                 .styleProvider(edgeStyleProvider)
+                .deleteHandler(variableManager -> Status.ERROR)
                 .build();
         // @formatter:on
     }

--- a/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/DiagramDescriptionService.java
+++ b/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/DiagramDescriptionService.java
@@ -20,6 +20,7 @@ import java.util.function.Predicate;
 
 import org.eclipse.sirius.web.collaborative.diagrams.api.IDiagramDescriptionService;
 import org.eclipse.sirius.web.diagrams.description.DiagramDescription;
+import org.eclipse.sirius.web.diagrams.description.EdgeDescription;
 import org.eclipse.sirius.web.diagrams.description.NodeDescription;
 import org.springframework.stereotype.Service;
 
@@ -49,5 +50,14 @@ public class DiagramDescriptionService implements IDiagramDescriptionService {
             }
         }
         return result;
+    }
+
+    @Override
+    public Optional<EdgeDescription> findEdgeDescriptionById(DiagramDescription diagramDescription, UUID edgeDescriptionId) {
+        return this.findEdgeDescription(edgeDesc -> Objects.equals(edgeDesc.getId(), edgeDescriptionId), diagramDescription.getEdgeDescriptions());
+    }
+
+    private Optional<EdgeDescription> findEdgeDescription(Predicate<EdgeDescription> condition, List<EdgeDescription> candidates) {
+        return candidates.stream().filter(condition).findFirst();
     }
 }

--- a/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/DiagramService.java
+++ b/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/DiagramService.java
@@ -24,6 +24,7 @@ import org.eclipse.sirius.web.collaborative.diagrams.api.DiagramCreationParamete
 import org.eclipse.sirius.web.collaborative.diagrams.api.IDiagramService;
 import org.eclipse.sirius.web.components.Element;
 import org.eclipse.sirius.web.diagrams.Diagram;
+import org.eclipse.sirius.web.diagrams.Edge;
 import org.eclipse.sirius.web.diagrams.Node;
 import org.eclipse.sirius.web.diagrams.components.DiagramComponent;
 import org.eclipse.sirius.web.diagrams.components.DiagramComponentProps;
@@ -91,6 +92,11 @@ public class DiagramService implements IDiagramService {
             }
         }
         return result;
+    }
+
+    @Override
+    public Optional<Edge> findEdgeById(Diagram diagram, String edgeId) {
+        return diagram.getEdges().stream().filter(edge -> Objects.equals(edgeId, edge.getId())).findFirst();
     }
 
     @Override

--- a/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/graphql/MutationDeleteFromDiagramDataFetcher.java
+++ b/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/graphql/MutationDeleteFromDiagramDataFetcher.java
@@ -29,7 +29,7 @@ import org.eclipse.sirius.web.spring.graphql.api.IDataFetcherWithFieldCoordinate
 import graphql.schema.DataFetchingEnvironment;
 
 /**
- * The data fetcher used to delete an element from a diagram.
+ * The data fetcher used to delete edges and nodes from a diagram.
  * <p>
  * It will be used to handle the following GraphQL field:
  * </p>
@@ -41,6 +41,8 @@ import graphql.schema.DataFetchingEnvironment;
  * </pre>
  *
  * @author pcdavid
+ * @author sdrapeau
+ * @author hmarchadour
  */
 // @formatter:off
 @GraphQLMutationTypes(

--- a/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/messages/CollaborativeDiagramMessageService.java
+++ b/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/messages/CollaborativeDiagramMessageService.java
@@ -33,6 +33,46 @@ public class CollaborativeDiagramMessageService implements ICollaborativeDiagram
 
     @Override
     public String invalidInput(String expectedInputTypeName, String receivedInputTypeName) {
-        return this.messageSourceAccessor.getMessage("INVALID_INPUT", new Object[] { expectedInputTypeName, receivedInputTypeName }); //$NON-NLS-1$
+        return this.messageSourceAccessor.getMessage(MessageConstants.INVALID_INPUT, new Object[] { expectedInputTypeName, receivedInputTypeName });
+    }
+
+    @Override
+    public String edgeNotFound(String id) {
+        return this.messageSourceAccessor.getMessage(MessageConstants.EDGE_NOT_FOUND, new Object[] { id });
+    }
+
+    @Override
+    public String nodeNotFound(String id) {
+        return this.messageSourceAccessor.getMessage(MessageConstants.NODE_NOT_FOUND, new Object[] { id });
+    }
+
+    @Override
+    public String semanticObjectNotFound(String id) {
+        return this.messageSourceAccessor.getMessage(MessageConstants.SEMANTIC_OBJECT_NOT_FOUND, new Object[] { id });
+    }
+
+    @Override
+    public String nodeDescriptionNotFound(String id) {
+        return this.messageSourceAccessor.getMessage(MessageConstants.NODE_DESCRIPTION_NOT_FOUND, new Object[] { id });
+    }
+
+    @Override
+    public String edgeDescriptionNotFound(String id) {
+        return this.messageSourceAccessor.getMessage(MessageConstants.EDGE_DESCRIPTION_NOT_FOUND, new Object[] { id });
+    }
+
+    @Override
+    public String deleteEdgeFailed(String id) {
+        return this.messageSourceAccessor.getMessage(MessageConstants.DELETE_EGDE_FAILED, new Object[] { id });
+    }
+
+    @Override
+    public String deleteNodeFailed(String id) {
+        return this.messageSourceAccessor.getMessage(MessageConstants.DELETE_NODE_FAILED, new Object[] { id });
+    }
+
+    @Override
+    public String deleteFailed() {
+        return this.messageSourceAccessor.getMessage(MessageConstants.DELETE_FAILED);
     }
 }

--- a/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/messages/ICollaborativeDiagramMessageService.java
+++ b/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/messages/ICollaborativeDiagramMessageService.java
@@ -21,4 +21,19 @@ public interface ICollaborativeDiagramMessageService {
 
     String invalidInput(String expectedInputTypeName, String receivedInputTypeName);
 
+    String edgeNotFound(String id);
+
+    String nodeNotFound(String id);
+
+    String deleteEdgeFailed(String id);
+
+    String deleteNodeFailed(String id);
+
+    String deleteFailed();
+
+    String semanticObjectNotFound(String id);
+
+    String nodeDescriptionNotFound(String id);
+
+    String edgeDescriptionNotFound(String id);
 }

--- a/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/messages/MessageConstants.java
+++ b/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/messages/MessageConstants.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2020 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.spring.collaborative.diagrams.messages;
+
+/**
+ * This class is used to hold all the keys of the internationalization messages.
+ *
+ * @author sdrapeau
+ */
+public final class MessageConstants {
+
+    public static final String INVALID_INPUT = "INVALID_INPUT"; //$NON-NLS-1$
+
+    public static final String EDGE_NOT_FOUND = "EDGE_NOT_FOUND"; //$NON-NLS-1$
+
+    public static final String NODE_NOT_FOUND = "NODE_NOT_FOUND"; //$NON-NLS-1$
+
+    public static final String SEMANTIC_OBJECT_NOT_FOUND = "SEMANTIC_OBJECT_NOT_FOUND"; //$NON-NLS-1$
+
+    public static final String NODE_DESCRIPTION_NOT_FOUND = "NODE_DESCRIPTION_NOT_FOUND"; //$NON-NLS-1$
+
+    public static final String EDGE_DESCRIPTION_NOT_FOUND = "EDGE_DESCRIPTION_NOT_FOUND"; //$NON-NLS-1$
+
+    public static final String DELETE_EGDE_FAILED = "DELETE_EGDE_FAILED"; //$NON-NLS-1$
+
+    public static final String DELETE_NODE_FAILED = "DELETE_NODE_FAILED"; //$NON-NLS-1$
+
+    public static final String DELETE_FAILED = "DELETE_FAILED"; //$NON-NLS-1$
+
+    private MessageConstants() {
+        // Prevent instantiation
+    }
+}

--- a/backend/sirius-web-spring-collaborative-diagrams/src/main/resources/messages/sirius-web-spring-collaborative-diagrams.properties
+++ b/backend/sirius-web-spring-collaborative-diagrams/src/main/resources/messages/sirius-web-spring-collaborative-diagrams.properties
@@ -11,3 +11,11 @@
 #     Obeo - initial API and implementation
 ################################################################################################
 INVALID_INPUT=Invalid input type, "{0}" has been received while "{1}" was expected
+EDGE_NOT_FOUND=Edge "{0}" not found
+NODE_NOT_FOUND=Node "{0}" not found
+SEMANTIC_OBJECT_NOT_FOUND=Semantic object "{0}" not found
+NODE_DESCRIPTION_NOT_FOUND=Node description "{0}" not found
+EDGE_DESCRIPTION_NOT_FOUND=Edge description "{0}" not found
+DELETE_EGDE_FAILED=The deletion on the edge "{0}" has failed
+DELETE_NODE_FAILED=The deletion on the node "{0}" has failed
+DELETE_FAILED=At least one error during the deletion:

--- a/backend/sirius-web-spring-collaborative-diagrams/src/test/java/org/eclipse/sirius/web/spring/collaborative/diagrams/handlers/NoOpCollaborativeDiagramMessageService.java
+++ b/backend/sirius-web-spring-collaborative-diagrams/src/test/java/org/eclipse/sirius/web/spring/collaborative/diagrams/handlers/NoOpCollaborativeDiagramMessageService.java
@@ -26,4 +26,44 @@ public class NoOpCollaborativeDiagramMessageService implements ICollaborativeDia
         return null;
     }
 
+    @Override
+    public String edgeNotFound(String id) {
+        return null;
+    }
+
+    @Override
+    public String nodeNotFound(String id) {
+        return null;
+    }
+
+    @Override
+    public String deleteEdgeFailed(String id) {
+        return null;
+    }
+
+    @Override
+    public String deleteNodeFailed(String id) {
+        return null;
+    }
+
+    @Override
+    public String deleteFailed() {
+        return null;
+    }
+
+    @Override
+    public String semanticObjectNotFound(String id) {
+        return null;
+    }
+
+    @Override
+    public String nodeDescriptionNotFound(String id) {
+        return null;
+    }
+
+    @Override
+    public String edgeDescriptionNotFound(String id) {
+        return null;
+    }
+
 }

--- a/backend/sirius-web-spring-collaborative-diagrams/src/test/java/org/eclipse/sirius/web/spring/collaborative/diagrams/handlers/NoOpDiagramService.java
+++ b/backend/sirius-web-spring-collaborative-diagrams/src/test/java/org/eclipse/sirius/web/spring/collaborative/diagrams/handlers/NoOpDiagramService.java
@@ -18,6 +18,7 @@ import java.util.UUID;
 import org.eclipse.sirius.web.collaborative.diagrams.api.DiagramCreationParameters;
 import org.eclipse.sirius.web.collaborative.diagrams.api.IDiagramService;
 import org.eclipse.sirius.web.diagrams.Diagram;
+import org.eclipse.sirius.web.diagrams.Edge;
 import org.eclipse.sirius.web.diagrams.Node;
 
 /**
@@ -39,6 +40,11 @@ public class NoOpDiagramService implements IDiagramService {
 
     @Override
     public Optional<Node> findNodeById(Diagram diagram, String nodeId) {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<Edge> findEdgeById(Diagram diagram, String edgeId) {
         return Optional.empty();
     }
 }

--- a/frontend/src/diagram/reducer.ts
+++ b/frontend/src/diagram/reducer.ts
@@ -133,7 +133,7 @@ const initializeAction = (prevState, action) => {
   const { displayedRepresentationId, subscribers } = prevState;
   const {
     diagramDomElement,
-    deleteElement,
+    deleteElements,
     invokeTool,
     editLabel,
     onSelectElement,
@@ -152,7 +152,7 @@ const initializeAction = (prevState, action) => {
   diagramServer.setLogger(container.get(TYPES.ILogger));
 
   diagramServer.setEditLabelListener(editLabel);
-  diagramServer.setDeleteElementListener(deleteElement);
+  diagramServer.setDeleteElementsListener(deleteElements);
   diagramServer.setInvokeToolListener(invokeTool);
   diagramServer.setContextualPaletteListener(setContextualPalette);
 

--- a/frontend/src/diagram/sprotty/WebSocketDiagramServer.tsx
+++ b/frontend/src/diagram/sprotty/WebSocketDiagramServer.tsx
@@ -85,7 +85,7 @@ export class SiriusWebWebSocketDiagramServer extends ModelSource {
   modelFactory;
   activeTool;
   editLabel;
-  deleteElement;
+  deleteElements;
 
   invokeTool;
   setContextualPalette;
@@ -271,10 +271,7 @@ export class SiriusWebWebSocketDiagramServer extends ModelSource {
     const { element } = action;
     if (element) {
       const selectedItems = element.index.all().filter((e) => e.selected);
-      selectedItems.forEach((item) => {
-        element.index.remove(item);
-        this.deleteElement(item.id);
-      });
+      this.deleteElements([...selectedItems]);
     } else {
       this.logger.log(this, 'Invalid delete action', action);
     }
@@ -404,8 +401,8 @@ export class SiriusWebWebSocketDiagramServer extends ModelSource {
     this.editLabel = editLabel;
   }
 
-  setDeleteElementListener(deleteElement) {
-    this.deleteElement = deleteElement;
+  setDeleteElementsListener(deleteElements) {
+    this.deleteElements = deleteElements;
   }
 
   setInvokeToolListener(invokeTool) {


### PR DESCRIPTION
### Type of this PR 

- [ ] Bug fix
- [x] Improvement
- [ ] Documentation
- [ ] Cleanup
- [ ] Test

### Issue(s)
 
 #119

### What does this PR do?

Call the delete handler on an edge when the remove tool is triggered.

### Screenshot/screencast of this PR

![cap 114](https://user-images.githubusercontent.com/1506357/100630360-be57cc00-332a-11eb-88b6-dbdead59a5da.png)

### Potential side effects

* Diagram refresh
* Delete tool

### How to test this PR?

- [ ] Frontend Unit tests
- [ ] Backend Unit tests
- [x] Cypress : 
* A test case that delete all edges in Robot topography diagram
- [x] Manual Test : 
* On Robot sample, 
  * create a topography diagram
  * select an edge
  * use the palette delete tool 
    * **we expect a diagram refresh without this edge**
  * select another edge
  * use the [SUPPR] keyboard
    * **we expect a diagram refresh without this edge**

### Checklist

- [x] I have read CONTRIBUTING carefully.
- [x] I have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All my commits are signed-off (`-s`) with my mail address of my Eclipse Account.
- [x] I have covered my changes by unit tests or integration tests or manual tests.
- [x] All tests pass.
- [x] I have updated the documentation accordingly
- [x] New React components are available in storybook
