### PR TITLE
[161] Add success payload for MutationUpdateWidgetFocusDataFetcher

### DIFF
--- a/backend/sirius-web-collaborative-forms-api/src/main/java/org/eclipse/sirius/web/collaborative/forms/api/dto/UpdateWidgetFocusSuccessPayload.java
+++ b/backend/sirius-web-collaborative-forms-api/src/main/java/org/eclipse/sirius/web/collaborative/forms/api/dto/UpdateWidgetFocusSuccessPayload.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2020 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.collaborative.forms.api.dto;
+
+import java.text.MessageFormat;
+import java.util.Objects;
+
+import org.eclipse.sirius.web.annotations.graphql.GraphQLField;
+import org.eclipse.sirius.web.annotations.graphql.GraphQLNonNull;
+import org.eclipse.sirius.web.annotations.graphql.GraphQLObjectType;
+import org.eclipse.sirius.web.services.api.dto.IPayload;
+
+/**
+ * The payload of the "Widget Focus" mutation returned on success.
+ *
+ * @author smonnier
+ */
+@GraphQLObjectType
+public final class UpdateWidgetFocusSuccessPayload implements IPayload {
+    private final String widgetId;
+
+    public UpdateWidgetFocusSuccessPayload(String widgetId) {
+        this.widgetId = Objects.requireNonNull(widgetId);
+    }
+
+    @GraphQLField
+    @GraphQLNonNull
+    public String getUpdateFocusWidgetId() {
+        return this.widgetId;
+    }
+
+    @Override
+    public String toString() {
+        String pattern = "{0} '{'widgetId: {1}'}'"; //$NON-NLS-1$
+        return MessageFormat.format(pattern, this.getClass().getSimpleName(), this.widgetId);
+    }
+}

--- a/backend/sirius-web-graphql/src/main/java/org/eclipse/sirius/web/graphql/datafetchers/mutation/MutationUpdateWidgetFocusDataFetcher.java
+++ b/backend/sirius-web-graphql/src/main/java/org/eclipse/sirius/web/graphql/datafetchers/mutation/MutationUpdateWidgetFocusDataFetcher.java
@@ -18,6 +18,7 @@ import org.eclipse.sirius.web.annotations.graphql.GraphQLMutationTypes;
 import org.eclipse.sirius.web.annotations.spring.graphql.MutationDataFetcher;
 import org.eclipse.sirius.web.collaborative.api.services.IProjectEventProcessorRegistry;
 import org.eclipse.sirius.web.collaborative.forms.api.dto.UpdateWidgetFocusInput;
+import org.eclipse.sirius.web.collaborative.forms.api.dto.UpdateWidgetFocusSuccessPayload;
 import org.eclipse.sirius.web.graphql.datafetchers.IDataFetchingEnvironmentService;
 import org.eclipse.sirius.web.graphql.messages.IGraphQLMessageService;
 import org.eclipse.sirius.web.graphql.schema.MutationTypeProvider;
@@ -45,6 +46,7 @@ import graphql.schema.DataFetchingEnvironment;
 @GraphQLMutationTypes(
     input = UpdateWidgetFocusInput.class,
     payloads = {
+            UpdateWidgetFocusSuccessPayload.class
     }
 )
 @MutationDataFetcher(type = MutationTypeProvider.TYPE, field = MutationUpdateWidgetFocusDataFetcher.UPDATE_WIDGET_FOCUS_FIELD)

--- a/backend/sirius-web-spring-collaborative-forms/src/main/java/org/eclipse/sirius/web/spring/collaborative/forms/FormEventProcessor.java
+++ b/backend/sirius-web-spring-collaborative-forms/src/main/java/org/eclipse/sirius/web/spring/collaborative/forms/FormEventProcessor.java
@@ -28,6 +28,7 @@ import org.eclipse.sirius.web.collaborative.forms.api.IFormInput;
 import org.eclipse.sirius.web.collaborative.forms.api.IWidgetSubscriptionManager;
 import org.eclipse.sirius.web.collaborative.forms.api.dto.FormRefreshedEventPayload;
 import org.eclipse.sirius.web.collaborative.forms.api.dto.UpdateWidgetFocusInput;
+import org.eclipse.sirius.web.collaborative.forms.api.dto.UpdateWidgetFocusSuccessPayload;
 import org.eclipse.sirius.web.components.Element;
 import org.eclipse.sirius.web.forms.Form;
 import org.eclipse.sirius.web.forms.components.FormComponent;
@@ -108,12 +109,14 @@ public class FormEventProcessor implements IFormEventProcessor {
 
     @Override
     public Optional<EventHandlerResponse> handle(IRepresentationInput representationInput, Context context) {
+        Optional<EventHandlerResponse> result = Optional.empty();
         if (representationInput instanceof IFormInput) {
             IFormInput formInput = (IFormInput) representationInput;
 
             if (formInput instanceof UpdateWidgetFocusInput) {
                 UpdateWidgetFocusInput input = (UpdateWidgetFocusInput) formInput;
                 this.widgetSubscriptionManager.handle(input, context);
+                result = Optional.of(new EventHandlerResponse(false, representation -> false, new UpdateWidgetFocusSuccessPayload(input.getWidgetId())));
             } else {
                 Optional<IFormEventHandler> optionalFormEventHandler = this.formEventHandlers.stream().filter(handler -> handler.canHandle(formInput)).findFirst();
 
@@ -123,14 +126,14 @@ public class FormEventProcessor implements IFormEventProcessor {
                     if (eventHandlerResponse.getShouldRefreshPredicate().test(this.currentForm.get())) {
                         this.refresh();
                     }
-                    return Optional.of(eventHandlerResponse);
+                    result = Optional.of(eventHandlerResponse);
                 } else {
                     this.logger.warn("No handler found for event: {}", formInput); //$NON-NLS-1$
                 }
             }
         }
 
-        return Optional.empty();
+        return result;
     }
 
     @Override


### PR DESCRIPTION
As there was no success payload with the
MutationUpdateWidgetFocusDataFetcher, the response for the
updateWidgetFocus request was an error paylod with an error message.

Bug: https://github.com/eclipse-sirius/sirius-components/issues/161
Signed-off-by: Steve Monnier <steve.monnier@obeo.fr>

### Type of this PR 

- [X] Bug fix
- [ ] New feature or improvement
- [ ] Documentation
- [ ] Cleanup
- [ ] Test
- [ ] Build/Releng

### Issue(s)

...

### What does this PR do?

...

### Screenshot/screencast of this PR

...
 

### Potential side effects

...

### How to test this PR?

- [ ] Frontend Unit tests
- [ ] Backend Unit tests
- [ ] Cypress : please specify
- [ ] Manual Test : please specify

### Checklist

- [ ] I have read CONTRIBUTING carefully.
- [ ] I have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [ ] All my commits are signed-off (`-s`) with my mail address of my Eclipse Account.
- [ ] I have covered my changes by unit tests or integration tests or manual tests.
- [ ] All tests pass.
- [ ] I have updated the documentation accordingly
- [ ] New React components are availables in storybook
