### PR TITLE
[fix] Add dev-mode support for the Go component

### DIFF
--- a/frontend/src/core/go/Go.tsx
+++ b/frontend/src/core/go/Go.tsx
@@ -17,9 +17,10 @@ import { httpOrigin } from 'common/URL';
 
 export const Go = ({ to, disabled = false, children, ...props }) => {
   const capabilities = useCapabilities();
+  const devMode = !!process.env.REACT_APP_HTTP_SERVER_PORT;
   if (disabled) {
     return React.cloneElement(children, { disabled });
-  } else if (capabilities?.overrides(to)) {
+  } else if (capabilities?.overrides(to) && !devMode) {
     return (
       <a {...props} href={httpOrigin + to}>
         {children}


### PR DESCRIPTION
### Type of this PR 

- [x] Bug fix
- [ ] New feature or improvement
- [ ] Documentation
- [ ] Cleanup
- [ ] Test
- [ ] Build/Releng

### Issue(s)

The `Go` component redirects to a backend-provided page if the backend supports the corresponding capability. However when in dev mode, the backend-provided page is usually out of date compared to the frontend being developed. If we start from localhost:8080 (the dev frontend), as soon as we use a `Go` component we end up on localhost:3000, and then we're stuck on an older version of the frontend that what we expect.

### What does this PR do?

Disable the special behavior of `Go` when we are in dev mode.

### Potential side effects

`Go` may be removed after we move to Material (with things like `<Button component={ RouterLink } .../>`?

### How to test this PR?

- [ ] Frontend Unit tests
- [ ] Backend Unit tests
- [ ] Cypress : please specify
- [ ] Manual Test : please specify

### Checklist

- [x] I have read CONTRIBUTING carefully.
- [x] I have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All my commits are signed-off (`-s`) with my mail address of my Eclipse Account.
- [ ] I have covered my changes by unit tests or integration tests or manual tests.
- [ ] All tests pass.
- [ ] I have updated the documentation accordingly
- [ ] New React components are availables in storybook
