### PR TITLE
[cleanup] Remove GraphQLLong from GraphQLScalarConverter

### DIFF
--- a/backend/sirius-web-graphql-utils/src/main/java/org/eclipse/sirius/web/graphql/utils/providers/GraphQLScalarConverter.java
+++ b/backend/sirius-web-graphql-utils/src/main/java/org/eclipse/sirius/web/graphql/utils/providers/GraphQLScalarConverter.java
@@ -34,9 +34,7 @@ public class GraphQLScalarConverter {
         Map.entry(Float.class.getName(), Scalars.GraphQLFloat),
         Map.entry(Float.TYPE.getName(), Scalars.GraphQLFloat),
         Map.entry(Double.class.getName(), Scalars.GraphQLFloat),
-        Map.entry(Double.TYPE.getName(), Scalars.GraphQLFloat),
-        Map.entry(Long.class.getName(), Scalars.GraphQLLong),
-        Map.entry(Long.TYPE.getName(), Scalars.GraphQLLong)
+        Map.entry(Double.TYPE.getName(), Scalars.GraphQLFloat)
     );
     // @formatter:on
 


### PR DESCRIPTION
The type is deprecated and planned for removal in the latest version
of GraphQL Java, and we do not actually use it in our schema.

Signed-off-by: Pierre-Charles David <pierre-charles.david@obeo.fr>

### Type of this PR 

- [ ] Bug fix
- [ ] New feature or improvement
- [ ] Documentation
- [x] Cleanup
- [ ] Test
- [ ] Build/Releng

### Issue(s)

See commit message.

### What does this PR do?

See commit message.

### How to test this PR?

The existing tests should be enough to ensure the change does not cause any regression.

### Checklist

- [x] I have read CONTRIBUTING carefully.
- [x] I have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All my commits are signed-off (`-s`) with my mail address of my Eclipse Account.
- [ ] I have covered my changes by unit tests or integration tests or manual tests.
- [ ] All tests pass.
- [ ] I have updated the documentation accordingly
- [ ] New React components are availables in storybook
