### PR TITLE
[154] Add edit edge label support

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -25,6 +25,7 @@
 - https://github.com/eclipse-sirius/sirius-components/issues/773[#773] [compatibility] Add support for both `createView` and `deleteView` model operations which can be used to support unsynchronized diagrams from Sirius Desktop.
 - https://github.com/eclipse-sirius/sirius-components/issues/694[#694] [core] Add `IRepresentationRefreshPolicyRegistry` to contribute `IRepresentationRefreshPolicyProvider`s in order to customize on which kind of change description, representations will be refreshed.
 - https://github.com/eclipse-sirius/sirius-components/issues/613[#613] [compatibility] Add support for external java action with the new API `IExternalJavaActionProvider` which allows others to provide instances of `IExternalJavaAction` in order to perform some custom behavior during the execution of a tool for example.
+- https://github.com/eclipse-sirius/sirius-components/issues/154[#154] [diagram] Add support for the edition of the label of an edge
 
 === Improvements
 

--- a/backend/sirius-web-compatibility/src/main/java/org/eclipse/sirius/web/compat/diagrams/EdgeMappingConverter.java
+++ b/backend/sirius-web-compatibility/src/main/java/org/eclipse/sirius/web/compat/diagrams/EdgeMappingConverter.java
@@ -114,6 +114,7 @@ public class EdgeMappingConverter {
 
         ToolConverter toolConverter = new ToolConverter(interpreter, this.editService, this.modelOperationHandlerSwitchProvider);
         var deleteHandler = toolConverter.createDeleteToolHandler(edgeMapping.getDeletionDescription());
+        var labelEditHandler = toolConverter.createDirectEditToolHandler(edgeMapping.getLabelDirectEdit());
 
         Builder builder = EdgeDescription.newEdgeDescription(UUID.fromString(this.identifierProvider.getIdentifier(edgeMapping)))
                 .targetObjectIdProvider(targetIdProvider)
@@ -125,6 +126,7 @@ public class EdgeMappingConverter {
                 .sourceNodesProvider(sourceNodesProvider)
                 .targetNodesProvider(targetNodesProvider)
                 .styleProvider(styleProvider)
+                .labelEditHandler(labelEditHandler)
                 .deleteHandler(deleteHandler);
         optionalBeginLabelDescription.ifPresent(builder::beginLabelDescription);
         optionalCenterLabelDescription.ifPresent(builder::centerLabelDescription);

--- a/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/description/EdgeDescription.java
+++ b/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/description/EdgeDescription.java
@@ -16,6 +16,7 @@ import java.text.MessageFormat;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import org.eclipse.sirius.web.annotations.Immutable;
@@ -70,6 +71,8 @@ public final class EdgeDescription {
     private Function<VariableManager, EdgeStyle> styleProvider;
 
     private Function<VariableManager, IStatus> deleteHandler;
+
+    private BiFunction<VariableManager, String, IStatus> labelEditHandler;
 
     private EdgeDescription() {
         // Prevent instantiation
@@ -135,6 +138,10 @@ public final class EdgeDescription {
         return this.deleteHandler;
     }
 
+    public BiFunction<VariableManager, String, IStatus> getLabelEditHandler() {
+        return this.labelEditHandler;
+    }
+
     public static Builder newEdgeDescription(UUID id) {
         return new Builder(id);
     }
@@ -181,6 +188,8 @@ public final class EdgeDescription {
         private Function<VariableManager, EdgeStyle> styleProvider;
 
         private Function<VariableManager, IStatus> deleteHandler;
+
+        private BiFunction<VariableManager, String, IStatus> labelEditHandler;
 
         private Builder(UUID id) {
             this.id = Objects.requireNonNull(id);
@@ -257,6 +266,11 @@ public final class EdgeDescription {
             return this;
         }
 
+        public Builder labelEditHandler(BiFunction<VariableManager, String, IStatus> labelEditHandler) {
+            this.labelEditHandler = Objects.requireNonNull(labelEditHandler);
+            return this;
+        }
+
         public EdgeDescription build() {
             EdgeDescription edgeDescription = new EdgeDescription();
             edgeDescription.id = Objects.requireNonNull(this.id);
@@ -274,6 +288,7 @@ public final class EdgeDescription {
             edgeDescription.targetNodesProvider = Objects.requireNonNull(this.targetNodesProvider);
             edgeDescription.styleProvider = Objects.requireNonNull(this.styleProvider);
             edgeDescription.deleteHandler = Objects.requireNonNull(this.deleteHandler);
+            edgeDescription.labelEditHandler = Objects.requireNonNull(this.labelEditHandler);
             return edgeDescription;
         }
     }

--- a/backend/sirius-web-diagrams/src/test/java/org/eclipse/sirius/web/diagrams/renderer/DiagramRendererEdgeTests.java
+++ b/backend/sirius-web-diagrams/src/test/java/org/eclipse/sirius/web/diagrams/renderer/DiagramRendererEdgeTests.java
@@ -265,6 +265,7 @@ public class DiagramRendererEdgeTests {
                 .targetObjectLabelProvider(variableManager -> "")//$NON-NLS-1$
                 .styleProvider(edgeStyleProvider)
                 .deleteHandler(variableManager -> new Failure("")) //$NON-NLS-1$
+                .labelEditHandler((variableManager, newLabel) -> new Failure("")) //$NON-NLS-1$
                 .build();
         // @formatter:on
     }

--- a/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/DiagramQueryService.java
+++ b/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/DiagramQueryService.java
@@ -62,4 +62,9 @@ public class DiagramQueryService implements IDiagramQueryService {
         return diagram.getEdges().stream().filter(edge -> Objects.equals(edgeId, edge.getId())).findFirst();
     }
 
+    @Override
+    public Optional<Edge> findEdgeByLabelId(Diagram diagram, UUID labelId) {
+        return diagram.getEdges().stream().filter(edge -> Objects.equals(edge.getCenterLabel().getId(), labelId)).findFirst();
+    }
+
 }

--- a/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/api/IDiagramQueryService.java
+++ b/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/api/IDiagramQueryService.java
@@ -32,4 +32,6 @@ public interface IDiagramQueryService {
 
     Optional<Edge> findEdgeById(Diagram diagram, UUID edgeId);
 
+    Optional<Edge> findEdgeByLabelId(Diagram diagram, UUID labelId);
+
 }

--- a/frontend/src/diagram/sprotty/WebSocketDiagramServer.tsx
+++ b/frontend/src/diagram/sprotty/WebSocketDiagramServer.tsx
@@ -22,7 +22,6 @@ import {
   getWindowScroll,
   ModelSource,
   MoveCommand,
-  SEdge,
   SelectAction,
   SetViewportAction,
   SGraph,
@@ -342,7 +341,7 @@ export class SiriusWebWebSocketDiagramServer extends ModelSource {
             canvasBounds: bounds,
             origin,
             element: element,
-            renameable: !(element instanceof SGraph) && !(element instanceof SEdge),
+            renameable: !(element instanceof SGraph),
             deletable: !(element instanceof SGraph),
           };
           this.setContextualPalette(contextualPalette);

--- a/frontend/src/diagram/sprotty/__tests__/convertDiagram.test.ts
+++ b/frontend/src/diagram/sprotty/__tests__/convertDiagram.test.ts
@@ -132,6 +132,7 @@ describe('ModelConverter', () => {
           'style',
           'routingPoints',
           'features',
+          'editableLabel',
           'children',
         ]);
 

--- a/frontend/src/diagram/sprotty/convertDiagram.tsx
+++ b/frontend/src/diagram/sprotty/convertDiagram.tsx
@@ -78,7 +78,7 @@ const convertNode = (node, httpOrigin: string, readOnly: boolean, autoLayout: bo
 
   const features = handleNodeFeatures(node, readOnly, autoLayout);
 
-  const editableLabel = handleNodeLabel(convertedLabel, readOnly);
+  const editableLabel = handleEditableLabel(convertedLabel, readOnly);
 
   return {
     id,
@@ -96,7 +96,7 @@ const convertNode = (node, httpOrigin: string, readOnly: boolean, autoLayout: bo
   };
 };
 
-const handleNodeLabel = (label, readOnly: boolean) => {
+const handleEditableLabel = (label, readOnly: boolean) => {
   let editableLabel = undefined;
   if (!readOnly) {
     editableLabel = label;
@@ -183,6 +183,7 @@ const convertEdge = (edge, httpOrigin: string, readOnly: boolean) => {
     routingPoints,
   } = edge;
 
+  let editableLabel;
   let children = [];
   if (beginLabel) {
     const convertedBeginLabel = convertLabel(beginLabel, httpOrigin, readOnly);
@@ -190,6 +191,7 @@ const convertEdge = (edge, httpOrigin: string, readOnly: boolean) => {
   }
   if (centerLabel) {
     const convertedCenterLabel = convertLabel(centerLabel, httpOrigin, readOnly);
+    editableLabel = handleEditableLabel(convertedCenterLabel, readOnly);
     children.push(convertedCenterLabel);
   }
   if (endLabel) {
@@ -211,6 +213,7 @@ const convertEdge = (edge, httpOrigin: string, readOnly: boolean) => {
     style,
     routingPoints,
     features,
+    editableLabel,
     children: children,
   };
 };


### PR DESCRIPTION
Selecting an edge now display an edit tool in the popup palette allowing
the user to rename the edge.

Bug: https://github.com/eclipse-sirius/sirius-components/issues/154
Signed-off-by: Steve Monnier <steve.monnier@obeo.fr>

### Type of this PR 

- [ ] Bug fix
- [ ] New feature or improvement
- [ ] Documentation
- [ ] Cleanup
- [ ] Test
- [ ] Build/Releng

### Issue(s)

...

### What does this PR do?

...

### Screenshot/screencast of this PR

...
 

### Potential side effects

...

### How to test this PR?

- [ ] Frontend Unit tests
- [ ] Backend Unit tests
- [ ] Cypress : please specify
- [ ] Manual Test : please specify

### Checklist

- [ ] I have read CONTRIBUTING carefully.
- [ ] I have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [ ] All my commits are signed-off (`-s`) with my mail address of my Eclipse Account.
- [ ] I have covered my changes by unit tests or integration tests or manual tests.
- [ ] All tests pass.
- [ ] I have updated the documentation accordingly
- [ ] New React components are availables in storybook
