### PR TITLE
[159] Make the diagrams-related components easier to reuse

### DIFF
--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -123,3 +123,5 @@ export * from 'diagram/palette/ContextualPalette';
 export * from 'diagram/palette/tool/Tool';
 export * from 'diagram/palette/tool-section/ToolSection';
 export * from 'diagram/palette/tool-separator/ToolSeparator';
+export * from 'diagram/DiagramWebSocketContainer';
+export * from 'diagram/Toolbar';

--- a/frontend/src/views/edit-project/EditProjectLoadedView.tsx
+++ b/frontend/src/views/edit-project/EditProjectLoadedView.tsx
@@ -28,16 +28,20 @@ const selectionPropType = PropTypes.shape(
   })
 );
 const propTypes = {
+  projectId: PropTypes.string.isRequired,
   subscribers: PropTypes.array.isRequired,
   representations: PropTypes.array.isRequired,
+  readOnly: PropTypes.bool.isRequired,
   selection: selectionPropType,
   displayedRepresentation: PropTypes.object,
   setSelection: PropTypes.func.isRequired,
   setSubscribers: PropTypes.func.isRequired,
 };
 export const EditProjectLoadedView = ({
+  projectId,
   subscribers,
   representations,
+  readOnly,
   selection,
   displayedRepresentation,
   setSelection,
@@ -53,7 +57,9 @@ export const EditProjectLoadedView = ({
 
   let representation = (
     <RepresentationArea
+      projectId={projectId}
       representations={representations}
+      readOnly={readOnly}
       selection={selection}
       displayedRepresentation={displayedRepresentation}
       setSelection={setSelection}

--- a/frontend/src/views/edit-project/EditProjectView.tsx
+++ b/frontend/src/views/edit-project/EditProjectView.tsx
@@ -63,8 +63,10 @@ export const EditProjectView = () => {
 
   const context = useProject() as any;
   let contextId;
+  let canEdit = false;
   if (context) {
     contextId = context.id;
+    canEdit = context.canEdit;
   }
 
   useEffect(() => {
@@ -164,8 +166,10 @@ export const EditProjectView = () => {
   }
   return (
     <EditProjectLoadedView
+      projectId={projectId}
       subscribers={subscribers}
       representations={representations}
+      readOnly={!canEdit}
       displayedRepresentation={displayedRepresentation}
       selection={selection}
       setSelection={setSelection}

--- a/frontend/src/views/edit-project/RepresentationArea.tsx
+++ b/frontend/src/views/edit-project/RepresentationArea.tsx
@@ -21,6 +21,8 @@ import { RepresentationNavigation } from 'views/edit-project/RepresentationNavig
 import styles from './RepresentationArea.module.css';
 
 const propTypes = {
+  projectId: PropTypes.string.isRequired,
+  readOnly: PropTypes.bool.isRequired,
   representations: PropTypes.array.isRequired,
   selection: PropTypes.object,
   displayedRepresentation: PropTypes.object,
@@ -28,7 +30,9 @@ const propTypes = {
   setSubscribers: PropTypes.func.isRequired,
 };
 export const RepresentationArea = ({
+  projectId,
   representations,
+  readOnly,
   selection,
   displayedRepresentation,
   setSelection,
@@ -40,7 +44,9 @@ export const RepresentationArea = ({
   } else if (displayedRepresentation.kind === 'Diagram') {
     content = (
       <DiagramWebSocketContainer
+        projectId={projectId}
         representationId={displayedRepresentation.id}
+        readOnly={readOnly}
         selection={selection}
         setSelection={setSelection}
         setSubscribers={setSubscribers}


### PR DESCRIPTION
This commit is a first part of the refactoring to improve the reusability of
our representations. Additional contributions will define a clear contract
between the core parts of the application and representation components.

Bug: https://github.com/eclipse-sirius/sirius-components/issues/159
Signed-off-by: Stéphane Bégaudeau <stephane.begaudeau@obeo.fr>

### Type of this PR 

- [ ] Bug fix
- [x] New feature or improvement
- [ ] Documentation
- [ ] Cleanup
- [ ] Test
- [ ] Build/Releng

### Issue(s)

...

### What does this PR do?

...

### Screenshot/screencast of this PR

...
 

### Potential side effects

...

### How to test this PR?

- [ ] Frontend Unit tests
- [ ] Backend Unit tests
- [x] Cypress : please specify
- [ ] Manual Test : please specify

### Checklist

- [x] I have read CONTRIBUTING carefully.
- [x] I have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All my commits are signed-off (`-s`) with my mail address of my Eclipse Account.
- [ ] I have covered my changes by unit tests or integration tests or manual tests.
- [x] All tests pass.
- [ ] I have updated the documentation accordingly
- [ ] New React components are availables in storybook
