### PR TITLE
[188] Ignore Sequence Diagram in VSMs

### DIFF
--- a/backend/sirius-web-compatibility/src/main/java/org/eclipse/sirius/web/compat/services/representations/SiriusRepresentationDescriptionProvider.java
+++ b/backend/sirius-web-compatibility/src/main/java/org/eclipse/sirius/web/compat/services/representations/SiriusRepresentationDescriptionProvider.java
@@ -57,7 +57,8 @@ public class SiriusRepresentationDescriptionProvider {
 
         List<IRepresentationDescription> representationDescriptions = new ArrayList<>();
         for (RepresentationDescription siriusRepresentationDescription : siriusRepresentationDescriptions) {
-            if (siriusRepresentationDescription instanceof org.eclipse.sirius.diagram.description.DiagramDescription) {
+            if (siriusRepresentationDescription instanceof org.eclipse.sirius.diagram.description.DiagramDescription
+                    && !(siriusRepresentationDescription instanceof org.eclipse.sirius.diagram.sequence.description.SequenceDiagramDescription)) {
                 representationDescriptions.add(this.diagramDescriptionConverter.convert((org.eclipse.sirius.diagram.description.DiagramDescription) siriusRepresentationDescription));
             }
         }


### PR DESCRIPTION
Fixes #188

Bug: https://github.com/eclipse-sirius/sirius-components/issues/188
Signed-off-by: Mélanie Bats <melanie.bats@obeo.fr>
Signed-off-by: Pierre-Charles David <pierre-charles.david@obeo.fr>

### Type of this PR 

- [x] Bug fix
- [ ] New feature or improvement
- [ ] Documentation
- [ ] Cleanup
- [ ] Test
- [ ] Build/Releng

### Issue(s)

See https://github.com/eclipse-sirius/sirius-components/issues/188

### What does this PR do?

Do not try to transpile sequence diagram descriptions found in VSMs, we do not support them and the resulting conversion is meaningless.

### How to test this PR?

- [ ] Frontend Unit tests
- [ ] Backend Unit tests
- [ ] Cypress : please specify
- [ ] Manual Test : please specify

### Checklist

- [x] I have read CONTRIBUTING carefully.
- [x] I have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All my commits are signed-off (`-s`) with my mail address of my Eclipse Account.
- [ ] I have covered my changes by unit tests or integration tests or manual tests.
- [x] All tests pass.
- [ ] I have updated the documentation accordingly
- [ ] New React components are availables in storybook
