### PR TITLE
[303] Remove the link to modelers from the project context menu

### DIFF
--- a/frontend/src/views/edit-project/EditProjectNavbar/EditProjectNavbarContextMenu.tsx
+++ b/frontend/src/views/edit-project/EditProjectNavbar/EditProjectNavbarContextMenu.tsx
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Obeo.
+ * Copyright (c) 2019, 2021 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -75,10 +75,6 @@ export const EditProjectNavbarContextMenu = ({
       <Permission requiredAccessLevel="EDIT">
         <Entry icon={<Delete title="" />} label="Delete" onClick={onDelete} data-testid="delete" />
       </Permission>
-      <Separator />
-      <Link to={`/projects/${projectId}/modelers`} data-testid="projects-link">
-        <Entry label="Modelers" data-testid="modelers" />
-      </Link>
       <Separator />
       <Link to={`/projects`} data-testid="projects-link">
         <Entry label="Back to all projects" data-testid="projects" />


### PR DESCRIPTION
Bug: https://github.com/eclipse-sirius/sirius-components/issues/303
Signed-off-by: Stéphane Bégaudeau <stephane.begaudeau@obeo.fr>

### Type of this PR 

- [ ] Bug fix
- [ ] New feature or improvement
- [ ] Documentation
- [ ] Cleanup
- [ ] Test
- [ ] Build/Releng

### Issue(s)

...

### What does this PR do?

...

### Screenshot/screencast of this PR

...
 

### Potential side effects

...

### How to test this PR?

- [ ] Frontend Unit tests
- [ ] Backend Unit tests
- [ ] Cypress : please specify
- [ ] Manual Test : please specify

### Checklist

- [ ] I have read CONTRIBUTING carefully.
- [ ] I have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [ ] All my commits are signed-off (`-s`) with my mail address of my Eclipse Account.
- [ ] I have covered my changes by unit tests or integration tests or manual tests.
- [ ] All tests pass.
- [ ] I have updated the documentation accordingly
- [ ] New React components are availables in storybook
