### PR TITLE
[build] Cache Node and Maven dependencies for faster builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,16 @@ jobs:
         with:
           node-version: 14
           registry-url: https://npm.pkg.github.com/
-
+          
+      - name: Cache Node.js modules
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.OS }}-node-
+            ${{ runner.OS }}-
+      
       - name: Install Yalc globally
         run: npm i yalc -g
 
@@ -29,6 +38,13 @@ jobs:
         with:
           java-version: 11
 
+      - name: Cache Maven packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      
       - name: Build the frontend
         run: |
           npm ci


### PR DESCRIPTION
### Type of this PR 

- [ ] Bug fix
- [ ] New feature or improvement
- [ ] Documentation
- [ ] Cleanup
- [ ] Test
- [x] Build/Releng

### What does this PR do?

Try to speed up the builds by enabling caching of Node and Maven dependencies.
See:
* https://docs.github.com/en/free-pro-team@latest/actions/guides/building-and-testing-java-with-maven#caching-dependencies
* https://docs.github.com/en/free-pro-team@latest/actions/guides/building-and-testing-nodejs#example-caching-dependencies

### Checklist

- [x] I have read CONTRIBUTING carefully.
- [x] I have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All my commits are signed-off (`-s`) with my mail address of my Eclipse Account.
- [ ] I have covered my changes by unit tests or integration tests or manual tests.
- [ ] All tests pass.
- [ ] I have updated the documentation accordingly
- [ ] New React components are availables in storybook
