### PR TITLE
Display mutation/query errors in diagram UX

### DIFF
--- a/frontend/src/diagram/Diagram.module.css
+++ b/frontend/src/diagram/Diagram.module.css
@@ -37,8 +37,9 @@
 }
 
 .diagramWrapper {
-  display: flex;
-  align-items: stretch;
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-template-rows: 1fr;
 }
 .diagram {
   display: flex;
@@ -48,4 +49,9 @@
 
 .diagram > * {
   flex-grow: 1;
+}
+
+.errorBanner {
+  position: fixed;
+  cursor: pointer;
 }


### PR DESCRIPTION
### Type of this PR 

- [ ] Bug fix
- [x] Improvement
- [ ] Documentation
- [ ] Cleanup
- [ ] Test

### Issue(s)
 
 #130

### What does this PR do?

Display errors thanks to the Banner component.
Mutation and queries errors in DiagramWebSocketContainer must be
displayed clearly.

In this implementation, we avoid to change the heavy diagram
machine/reducer thanks to a dedicated useState.
This choice can be debated.
The aim of this implementation:handle a basic UX feedback as simple as
possible.
the actual state machine handle too many things/concepts and the purpose
to display "something goes wrong" should not interact with this complex
state machine(complex by it size)

### Screenshot/screencast of this PR

<img width="411" alt="cap 119" src="https://user-images.githubusercontent.com/1506357/100746446-020d0d00-33e1-11eb-9d92-eb99d0c8cae7.png">

<img width="607" alt="cap 120" src="https://user-images.githubusercontent.com/1506357/100746461-05a09400-33e1-11eb-8939-cceaf0955984.png">


### Potential side effects

* Minor

### How to test this PR?

- [ ] Frontend Unit tests
- [ ] Backend Unit tests
- [ ] Cypress :
- [x] Manual Test : 
* create a robot topography diagram
* try to make an edge between the radar and the camera
* **The invoke edge error message appears in a banner component. A clic on it will close the banner**

### Checklist

- [x] I have read CONTRIBUTING carefully.
- [x] I have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All my commits are signed-off (`-s`) with my mail address of my Eclipse Account.
- [x] I have covered my changes by unit tests or integration tests or manual tests.
- [ ] All tests pass.
- [ ] I have updated the documentation accordingly
- [ ] New React components are available in storybook
