### PR TITLE
Reduce dependency to httpOrigin

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -15,7 +15,7 @@
 
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-components</artifactId>
-	<version>0.1.36</version>
+	<version>0.1.37</version>
 
 	<name>sirius-components</name>
 	<description>Sirius Components</description>

--- a/backend/sirius-web-annotations-spring/pom.xml
+++ b/backend/sirius-web-annotations-spring/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-annotations-spring</artifactId>
-	<version>0.1.36</version>
+	<version>0.1.37</version>
 	<name>sirius-web-annotations-spring</name>
 	<description>Sirius Web Annotations Spring</description>
 

--- a/backend/sirius-web-annotations/pom.xml
+++ b/backend/sirius-web-annotations/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-annotations</artifactId>
-	<version>0.1.36</version>
+	<version>0.1.37</version>
 	<name>sirius-web-annotations</name>
 	<description>Sirius Web Annotations</description>
 

--- a/backend/sirius-web-api/pom.xml
+++ b/backend/sirius-web-api/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-api</artifactId>
-	<version>0.1.36</version>
+	<version>0.1.37</version>
 	<name>sirius-web-api</name>
 	<description>Sirius Web API</description>
 
@@ -42,17 +42,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-annotations</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-representations</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-forms</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>io.projectreactor</groupId>
@@ -61,7 +61,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend/sirius-web-collaborative-api/pom.xml
+++ b/backend/sirius-web-collaborative-api/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-collaborative-api</artifactId>
-	<version>0.1.36</version>
+	<version>0.1.37</version>
 	<name>sirius-web-collaborative-api</name>
 	<description>Sirius Web Collaborative API</description>
 
@@ -46,17 +46,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-core-api</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-representations</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend/sirius-web-collaborative-diagrams-api/pom.xml
+++ b/backend/sirius-web-collaborative-diagrams-api/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-collaborative-diagrams-api</artifactId>
-	<version>0.1.36</version>
+	<version>0.1.37</version>
 	<name>sirius-web-collaborative-diagrams-api</name>
 	<description>Sirius Web Collaborative Diagrams API</description>
 
@@ -42,17 +42,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-collaborative-api</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-diagrams</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend/sirius-web-collaborative-forms-api/pom.xml
+++ b/backend/sirius-web-collaborative-forms-api/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-collaborative-forms-api</artifactId>
-	<version>0.1.36</version>
+	<version>0.1.37</version>
 	<name>sirius-web-collaborative-forms-api</name>
 	<description>Sirius Web Collaborative Forms API</description>
 
@@ -42,17 +42,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-collaborative-api</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-forms</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend/sirius-web-collaborative-trees-api/pom.xml
+++ b/backend/sirius-web-collaborative-trees-api/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-collaborative-trees-api</artifactId>
-	<version>0.1.36</version>
+	<version>0.1.37</version>
 	<name>sirius-web-collaborative-trees-api</name>
 	<description>Sirius Web Collaborative Trees API</description>
 
@@ -42,17 +42,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-collaborative-api</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-trees</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend/sirius-web-compatibility/pom.xml
+++ b/backend/sirius-web-compatibility/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-compatibility</artifactId>
-	<version>0.1.36</version>
+	<version>0.1.37</version>
 	<name>sirius-web-compatibility</name>
 	<description>Sirius Web Compatibility</description>
 
@@ -77,7 +77,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -87,33 +87,33 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-tests</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-services-api</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-diagrams</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-forms</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-trees</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-interpreter</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.emf</groupId>

--- a/backend/sirius-web-components/pom.xml
+++ b/backend/sirius-web-components/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-components</artifactId>
-	<version>0.1.36</version>
+	<version>0.1.37</version>
 	<name>sirius-web-components</name>
 	<description>Sirius Web Components</description>
 
@@ -47,7 +47,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend/sirius-web-core-api/pom.xml
+++ b/backend/sirius-web-core-api/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-core-api</artifactId>
-	<version>0.1.36</version>
+	<version>0.1.37</version>
 	<name>sirius-web-core-api</name>
 	<description>Sirius Web Core API</description>
 
@@ -42,12 +42,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-annotations</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend/sirius-web-diagrams-layout-api/pom.xml
+++ b/backend/sirius-web-diagrams-layout-api/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-diagrams-layout-api</artifactId>
-	<version>0.1.36</version>
+	<version>0.1.37</version>
 	<name>sirius-web-diagrams-layout-api</name>
 	<description>Sirius Web Diagrams Layout API</description>
 
@@ -42,7 +42,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-diagrams</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 	</dependencies>
 

--- a/backend/sirius-web-diagrams-layout/pom.xml
+++ b/backend/sirius-web-diagrams-layout/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-diagrams-layout</artifactId>
-	<version>0.1.36</version>
+	<version>0.1.37</version>
 	<name>sirius-web-diagrams-layout</name>
 	<description>Sirius Web Diagrams layout</description>
 
@@ -51,12 +51,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-annotations</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-diagrams-layout-api</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.elk</groupId>
@@ -76,12 +76,12 @@
  		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-services-api</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -101,12 +101,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-diagrams</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-diagrams-tests</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend/sirius-web-diagrams-services-api/pom.xml
+++ b/backend/sirius-web-diagrams-services-api/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-diagrams-services-api</artifactId>
-	<version>0.1.36</version>
+	<version>0.1.37</version>
 	<name>sirius-web-diagrams-services-api</name>
 	<description>Sirius Web Diagrams Servuces API</description>
 
@@ -42,12 +42,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-core-api</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-diagrams</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 	</dependencies>
 

--- a/backend/sirius-web-diagrams-services/pom.xml
+++ b/backend/sirius-web-diagrams-services/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-diagrams-services</artifactId>
-	<version>0.1.36</version>
+	<version>0.1.37</version>
 	<name>sirius-web-diagrams-services</name>
 	<description>Sirius Web Diagrams Servuces</description>
 
@@ -42,12 +42,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-diagrams-services-api</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-services</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 	</dependencies>
 

--- a/backend/sirius-web-diagrams-tests/pom.xml
+++ b/backend/sirius-web-diagrams-tests/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-diagrams-tests</artifactId>
-	<version>0.1.36</version>
+	<version>0.1.37</version>
 	<name>sirius-web-diagrams-tests</name>
 	<description>Sirius Web Diagrams Tests</description>
 
@@ -42,7 +42,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-diagrams</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.assertj</groupId>

--- a/backend/sirius-web-diagrams/pom.xml
+++ b/backend/sirius-web-diagrams/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-diagrams</artifactId>
-	<version>0.1.36</version>
+	<version>0.1.37</version>
 	<name>sirius-web-diagrams</name>
 	<description>Sirius Web Diagrams</description>
 
@@ -42,12 +42,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-components</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-representations</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>
@@ -62,7 +62,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/backend/sirius-web-emf/pom.xml
+++ b/backend/sirius-web-emf/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-emf</artifactId>
-	<version>0.1.36</version>
+	<version>0.1.37</version>
 	<name>sirius-web-emf</name>
 	<description>Sirius Web EMF</description>
 
@@ -70,42 +70,42 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-graphql-api</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-collaborative-api</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-collaborative-forms-api</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-collaborative-trees-api</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-compatibility</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-services-api</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-persistence</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-interpreter</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.emf</groupId>
@@ -165,19 +165,19 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-tests</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-collaborative</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/backend/sirius-web-forms-tests/pom.xml
+++ b/backend/sirius-web-forms-tests/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-forms-tests</artifactId>
-	<version>0.1.36</version>
+	<version>0.1.37</version>
 	<name>sirius-web-forms-tests</name>
 	<description>Sirius Web Forms Tests</description>
 
@@ -42,7 +42,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-forms</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.assertj</groupId>

--- a/backend/sirius-web-forms/pom.xml
+++ b/backend/sirius-web-forms/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-forms</artifactId>
-	<version>0.1.36</version>
+	<version>0.1.37</version>
 	<name>sirius-web-forms</name>
 	<description>Sirius Web Forms</description>
 
@@ -46,22 +46,22 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-annotations</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-components</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-representations</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/backend/sirius-web-graphiql/pom.xml
+++ b/backend/sirius-web-graphiql/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-graphiql</artifactId>
-	<version>0.1.36</version>
+	<version>0.1.37</version>
 	<name>sirius-web-graphiql</name>
 	<description>Sirius Web Graphiql support. This project contribute a GraphQL query tool on the /graphiql/index.html URI.</description>
 

--- a/backend/sirius-web-graphql-schema/pom.xml
+++ b/backend/sirius-web-graphql-schema/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-graphql-schema</artifactId>
-	<version>0.1.36</version>
+	<version>0.1.37</version>
 	<name>sirius-web-graphql-schema</name>
 	<description>Sirius Web GraphQL Schema</description>
 
@@ -46,38 +46,38 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-graphql-utils</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-graphql-api</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-services-api</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-collaborative-api</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-collaborative-trees-api</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-tests</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend/sirius-web-graphql-utils/pom.xml
+++ b/backend/sirius-web-graphql-utils/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-graphql-utils</artifactId>
-	<version>0.1.36</version>
+	<version>0.1.37</version>
 	<name>sirius-web-graphql-utils</name>
 	<description>Sirius Web GraphQL Utils</description>
 
@@ -43,7 +43,7 @@
 		<dependency>
         	<groupId>org.eclipse.sirius.web</groupId>
         	<artifactId>sirius-web-annotations</artifactId>
-        	<version>0.1.36</version>
+        	<version>0.1.37</version>
     	</dependency>
 		<dependency>
         	<groupId>com.graphql-java</groupId>
@@ -53,7 +53,7 @@
     	<dependency>
    			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 			<scope>test</scope>
     	</dependency>
     	<dependency>

--- a/backend/sirius-web-graphql-voyager/pom.xml
+++ b/backend/sirius-web-graphql-voyager/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-graphql-voyager</artifactId>
-	<version>0.1.36</version>
+	<version>0.1.37</version>
 	<name>sirius-web-graphql-voyager</name>
 	<description>Sirius Web Graph Voyager. This project contribute a GraphQL API UX thanks to the https://github.com/APIs-guru/graphql-voyager project.</description>
 

--- a/backend/sirius-web-graphql/pom.xml
+++ b/backend/sirius-web-graphql/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-graphql</artifactId>
-	<version>0.1.36</version>
+	<version>0.1.37</version>
 	<name>sirius-web-graphql</name>
 	<description>Sirius Web GraphQL</description>
 
@@ -42,58 +42,58 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-interpreter</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-annotations</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-annotations-spring</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-graphql-api</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-graphql-schema</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-services-api</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-collaborative-api</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-collaborative-forms-api</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-collaborative-trees-api</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-tests</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend/sirius-web-interpreter/pom.xml
+++ b/backend/sirius-web-interpreter/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-interpreter</artifactId>
-	<version>0.1.36</version>
+	<version>0.1.37</version>
 	<name>sirius-web-interpreter</name>
 	<description>Sirius Web Intepreter</description>
 

--- a/backend/sirius-web-persistence/pom.xml
+++ b/backend/sirius-web-persistence/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-persistence</artifactId>
-	<version>0.1.36</version>
+	<version>0.1.37</version>
 	<name>sirius-web-persistence</name>
 	<description>Sirius Web Persistence</description>
 
@@ -60,7 +60,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-annotations</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -81,13 +81,13 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-tests</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/backend/sirius-web-representations/pom.xml
+++ b/backend/sirius-web-representations/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-representations</artifactId>
-	<version>0.1.36</version>
+	<version>0.1.37</version>
 	<name>sirius-web-representations</name>
 	<description>Sirius Web Representations</description>
 
@@ -42,7 +42,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-annotations</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 	</dependencies>
 

--- a/backend/sirius-web-services-api/pom.xml
+++ b/backend/sirius-web-services-api/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-services-api</artifactId>
-	<version>0.1.36</version>
+	<version>0.1.37</version>
 	<name>sirius-web-services-api</name>
 	<description>Sirius Web Services API</description>
 
@@ -46,27 +46,27 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-api</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-core-api</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-representations</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-graphql-api</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend/sirius-web-services/pom.xml
+++ b/backend/sirius-web-services/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-services</artifactId>
-	<version>0.1.36</version>
+	<version>0.1.37</version>
 	<name>sirius-web-services</name>
 	<description>Sirius Web Services</description>
 
@@ -50,17 +50,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-services-api</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-persistence</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/backend/sirius-web-spring-collaborative-diagrams/pom.xml
+++ b/backend/sirius-web-spring-collaborative-diagrams/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-spring-collaborative-diagrams</artifactId>
-	<version>0.1.36</version>
+	<version>0.1.37</version>
 	<name>sirius-web-spring-collaborative-diagrams</name>
 	<description>Sirius Web Spring Collaborative Diagrams</description>
 
@@ -50,49 +50,49 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-collaborative-diagrams-api</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-collaborative</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-diagrams-services-api</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-diagrams-layout</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-graphql-utils</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-graphql</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
     		<groupId>org.eclipse.sirius.web</groupId>
     		<artifactId>sirius-web-tests</artifactId>
-    		<version>0.1.36</version>
+    		<version>0.1.37</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius.web</groupId>
     		<artifactId>sirius-web-spring-tests</artifactId>
-    		<version>0.1.36</version>
+    		<version>0.1.37</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-diagrams-tests</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend/sirius-web-spring-collaborative-forms/pom.xml
+++ b/backend/sirius-web-spring-collaborative-forms/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-spring-collaborative-forms</artifactId>
-	<version>0.1.36</version>
+	<version>0.1.37</version>
 	<name>sirius-web-spring-collaborative-forms</name>
 	<description>Sirius Web Spring Collaborative Forms</description>
 
@@ -50,33 +50,33 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-collaborative-forms-api</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-collaborative</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-services</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-graphql-utils</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
     		<groupId>org.eclipse.sirius.web</groupId>
     		<artifactId>sirius-web-tests</artifactId>
-    		<version>0.1.36</version>
+    		<version>0.1.37</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius.web</groupId>
     		<artifactId>sirius-web-spring-tests</artifactId>
-    		<version>0.1.36</version>
+    		<version>0.1.37</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>

--- a/backend/sirius-web-spring-collaborative-trees/pom.xml
+++ b/backend/sirius-web-spring-collaborative-trees/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-spring-collaborative-trees</artifactId>
-	<version>0.1.36</version>
+	<version>0.1.37</version>
 	<name>sirius-web-spring-collaborative-trees</name>
 	<description>Sirius Web Spring Collaborative Trees</description>
 
@@ -54,28 +54,28 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-collaborative-trees-api</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-services-api</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-graphql-utils</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
     		<groupId>org.eclipse.sirius.web</groupId>
     		<artifactId>sirius-web-tests</artifactId>
-    		<version>0.1.36</version>
+    		<version>0.1.37</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius.web</groupId>
     		<artifactId>sirius-web-spring-tests</artifactId>
-    		<version>0.1.36</version>
+    		<version>0.1.37</version>
     		<scope>test</scope>
     	</dependency>
 	</dependencies>

--- a/backend/sirius-web-spring-collaborative/pom.xml
+++ b/backend/sirius-web-spring-collaborative/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-spring-collaborative</artifactId>
-	<version>0.1.36</version>
+	<version>0.1.37</version>
 	<name>sirius-web-spring-collaborative</name>
 	<description>Sirius Web Spring Collaborative</description>
 
@@ -62,28 +62,28 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-services-api</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-collaborative-api</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-trees</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
     		<groupId>org.eclipse.sirius.web</groupId>
     		<artifactId>sirius-web-tests</artifactId>
-    		<version>0.1.36</version>
+    		<version>0.1.37</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius.web</groupId>
     		<artifactId>sirius-web-spring-tests</artifactId>
-    		<version>0.1.36</version>
+    		<version>0.1.37</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>

--- a/backend/sirius-web-spring-graphql-api/pom.xml
+++ b/backend/sirius-web-spring-graphql-api/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-spring-graphql-api</artifactId>
-	<version>0.1.36</version>
+	<version>0.1.37</version>
 	<name>sirius-web-spring-graphql-api</name>
 	<description>Sirius Web Spring GraphQL API</description>
 
@@ -48,7 +48,7 @@
     	<dependency>
         	<groupId>org.eclipse.sirius.web</groupId>
         	<artifactId>sirius-web-annotations-spring</artifactId>
-        	<version>0.1.36</version>
+        	<version>0.1.37</version>
     	</dependency>
 	</dependencies>
 

--- a/backend/sirius-web-spring-graphql/pom.xml
+++ b/backend/sirius-web-spring-graphql/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-spring-graphql</artifactId>
-	<version>0.1.36</version>
+	<version>0.1.37</version>
 	<name>sirius-web-spring-graphql</name>
 	<description>Sirius Web Spring GraphQL</description>
 
@@ -68,17 +68,17 @@
     	<dependency>
     		<groupId>org.eclipse.sirius.web</groupId>
     		<artifactId>sirius-web-annotations</artifactId>
-    		<version>0.1.36</version>
+    		<version>0.1.37</version>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius.web</groupId>
     		<artifactId>sirius-web-graphql-utils</artifactId>
-    		<version>0.1.36</version>
+    		<version>0.1.37</version>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius.web</groupId>
     		<artifactId>sirius-web-spring-graphql-api</artifactId>
-    		<version>0.1.36</version>
+    		<version>0.1.37</version>
     	</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -99,13 +99,13 @@
     	<dependency>
     		<groupId>org.eclipse.sirius.web</groupId>
     		<artifactId>sirius-web-tests</artifactId>
-    		<version>0.1.36</version>
+    		<version>0.1.37</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius.web</groupId>
     		<artifactId>sirius-web-spring-tests</artifactId>
-    		<version>0.1.36</version>
+    		<version>0.1.37</version>
     		<scope>test</scope>
     	</dependency>
 	</dependencies>

--- a/backend/sirius-web-spring-starter/pom.xml
+++ b/backend/sirius-web-spring-starter/pom.xml
@@ -15,7 +15,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-spring-starter</artifactId>
-	<version>0.1.36</version>
+	<version>0.1.37</version>
 	<name>sirius-web-spring-starter</name>
 	<description>Sirius Web Spring Starter</description>
 
@@ -39,62 +39,62 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-graphql</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-graphql</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-diagrams-layout</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-diagrams-services</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-collaborative</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-collaborative-diagrams</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-collaborative-forms</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-collaborative-trees</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-services</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-emf</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-compatibility</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 	</dependencies>
 

--- a/backend/sirius-web-spring-tests/pom.xml
+++ b/backend/sirius-web-spring-tests/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-spring-tests</artifactId>
-	<version>0.1.36</version>
+	<version>0.1.37</version>
 	<name>sirius-web-spring-tests</name>
 	<description>Sirius Web Spring Tests</description>
 
@@ -42,7 +42,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-annotations</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>

--- a/backend/sirius-web-spring/pom.xml
+++ b/backend/sirius-web-spring/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-spring</artifactId>
-	<version>0.1.36</version>
+	<version>0.1.37</version>
 	<name>sirius-web-spring</name>
 	<description>Sirius Web Spring</description>
 
@@ -50,7 +50,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-services-api</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -71,13 +71,13 @@
 		<dependency>
     		<groupId>org.eclipse.sirius.web</groupId>
     		<artifactId>sirius-web-tests</artifactId>
-    		<version>0.1.36</version>
+    		<version>0.1.37</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius.web</groupId>
     		<artifactId>sirius-web-spring-tests</artifactId>
-    		<version>0.1.36</version>
+    		<version>0.1.37</version>
     		<scope>test</scope>
     	</dependency>
 	</dependencies>

--- a/backend/sirius-web-test-diagrams-only-application/pom.xml
+++ b/backend/sirius-web-test-diagrams-only-application/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-test-diagrams-only-application</artifactId>
-	<version>0.1.36</version>
+	<version>0.1.37</version>
 	<name>sirius-web-test-diagrams-only-application</name>
 	<description>Sirius Web Test Diagrams Only Application</description>
 
@@ -93,17 +93,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-starter</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-graphiql</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-graphql-voyager</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>fr.obeo.dsl.designer.sample.flow</groupId>

--- a/backend/sirius-web-test-sample-application/pom.xml
+++ b/backend/sirius-web-test-sample-application/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-test-sample-application</artifactId>
-	<version>0.1.36</version>
+	<version>0.1.37</version>
 	<name>sirius-web-test-sample-application</name>
 	<description>Sirius Web Test Sample Application</description>
 
@@ -97,17 +97,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-starter</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-graphiql</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-graphql-voyager</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>fr.obeo.dsl.designer.sample.flow</groupId>

--- a/backend/sirius-web-tests/pom.xml
+++ b/backend/sirius-web-tests/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-tests</artifactId>
-	<version>0.1.36</version>
+	<version>0.1.37</version>
 	<name>sirius-web-tests</name>
 	<description>Sirius Web Tests</description>
 
@@ -51,7 +51,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-annotations</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 	</dependencies>
 

--- a/backend/sirius-web-trees/pom.xml
+++ b/backend/sirius-web-trees/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-trees</artifactId>
-	<version>0.1.36</version>
+	<version>0.1.37</version>
 	<name>sirius-web-trees</name>
 	<description>Sirius Web Trees</description>
 
@@ -42,17 +42,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-annotations</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-representations</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>0.1.36</version>
+			<version>0.1.37</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-sirius/sirius-components",
-  "version": "0.1.36",
+  "version": "0.1.37",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-sirius/sirius-components",
-  "version": "0.1.36",
+  "version": "0.1.37",
   "author": "Eclipse Sirius",
   "license": "EPL-2.0",
   "description": "Reusable components used to build the Sirius Web frontend",

--- a/frontend/src/common/ServerContext.ts
+++ b/frontend/src/common/ServerContext.ts
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+import React from 'react';
+import { httpOrigin } from './URL';
+
+const value = { httpOrigin };
+export const ServerContext = React.createContext(value);

--- a/frontend/src/diagram/DiagramWebSocketContainer.tsx
+++ b/frontend/src/diagram/DiagramWebSocketContainer.tsx
@@ -17,6 +17,7 @@ import makeStyles from '@material-ui/core/styles/makeStyles';
 import Typography from '@material-ui/core/Typography';
 import CloseIcon from '@material-ui/icons/Close';
 import { useMachine } from '@xstate/react';
+import { ServerContext } from 'common/ServerContext';
 import { Palette, Tool } from 'diagram/DiagramWebSocketContainer.types';
 import {
   DiagramRefreshedEvent,
@@ -60,7 +61,7 @@ import {
 } from 'diagram/sprotty/WebSocketDiagramServer';
 import { Toolbar } from 'diagram/Toolbar';
 import { canInvokeTool } from 'diagram/toolServices';
-import React, { useCallback, useEffect, useRef } from 'react';
+import React, { useCallback, useContext, useEffect, useRef } from 'react';
 import { EditLabelAction, FitToScreenAction, SEdge, SNode } from 'sprotty';
 import { RepresentationComponentProps } from 'workbench/Workbench.types';
 
@@ -252,6 +253,7 @@ export const DiagramWebSocketContainer = ({
   setSelection,
 }: RepresentationComponentProps) => {
   const diagramDomElement = useRef(null);
+  const { httpOrigin } = useContext(ServerContext);
   const classes = useDiagramWebSocketContainerStyle();
   const [{ value, context }, dispatch] = useMachine<DiagramWebSocketContainerContext, DiagramWebSocketContainerEvent>(
     diagramWebSocketContainerMachine
@@ -480,6 +482,7 @@ export const DiagramWebSocketContainer = ({
         setActiveTool,
         toolSections,
         setContextualPalette,
+        httpOrigin,
       };
       dispatch(initializeRepresentationEvent);
     }
@@ -495,8 +498,9 @@ export const DiagramWebSocketContainer = ({
     selection,
     editingContextId,
     representationId,
-    readOnly,
+    httpOrigin,
     dispatch,
+    readOnly,
   ]);
 
   useEffect(() => {

--- a/frontend/src/diagram/DiagramWebSocketContainerMachine.ts
+++ b/frontend/src/diagram/DiagramWebSocketContainerMachine.ts
@@ -81,6 +81,7 @@ export type InitializeRepresentationEvent = {
   setActiveTool: (tool: Tool) => void;
   toolSections: ToolSection[];
   setContextualPalette: (contextualPalette: Palette) => void;
+  httpOrigin: string;
 };
 
 export type DiagramWebSocketContainerEvent =
@@ -255,6 +256,7 @@ export const diagramWebSocketContainerMachine = Machine<
           setActiveTool,
           toolSections,
           setContextualPalette,
+          httpOrigin,
         } = event as InitializeRepresentationEvent;
 
         const container = createDependencyInjectionContainer(
@@ -276,6 +278,7 @@ export const diagramWebSocketContainerMachine = Machine<
         diagramServer.setDeleteElementsListener(deleteElements);
         diagramServer.setInvokeToolListener(invokeTool);
         diagramServer.setContextualPaletteListener(setContextualPalette);
+        diagramServer.setHttpOrigin(httpOrigin);
 
         return {
           diagramServer,

--- a/frontend/src/diagram/sprotty/WebSocketDiagramServer.tsx
+++ b/frontend/src/diagram/sprotty/WebSocketDiagramServer.tsx
@@ -94,6 +94,8 @@ export class SiriusWebWebSocketDiagramServer extends ModelSource {
   diagramSourceElement;
   currentRoot: Root = INITIAL_ROOT;
 
+  httpOrigin;
+
   initialize(registry) {
     super.initialize(registry);
     registry.register(ApplyLabelEditAction.KIND, this);
@@ -225,7 +227,7 @@ export class SiriusWebWebSocketDiagramServer extends ModelSource {
   handleSiriusUpdateModelAction(action) {
     const { diagram } = action;
     if (diagram) {
-      const convertedDiagram = convertDiagram(diagram);
+      const convertedDiagram = convertDiagram(diagram, this.httpOrigin);
       const sprottyModel = this.modelFactory.createRoot(convertedDiagram);
       this.actionDispatcher.request(GetSelectionAction.create()).then((selectionResult) => {
         sprottyModel.index
@@ -416,5 +418,9 @@ export class SiriusWebWebSocketDiagramServer extends ModelSource {
 
   setContextualPaletteListener(setContextualPalette) {
     this.setContextualPalette = setContextualPalette;
+  }
+
+  setHttpOrigin(httpOrigin) {
+    this.httpOrigin = httpOrigin;
   }
 }

--- a/frontend/src/diagram/sprotty/__tests__/convertDiagram.test.ts
+++ b/frontend/src/diagram/sprotty/__tests__/convertDiagram.test.ts
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Obeo.
+ * Copyright (c) 2019, 2021 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -10,25 +10,25 @@
  * Contributors:
  *     Obeo - initial API and implementation
  *******************************************************************************/
+import { httpOrigin } from 'common/URL';
 import 'reflect-metadata';
 import {
-  createFeatureSet,
-  connectableFeature,
-  deletableFeature,
-  selectFeature,
   boundsFeature,
-  layoutContainerFeature,
+  connectableFeature,
+  createFeatureSet,
+  deletableFeature,
   fadeFeature,
   hoverFeedbackFeature,
+  layoutContainerFeature,
   popupFeature,
+  selectFeature,
 } from 'sprotty';
 import { convertDiagram } from '../convertDiagram';
-
 import siriusWebDiagram from './siriusWebDiagram.json';
 
 describe('ModelConverter', () => {
   it('converts a diagram', () => {
-    const sprottyDiagram = convertDiagram(siriusWebDiagram);
+    const sprottyDiagram = convertDiagram(siriusWebDiagram, httpOrigin);
 
     expect(sprottyDiagram).not.toBeNull();
     expect(sprottyDiagram).not.toBeUndefined();
@@ -81,7 +81,13 @@ describe('ModelConverter', () => {
         expect(sprottyNode.type).toBe(type);
         expect(sprottyNode.targetObjectId).toBe(targetObjectId);
         expect(sprottyNode.descriptionId).toBe(descriptionId);
-        expect(sprottyNode.style).toBe(style);
+        let convertedStyle;
+        if (style?.imageURL !== undefined) {
+          convertedStyle = { ...style, imageURL: httpOrigin + style.imageURL };
+        } else {
+          convertedStyle = style;
+        }
+        expect(sprottyNode.style).toStrictEqual(convertedStyle);
         expect(sprottyNode.size).toBe(size);
         expect(sprottyNode.position).toBe(position);
         expect(sprottyNode.features).toStrictEqual(

--- a/frontend/src/diagram/sprotty/__tests__/siriusWebDiagram.json
+++ b/frontend/src/diagram/sprotty/__tests__/siriusWebDiagram.json
@@ -44,7 +44,7 @@
         }
       },
       "style": {
-        "imageURL": "http://192.168.1.17:8080/api/images/images/antenna.svg"
+        "imageURL": "/api/images/images/antenna.svg"
       },
       "position": {
         "x": 314,
@@ -133,7 +133,7 @@
             }
           },
           "style": {
-            "imageURL": "http://192.168.1.17:8080/api/images/images/power_output.svg"
+            "imageURL": "/api/images/images/power_output.svg"
           },
           "position": {
             "x": -30,
@@ -179,7 +179,7 @@
             }
           },
           "style": {
-            "imageURL": "http://192.168.1.17:8080/api/images/images/chipset_standard.svg"
+            "imageURL": "/api/images/images/chipset_standard.svg"
           },
           "position": {
             "x": 86,
@@ -223,7 +223,7 @@
             }
           },
           "style": {
-            "imageURL": "http://192.168.1.17:8080/api/images/images/chipset2_high.svg"
+            "imageURL": "/api/images/images/chipset2_high.svg"
           },
           "position": {
             "x": 180,
@@ -267,7 +267,7 @@
             }
           },
           "style": {
-            "imageURL": "http://192.168.1.17:8080/api/images/images/fan.svg"
+            "imageURL": "/api/images/images/fan.svg"
           },
           "position": {
             "x": 12,
@@ -358,7 +358,7 @@
             }
           },
           "style": {
-            "imageURL": "http://192.168.1.17:8080/api/images/images/power_input.svg"
+            "imageURL": "/api/images/images/power_input.svg"
           },
           "position": {
             "x": -30,
@@ -404,7 +404,7 @@
             }
           },
           "style": {
-            "imageURL": "http://192.168.1.17:8080/api/images/images/cpu_standard.svg"
+            "imageURL": "/api/images/images/cpu_standard.svg"
           },
           "position": {
             "x": 136,
@@ -448,7 +448,7 @@
             }
           },
           "style": {
-            "imageURL": "http://192.168.1.17:8080/api/images/images/chipset2_standard.svg"
+            "imageURL": "/api/images/images/chipset2_standard.svg"
           },
           "position": {
             "x": 240,
@@ -492,7 +492,7 @@
             }
           },
           "style": {
-            "imageURL": "http://192.168.1.17:8080/api/images/images/cpu_standard.svg"
+            "imageURL": "/api/images/images/cpu_standard.svg"
           },
           "position": {
             "x": 136,
@@ -536,7 +536,7 @@
             }
           },
           "style": {
-            "imageURL": "http://192.168.1.17:8080/api/images/images/camera.svg"
+            "imageURL": "/api/images/images/camera.svg"
           },
           "position": {
             "x": 32,
@@ -580,7 +580,7 @@
             }
           },
           "style": {
-            "imageURL": "http://192.168.1.17:8080/api/images/images/radar.svg"
+            "imageURL": "/api/images/images/radar.svg"
           },
           "position": {
             "x": 12,
@@ -624,7 +624,7 @@
             }
           },
           "style": {
-            "imageURL": "http://192.168.1.17:8080/api/images/images/fan.svg"
+            "imageURL": "/api/images/images/fan.svg"
           },
           "position": {
             "x": 52,

--- a/frontend/src/diagram/sprotty/views/ImageView.tsx
+++ b/frontend/src/diagram/sprotty/views/ImageView.tsx
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Obeo.
+ * Copyright (c) 2019, 2021 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -11,7 +11,6 @@
  *     Obeo - initial API and implementation
  *******************************************************************************/
 /** @jsx svg */
-import { httpOrigin } from 'common/URL';
 import { svg } from 'snabbdom-jsx';
 import { RectangularNodeView } from 'sprotty';
 
@@ -46,7 +45,7 @@ export class ImageView extends RectangularNodeView {
           y={0}
           width={Math.max(0, bounds.width)}
           height={Math.max(0, bounds.height)}
-          href={httpOrigin + style.imageURL}
+          href={style.imageURL}
           style={styleObject}
         />
         {context.renderChildren(node)}

--- a/frontend/src/diagram/sprotty/views/LabelView.tsx
+++ b/frontend/src/diagram/sprotty/views/LabelView.tsx
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Obeo.
+ * Copyright (c) 2019, 2021 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -12,8 +12,7 @@
  *******************************************************************************/
 /** @jsx svg */
 import { svg } from 'snabbdom-jsx';
-import { SLabelView, getSubType, setAttr } from 'sprotty';
-import { httpOrigin } from 'common/URL';
+import { getSubType, setAttr, SLabelView } from 'sprotty';
 
 /**
  * The view used to display labels.
@@ -53,7 +52,7 @@ export class LabelView extends SLabelView {
     const iconVerticalOffset = label.text ? -12 : -6;
     const vnode = (
       <g attrs-data-testid={`Label - ${label.text}`}>
-        {iconURL ? <image href={httpOrigin + iconURL} y={iconVerticalOffset} x="-20" /> : ''}
+        {iconURL ? <image href={iconURL} y={iconVerticalOffset} x="-20" /> : ''}
         <text class-sprotty-label={true} style={styleObject}>
           {label.text}
         </text>

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Obeo.
+ * Copyright (c) 2019, 2021 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -17,6 +17,7 @@ export * from './auth/useAuth';
 export * from './capabilities/CapabilitiesProvider';
 export * from './capabilities/useCapabilities';
 export * from './common/BrandingContext';
+export * from './common/ServerContext';
 export * from './common/URL';
 export * from './core/banner/Banner';
 export * from './core/button/Button';


### PR DESCRIPTION
### Type of this PR 

- [ ] Bug fix
- [x] New feature or improvement
- [ ] Documentation
- [ ] Cleanup
- [ ] Test
- [ ] Build/Releng

### Issue(s)
[296]

### What does this PR do?
Allow the possibility for developers to contribute their own 'httpOrigin' by introducing a new 'ServerContext' react context.

### Screenshot/screencast of this PR

...
 

### Potential side effects

...

### How to test this PR?

- [ ] Frontend Unit tests
- [ ] Backend Unit tests
- [ ] Cypress : please specify
- [ ] Manual Test : please specify

### Checklist

- [x] I have read CONTRIBUTING carefully.
- [x] I have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All my commits are signed-off (`-s`) with my mail address of my Eclipse Account.
- [ ] I have covered my changes by unit tests or integration tests or manual tests.
- [ ] All tests pass.
- [ ] I have updated the documentation accordingly
- [ ] New React components are availables in storybook
