### PR TITLE
[154] Add edit edge label support

### DIFF
--- a/backend/sirius-web-collaborative-diagrams-api/src/main/java/org/eclipse/sirius/web/collaborative/diagrams/api/IDiagramDescriptionService.java
+++ b/backend/sirius-web-collaborative-diagrams-api/src/main/java/org/eclipse/sirius/web/collaborative/diagrams/api/IDiagramDescriptionService.java
@@ -16,6 +16,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import org.eclipse.sirius.web.diagrams.description.DiagramDescription;
+import org.eclipse.sirius.web.diagrams.description.EdgeDescription;
 import org.eclipse.sirius.web.diagrams.description.NodeDescription;
 
 /**
@@ -26,5 +27,7 @@ import org.eclipse.sirius.web.diagrams.description.NodeDescription;
 public interface IDiagramDescriptionService {
 
     Optional<NodeDescription> findNodeDescriptionById(DiagramDescription diagramDescription, UUID nodeDescriptionId);
+
+    Optional<EdgeDescription> findEdgeDescriptionById(DiagramDescription diagramDescription, UUID edgeDescriptionId);
 
 }

--- a/backend/sirius-web-collaborative-diagrams-api/src/main/java/org/eclipse/sirius/web/collaborative/diagrams/api/IDiagramService.java
+++ b/backend/sirius-web-collaborative-diagrams-api/src/main/java/org/eclipse/sirius/web/collaborative/diagrams/api/IDiagramService.java
@@ -16,6 +16,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import org.eclipse.sirius.web.diagrams.Diagram;
+import org.eclipse.sirius.web.diagrams.Edge;
 import org.eclipse.sirius.web.diagrams.Node;
 
 /**
@@ -29,5 +30,7 @@ public interface IDiagramService {
     Optional<Diagram> findById(UUID diagramId);
 
     Optional<Node> findNodeById(Diagram diagram, String nodeId);
+
+    Optional<Edge> findEdgeById(Diagram diagram, String edgeId);
 
 }

--- a/backend/sirius-web-compatibility/src/main/java/org/eclipse/sirius/web/compat/diagrams/EdgeMappingConverter.java
+++ b/backend/sirius-web-compatibility/src/main/java/org/eclipse/sirius/web/compat/diagrams/EdgeMappingConverter.java
@@ -41,6 +41,7 @@ import org.eclipse.sirius.web.diagrams.description.NodeDescription;
 import org.eclipse.sirius.web.diagrams.elements.NodeElementProps;
 import org.eclipse.sirius.web.interpreter.AQLInterpreter;
 import org.eclipse.sirius.web.representations.VariableManager;
+import org.eclipse.sirius.web.services.api.objects.IEditService;
 import org.eclipse.sirius.web.services.api.objects.IObjectService;
 
 /**
@@ -53,14 +54,18 @@ public class EdgeMappingConverter {
 
     private final IObjectService objectService;
 
+    private final IEditService editService;
+
     private final AQLInterpreter interpreter;
 
     private final IdentifierProvider identifierProvider;
 
     private final Map<UUID, NodeDescription> id2NodeDescriptions;
 
-    public EdgeMappingConverter(IObjectService objectService, AQLInterpreter interpreter, IdentifierProvider identifierProvider, Map<UUID, NodeDescription> id2NodeDescriptions) {
+    public EdgeMappingConverter(IObjectService objectService, IEditService editService, AQLInterpreter interpreter, IdentifierProvider identifierProvider,
+            Map<UUID, NodeDescription> id2NodeDescriptions) {
         this.objectService = Objects.requireNonNull(objectService);
+        this.editService = Objects.requireNonNull(editService);
         this.interpreter = Objects.requireNonNull(interpreter);
         this.identifierProvider = Objects.requireNonNull(identifierProvider);
         this.id2NodeDescriptions = Objects.requireNonNull(id2NodeDescriptions);
@@ -134,6 +139,9 @@ public class EdgeMappingConverter {
                 .map(edgeStyle -> this.createLabelProvider(labelStyleDescriptionConverter, edgeStyle.getEndLabelStyleDescription(), "_endlabel")) //$NON-NLS-1$
                 .orElse(variableManager -> Optional.empty());
 
+        ToolConverter toolConverter = new ToolConverter(this.interpreter, this.editService);
+        var labelEditHandler = toolConverter.createDirectEditToolHandler(edgeMapping.getLabelDirectEdit());
+
         return EdgeDescription.newEdgeDescription(UUID.fromString(this.identifierProvider.getIdentifier(edgeMapping)))
                 .idProvider(idProvider)
                 .targetObjectIdProvider(targetIdProvider)
@@ -147,6 +155,7 @@ public class EdgeMappingConverter {
                 .targetNodeDescriptions(targetNodeDescriptions)
                 .sourceNodesProvider(sourceNodesProvider)
                 .targetNodesProvider(targetNodesProvider)
+                .labelEditHandler(labelEditHandler)
                 .styleProvider(styleProvider).build();
         // @formatter:on
     }

--- a/backend/sirius-web-compatibility/src/main/java/org/eclipse/sirius/web/compat/services/diagrams/DiagramDescriptionConverter.java
+++ b/backend/sirius-web-compatibility/src/main/java/org/eclipse/sirius/web/compat/services/diagrams/DiagramDescriptionConverter.java
@@ -104,7 +104,7 @@ public class DiagramDescriptionConverter implements IDiagramDescriptionConverter
         nodeDescriptions.addAll(containerDescriptions);
 
         // @formatter:off
-        EdgeMappingConverter edgeMappingConverter = new EdgeMappingConverter(this.objectService, interpreter, this.identifierProvider, id2NodeDescriptions);
+        EdgeMappingConverter edgeMappingConverter = new EdgeMappingConverter(this.objectService, this.editService, interpreter, this.identifierProvider, id2NodeDescriptions);
         List<EdgeDescription> edgeDescriptions = layers.stream()
                 .flatMap(layer -> layer.getEdgeMappings().stream())
                 .map(edgeMappingConverter::convert)

--- a/backend/sirius-web-compatibility/src/test/java/org/eclipse/sirius/web/compat/diagrams/EdgeMappingConverterTestCases.java
+++ b/backend/sirius-web-compatibility/src/test/java/org/eclipse/sirius/web/compat/diagrams/EdgeMappingConverterTestCases.java
@@ -52,8 +52,8 @@ public class EdgeMappingConverterTestCases {
     };
 
     /**
-     * Non-regression test for the create edges issue. This test will ensure that a container description can be used as a valid
-     * target for an edge.
+     * Non-regression test for the create edges issue. This test will ensure that a container description can be used as
+     * a valid target for an edge.
      */
     @Test
     public void testEdgeFromNodeToContainer() {
@@ -73,7 +73,8 @@ public class EdgeMappingConverterTestCases {
                 containerMappingUUID, this.createNodeDescription(containerMappingUUID)
         );
         // @formatter:on
-        EdgeMappingConverter edgeMappingConverter = new EdgeMappingConverter(new NoOpObjectService(), new AQLInterpreter(List.of(), List.of()), this.identifierProvider, id2NodeDescriptions);
+        EdgeMappingConverter edgeMappingConverter = new EdgeMappingConverter(new NoOpObjectService(), new NoOpEditService(), new AQLInterpreter(List.of(), List.of()), this.identifierProvider,
+                id2NodeDescriptions);
 
         EdgeDescription edgeDescription = edgeMappingConverter.convert(edgeMapping);
         assertThat(edgeDescription.getTargetNodeDescriptions()).contains(id2NodeDescriptions.get(containerMappingUUID));
@@ -115,8 +116,8 @@ public class EdgeMappingConverterTestCases {
     }
 
     /**
-     * Non-regression test for the create edges issue. This test will ensure that a container description can be used as a valid
-     * source for an edge.
+     * Non-regression test for the create edges issue. This test will ensure that a container description can be used as
+     * a valid source for an edge.
      */
     @Test
     public void testEdgeFromContainerToNode() {
@@ -136,15 +137,16 @@ public class EdgeMappingConverterTestCases {
                 containerMappingUUID, this.createNodeDescription(containerMappingUUID)
         );
         // @formatter:on
-        EdgeMappingConverter edgeMappingConverter = new EdgeMappingConverter(new NoOpObjectService(), new AQLInterpreter(List.of(), List.of()), this.identifierProvider, id2NodeDescriptions);
+        EdgeMappingConverter edgeMappingConverter = new EdgeMappingConverter(new NoOpObjectService(), new NoOpEditService(), new AQLInterpreter(List.of(), List.of()), this.identifierProvider,
+                id2NodeDescriptions);
 
         EdgeDescription edgeDescription = edgeMappingConverter.convert(edgeMapping);
         assertThat(edgeDescription.getSourceNodeDescriptions()).contains(id2NodeDescriptions.get(containerMappingUUID));
     }
 
     /**
-     * Non-regression test for the create edges issue. This test will ensure that a container description can be used as both a valid
-     * source and a valid target for an edge.
+     * Non-regression test for the create edges issue. This test will ensure that a container description can be used as
+     * both a valid source and a valid target for an edge.
      */
     @Test
     public void testEdgeFromContainerToContainer() {
@@ -164,7 +166,8 @@ public class EdgeMappingConverterTestCases {
                 targetContainerMappingUUID, this.createNodeDescription(targetContainerMappingUUID)
         );
         // @formatter:on
-        EdgeMappingConverter edgeMappingConverter = new EdgeMappingConverter(new NoOpObjectService(), new AQLInterpreter(List.of(), List.of()), this.identifierProvider, id2NodeDescriptions);
+        EdgeMappingConverter edgeMappingConverter = new EdgeMappingConverter(new NoOpObjectService(), new NoOpEditService(), new AQLInterpreter(List.of(), List.of()), this.identifierProvider,
+                id2NodeDescriptions);
 
         EdgeDescription edgeDescription = edgeMappingConverter.convert(edgeMapping);
         edgeDescription.getSourceNodeDescriptions().contains(id2NodeDescriptions.get(sourceContainerMappingUUID));

--- a/backend/sirius-web-compatibility/src/test/java/org/eclipse/sirius/web/compat/diagrams/NoOpEditService.java
+++ b/backend/sirius-web-compatibility/src/test/java/org/eclipse/sirius/web/compat/diagrams/NoOpEditService.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2020 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.compat.diagrams;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.eclipse.sirius.web.services.api.objects.ChildCreationDescription;
+import org.eclipse.sirius.web.services.api.objects.IEditService;
+import org.eclipse.sirius.web.services.api.objects.IEditingContext;
+import org.eclipse.sirius.web.services.api.objects.Namespace;
+
+/**
+ * The implementation of the {@link IEditService} repository which does nothing.
+ *
+ * @author SMonnier
+ */
+public class NoOpEditService implements IEditService {
+
+    @Override
+    public Optional<Object> findClass(String classId) {
+        return Optional.empty();
+    }
+
+    @Override
+    public List<ChildCreationDescription> getChildCreationDescriptions(String classId) {
+        return new ArrayList<>();
+    }
+
+    @Override
+    public Optional<Object> createChild(IEditingContext editingContext, Object object, String childCreationDescriptionId) {
+        return Optional.empty();
+    }
+
+    @Override
+    public List<Namespace> getNamespaces() {
+        return new ArrayList<>();
+    }
+
+    @Override
+    public List<ChildCreationDescription> getRootCreationDescriptions(String namespaceId, boolean suggested) {
+        return new ArrayList<>();
+    }
+
+    @Override
+    public Optional<Object> createRootObject(IEditingContext editingContext, UUID documentId, String namespaceId, String rootObjectCreationDescriptionId) {
+        return Optional.empty();
+    }
+
+    @Override
+    public void delete(Object object) {
+    }
+
+    @Override
+    public void editLabel(Object object, String labelField, String newValue) {
+    }
+
+}

--- a/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/description/EdgeDescription.java
+++ b/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/description/EdgeDescription.java
@@ -17,12 +17,14 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import org.eclipse.sirius.web.annotations.Immutable;
 import org.eclipse.sirius.web.components.Element;
 import org.eclipse.sirius.web.diagrams.EdgeStyle;
 import org.eclipse.sirius.web.diagrams.Label;
+import org.eclipse.sirius.web.representations.Status;
 import org.eclipse.sirius.web.representations.VariableManager;
 
 /**
@@ -66,6 +68,8 @@ public final class EdgeDescription {
     private Function<VariableManager, List<Element>> targetNodesProvider;
 
     private Function<VariableManager, EdgeStyle> styleProvider;
+
+    private BiFunction<VariableManager, String, Status> labelEditHandler;
 
     private EdgeDescription() {
         // Prevent instantiation
@@ -127,6 +131,10 @@ public final class EdgeDescription {
         return this.styleProvider;
     }
 
+    public BiFunction<VariableManager, String, Status> getLabelEditHandler() {
+        return this.labelEditHandler;
+    }
+
     public static Builder newEdgeDescription(UUID id) {
         return new Builder(id);
     }
@@ -171,6 +179,8 @@ public final class EdgeDescription {
         private Function<VariableManager, List<Element>> targetNodesProvider;
 
         private Function<VariableManager, EdgeStyle> styleProvider;
+
+        private BiFunction<VariableManager, String, Status> labelEditHandler;
 
         private Builder(UUID id) {
             this.id = Objects.requireNonNull(id);
@@ -242,6 +252,11 @@ public final class EdgeDescription {
             return this;
         }
 
+        public Builder labelEditHandler(BiFunction<VariableManager, String, Status> labelEditHandler) {
+            this.labelEditHandler = Objects.requireNonNull(labelEditHandler);
+            return this;
+        }
+
         public EdgeDescription build() {
             EdgeDescription edgeDescription = new EdgeDescription();
             edgeDescription.id = Objects.requireNonNull(this.id);
@@ -258,6 +273,7 @@ public final class EdgeDescription {
             edgeDescription.sourceNodesProvider = Objects.requireNonNull(this.sourceNodesProvider);
             edgeDescription.targetNodesProvider = Objects.requireNonNull(this.targetNodesProvider);
             edgeDescription.styleProvider = Objects.requireNonNull(this.styleProvider);
+            edgeDescription.labelEditHandler = Objects.requireNonNull(this.labelEditHandler);
             return edgeDescription;
         }
     }

--- a/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/DiagramDescriptionService.java
+++ b/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/DiagramDescriptionService.java
@@ -20,6 +20,7 @@ import java.util.function.Predicate;
 
 import org.eclipse.sirius.web.collaborative.diagrams.api.IDiagramDescriptionService;
 import org.eclipse.sirius.web.diagrams.description.DiagramDescription;
+import org.eclipse.sirius.web.diagrams.description.EdgeDescription;
 import org.eclipse.sirius.web.diagrams.description.NodeDescription;
 import org.springframework.stereotype.Service;
 
@@ -49,5 +50,14 @@ public class DiagramDescriptionService implements IDiagramDescriptionService {
             }
         }
         return result;
+    }
+
+    @Override
+    public Optional<EdgeDescription> findEdgeDescriptionById(DiagramDescription diagramDescription, UUID edgeDescriptionId) {
+        return this.findEdgeDescription(edgeDesc -> Objects.equals(edgeDesc.getId(), edgeDescriptionId), diagramDescription.getEdgeDescriptions());
+    }
+
+    private Optional<EdgeDescription> findEdgeDescription(Predicate<EdgeDescription> condition, List<EdgeDescription> candidates) {
+        return candidates.stream().filter(condition).findFirst();
     }
 }

--- a/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/DiagramService.java
+++ b/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/DiagramService.java
@@ -24,6 +24,7 @@ import org.eclipse.sirius.web.collaborative.diagrams.api.DiagramCreationParamete
 import org.eclipse.sirius.web.collaborative.diagrams.api.IDiagramService;
 import org.eclipse.sirius.web.components.Element;
 import org.eclipse.sirius.web.diagrams.Diagram;
+import org.eclipse.sirius.web.diagrams.Edge;
 import org.eclipse.sirius.web.diagrams.Node;
 import org.eclipse.sirius.web.diagrams.components.DiagramComponent;
 import org.eclipse.sirius.web.diagrams.components.DiagramComponentProps;
@@ -102,5 +103,14 @@ public class DiagramService implements IDiagramService {
                 .filter(Diagram.class::isInstance)
                 .map(Diagram.class::cast);
         // @formatter:on
+    }
+
+    @Override
+    public Optional<Edge> findEdgeById(Diagram diagram, String edgeId) {
+        return this.findEdge(edge -> Objects.equals(edge.getId(), edgeId), diagram.getEdges());
+    }
+
+    private Optional<Edge> findEdge(Predicate<Edge> condition, List<Edge> candidates) {
+        return candidates.stream().filter(condition).findFirst();
     }
 }

--- a/backend/sirius-web-spring-collaborative-diagrams/src/test/java/org/eclipse/sirius/web/spring/collaborative/diagrams/handlers/NoOpDiagramService.java
+++ b/backend/sirius-web-spring-collaborative-diagrams/src/test/java/org/eclipse/sirius/web/spring/collaborative/diagrams/handlers/NoOpDiagramService.java
@@ -18,6 +18,7 @@ import java.util.UUID;
 import org.eclipse.sirius.web.collaborative.diagrams.api.DiagramCreationParameters;
 import org.eclipse.sirius.web.collaborative.diagrams.api.IDiagramService;
 import org.eclipse.sirius.web.diagrams.Diagram;
+import org.eclipse.sirius.web.diagrams.Edge;
 import org.eclipse.sirius.web.diagrams.Node;
 
 /**
@@ -39,6 +40,11 @@ public class NoOpDiagramService implements IDiagramService {
 
     @Override
     public Optional<Node> findNodeById(Diagram diagram, String nodeId) {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<Edge> findEdgeById(Diagram diagram, String edgeId) {
         return Optional.empty();
     }
 }

--- a/frontend/src/diagram/DiagramWebSocketContainer.tsx
+++ b/frontend/src/diagram/DiagramWebSocketContainer.tsx
@@ -48,7 +48,7 @@ import { useProject } from 'project/ProjectProvider';
 import PropTypes from 'prop-types';
 import React, { useCallback, useEffect, useReducer, useRef } from 'react';
 import 'reflect-metadata'; // Required because Sprotty uses Inversify and both frameworks are written in TypeScript with experimental features.
-import { EditLabelAction, FitToScreenAction } from 'sprotty';
+import { EditLabelAction, FitToScreenAction, SEdge } from 'sprotty';
 import styles from './Diagram.module.css';
 import {
   deleteFromDiagramMutation,
@@ -515,10 +515,11 @@ export const DiagramWebSocketContainer = ({ representationId, selection, setSele
     };
     let invokeLabelEditFromContextualPalette;
     if (renameable) {
+      let elementIdSuffix = element instanceof SEdge ? '_centerlabel' : '_label';
       invokeLabelEditFromContextualPalette = () =>
         diagramServer.actionDispatcher.dispatchAll([
           { kind: HIDE_CONTEXTUAL_TOOLBAR_ACTION },
-          new EditLabelAction(element.id + '_label'),
+          new EditLabelAction(element.id + elementIdSuffix),
         ]);
     }
     let invokeDeleteFromContextualPalette;

--- a/frontend/src/diagram/sprotty/WebSocketDiagramServer.tsx
+++ b/frontend/src/diagram/sprotty/WebSocketDiagramServer.tsx
@@ -24,7 +24,6 @@ import {
   getAbsoluteBounds,
   SGraph,
   SNode,
-  SEdge,
 } from 'sprotty';
 import { convertDiagram } from 'diagram/sprotty/convertDiagram';
 /** Action to delete a sprotty element */
@@ -318,7 +317,7 @@ export class SiriusWebWebSocketDiagramServer extends ModelSource {
           canvasBounds: bounds,
           origin,
           element: element,
-          renameable: !(element instanceof SGraph) && !(element instanceof SEdge),
+          renameable: !(element instanceof SGraph),
           deletable: !(element instanceof SGraph),
         };
         this.setContextualPalette(contextualPalette);

--- a/frontend/src/diagram/sprotty/__tests__/convertDiagram.test.ts
+++ b/frontend/src/diagram/sprotty/__tests__/convertDiagram.test.ts
@@ -117,6 +117,7 @@ describe('ModelConverter', () => {
           'style',
           'routingPoints',
           'features',
+          'editableLabel',
           'children',
         ]);
 

--- a/frontend/src/diagram/sprotty/convertDiagram.tsx
+++ b/frontend/src/diagram/sprotty/convertDiagram.tsx
@@ -127,6 +127,7 @@ const convertEdge = (edge) => {
     style,
     routingPoints,
     features: createFeatureSet([deletableFeature, selectFeature, fadeFeature, hoverFeedbackFeature]),
+    editableLabel: centerLabel,
     children: children,
   };
 };


### PR DESCRIPTION
Selecting an edge now display an edit tool in the popup palette allowing
the user to rename the edge.

Bug: https://github.com/eclipse-sirius/sirius-components/issues/154
Signed-off-by: Steve Monnier <steve.monnier@obeo.fr>

### Type of this PR 

- [ ] Bug fix
- [ ] New feature or improvement
- [ ] Documentation
- [ ] Cleanup
- [ ] Test
- [ ] Build/Releng

### Issue(s)

...

### What does this PR do?

...

### Screenshot/screencast of this PR

...
 

### Potential side effects

...

### How to test this PR?

- [ ] Frontend Unit tests
- [ ] Backend Unit tests
- [ ] Cypress : please specify
- [ ] Manual Test : please specify

### Checklist

- [ ] I have read CONTRIBUTING carefully.
- [ ] I have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [ ] All my commits are signed-off (`-s`) with my mail address of my Eclipse Account.
- [ ] I have covered my changes by unit tests or integration tests or manual tests.
- [ ] All tests pass.
- [ ] I have updated the documentation accordingly
- [ ] New React components are availables in storybook
