### PR TITLE
[190] Add support for inverse references navigation

### DIFF
--- a/backend/sirius-web-interpreter/src/main/java/org/eclipse/sirius/web/interpreter/AQLInterpreter.java
+++ b/backend/sirius-web-interpreter/src/main/java/org/eclipse/sirius/web/interpreter/AQLInterpreter.java
@@ -74,7 +74,7 @@ public class AQLInterpreter {
      *            to classes, such as <semanticMM>::<AClass>, can be interpreted.
      */
     public AQLInterpreter(List<Class<?>> classes, List<EPackage> ePackages) {
-        this.queryEnvironment = Query.newEnvironmentWithDefaultServices(null);
+        this.queryEnvironment = Query.newEnvironmentWithDefaultServices(new SimpleCrossReferenceProvider());
         this.queryEnvironment.registerEPackage(EcorePackage.eINSTANCE);
         this.queryEnvironment.registerCustomClassMapping(EcorePackage.eINSTANCE.getEStringToStringMapEntry(), EStringToStringMapEntryImpl.class);
 

--- a/backend/sirius-web-interpreter/src/main/java/org/eclipse/sirius/web/interpreter/SimpleCrossReferenceProvider.java
+++ b/backend/sirius-web-interpreter/src/main/java/org/eclipse/sirius/web/interpreter/SimpleCrossReferenceProvider.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.interpreter;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import org.eclipse.acceleo.query.runtime.CrossReferenceProvider;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.EStructuralFeature.Setting;
+import org.eclipse.emf.ecore.util.ECrossReferenceAdapter;
+
+/**
+ * {@link CrossReferenceProvider} implementation which simply looks for an existing {@link ECrossReferenceAdapter}
+ * already attached to the source {@link EObject}. Returns an empty set of references without any error if no
+ * {@link ECrossReferenceAdapter} is found.
+ *
+ * @author pcdavid
+ */
+public class SimpleCrossReferenceProvider implements CrossReferenceProvider {
+    @Override
+    public Collection<Setting> getInverseReferences(EObject self) {
+        if (self != null) {
+            // @formatter:off
+            var xref = self.eAdapters().stream()
+                           .filter(ECrossReferenceAdapter.class::isInstance)
+                           .map(ECrossReferenceAdapter.class::cast)
+                           .findFirst();
+            // @formatter:on
+            if (xref.isPresent()) {
+                return xref.get().getInverseReferences(self);
+            }
+        }
+        return Collections.emptySet();
+    }
+}

--- a/backend/sirius-web-services/src/main/java/org/eclipse/sirius/web/services/documents/EditingDomainFactory.java
+++ b/backend/sirius-web-services/src/main/java/org/eclipse/sirius/web/services/documents/EditingDomainFactory.java
@@ -18,6 +18,7 @@ import org.eclipse.emf.ecore.EcorePackage;
 import org.eclipse.emf.ecore.impl.EPackageRegistryImpl;
 import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
+import org.eclipse.emf.ecore.util.ECrossReferenceAdapter;
 import org.eclipse.emf.ecore.util.EcoreAdapterFactory;
 import org.eclipse.emf.edit.domain.AdapterFactoryEditingDomain;
 import org.eclipse.emf.edit.provider.ComposedAdapterFactory;
@@ -39,6 +40,7 @@ public class EditingDomainFactory {
 
         ResourceSet resourceSet = new ResourceSetImpl();
         resourceSet.setPackageRegistry(ePackageRegistry);
+        resourceSet.eAdapters().add(new ECrossReferenceAdapter());
 
         AdapterFactoryEditingDomain editingDomain = new AdapterFactoryEditingDomain(composedAdapterFactory, new BasicCommandStack(), resourceSet);
         return editingDomain;

--- a/backend/sirius-web-services/src/main/java/org/eclipse/sirius/web/services/editingcontext/EditingContextSearchService.java
+++ b/backend/sirius-web-services/src/main/java/org/eclipse/sirius/web/services/editingcontext/EditingContextSearchService.java
@@ -26,6 +26,7 @@ import org.eclipse.emf.ecore.EPackage;
 import org.eclipse.emf.ecore.impl.EPackageRegistryImpl;
 import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
+import org.eclipse.emf.ecore.util.ECrossReferenceAdapter;
 import org.eclipse.emf.edit.domain.AdapterFactoryEditingDomain;
 import org.eclipse.emf.edit.provider.ComposedAdapterFactory;
 import org.eclipse.sirius.emfjson.resource.JsonResource;
@@ -93,6 +94,7 @@ public class EditingContextSearchService implements IEditingContextSearchService
 
         this.logger.debug("Loading the editing context {}", editingContextId); //$NON-NLS-1$
         ResourceSet resourceSet = new ResourceSetImpl();
+        resourceSet.eAdapters().add(new ECrossReferenceAdapter());
 
         EPackageRegistryImpl ePackageRegistry = new EPackageRegistryImpl();
         this.globalEPackageRegistry.forEach(ePackageRegistry::put);

--- a/backend/sirius-web-services/src/test/java/org/eclipse/sirius/web/services/editingcontext/EditingContextSearchServiceTests.java
+++ b/backend/sirius-web-services/src/test/java/org/eclipse/sirius/web/services/editingcontext/EditingContextSearchServiceTests.java
@@ -22,6 +22,7 @@ import org.eclipse.emf.ecore.EPackage;
 import org.eclipse.emf.ecore.EcorePackage;
 import org.eclipse.emf.ecore.impl.EPackageRegistryImpl;
 import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.util.ECrossReferenceAdapter;
 import org.eclipse.emf.edit.domain.EditingDomain;
 import org.eclipse.emf.edit.provider.ComposedAdapterFactory;
 import org.eclipse.sirius.web.core.api.IEditingContext;
@@ -143,9 +144,22 @@ public class EditingContextSearchServiceTests {
 
     private void assertProperResourceLoading(Resource resource, DocumentEntity documentEntity) {
         assertThat(resource).isNotNull();
-        assertThat(resource.eAdapters()).hasSize(1);
-        assertThat(resource.eAdapters().get(0)).isInstanceOf(DocumentMetadataAdapter.class);
-        DocumentMetadataAdapter firstAdapter = (DocumentMetadataAdapter) resource.eAdapters().get(0);
-        assertThat(firstAdapter.getName()).isEqualTo(documentEntity.getName());
+        assertThat(resource.eAdapters()).hasSize(2);
+        // @formatter:off
+        var optionalDocumentMetadataAdapter = resource.eAdapters().stream()
+                                                      .filter(DocumentMetadataAdapter.class::isInstance)
+                                                      .map(DocumentMetadataAdapter.class::cast)
+                                                      .findFirst();
+        // @formatter:on
+        assertThat(optionalDocumentMetadataAdapter).isPresent();
+        assertThat(optionalDocumentMetadataAdapter.get().getName()).isEqualTo(documentEntity.getName());
+
+        // @formatter:off
+        var optionalCrossReferencerAdapter = resource.eAdapters().stream()
+                                                      .filter(ECrossReferenceAdapter.class::isInstance)
+                                                      .map(ECrossReferenceAdapter.class::cast)
+                                                      .findFirst();
+        // @formatter:on
+        assertThat(optionalCrossReferencerAdapter).isPresent();
     }
 }


### PR DESCRIPTION
### Type of this PR 

- [ ] Bug fix
- [x] New feature or improvement
- [ ] Documentation
- [ ] Cleanup
- [ ] Test
- [ ] Build/Releng

### Issue(s)

See https://github.com/eclipse-sirius/sirius-components/issues/190

### What does this PR do?

Install an ECrossReferenceAdapter directly on every EditingContext, and configure the AQL interpreter to use it as the source for eInverse().

### Potential side effects

See https://github.com/eclipse-sirius/sirius-components/issues/190

### How to test this PR?

I have not (yet) added specific tests, so this should probably not be merged for now.

- [ ] Frontend Unit tests
- [ ] Backend Unit tests
- [ ] Cypress : please specify
- [ ] Manual Test : please specify

### Checklist

- [x] I have read CONTRIBUTING carefully.
- [x] I have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All my commits are signed-off (`-s`) with my mail address of my Eclipse Account.
- [ ] I have covered my changes by unit tests or integration tests or manual tests.
- [ ] All tests pass.
- [ ] I have updated the documentation accordingly
