### PR TITLE
[300] Fix size computation

### DIFF
--- a/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/components/NodeSizeProvider.java
+++ b/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/components/NodeSizeProvider.java
@@ -25,12 +25,20 @@ import org.eclipse.sirius.web.diagrams.Size;
  * Provides the Size to apply to a new node.
  *
  * @author fbarbin
+ * @author wpiers
  */
 public class NodeSizeProvider {
 
+    /**
+     * For ELK, a node with an image style is an image within a node. The margin between a node and its content is 12 on
+     * each side, so to obtain the same result we have to add 12*2 to the width & height.
+     */
+    private static final int ELK_SIZE_DIFF = 24;
+
     public Size getSize(INodeStyle style, List<Element> childElements) {
         if (style instanceof ImageNodeStyle) {
-            return new ImageNodeStyleSizeProvider(new ImageSizeProvider()).getSize((ImageNodeStyle) style);
+            Size size = new ImageNodeStyleSizeProvider(new ImageSizeProvider()).getSize((ImageNodeStyle) style);
+            return Size.newSize().width(size.getWidth() + ELK_SIZE_DIFF).height(size.getHeight() + ELK_SIZE_DIFF).build();
         }
         // @formatter:off
         return Size.newSize()


### PR DESCRIPTION
Change-Id: If25f64661b655d71b8776796f66249dab13e0e22
Signed-off-by: William Piers <william.piers@obeo.fr>

### Type of this PR 

- [X] Bug fix
- [ ] New feature or improvement
- [ ] Documentation
- [ ] Cleanup
- [ ] Test
- [ ] Build/Releng

### Issue(s)

See #300

### What does this PR do?

Recompute the size of each node without children on refresh. This way nodes with conditional sizes are reevaluated.

### Screenshot/screencast of this PR

### Potential side effects

The solution cannot apply to containers as their size is computed by ELK accordingly to its content and the incremental layout, in its current state, cannot do that.

### How to test this PR?

- [ ] Frontend Unit tests
- [ ] Backend Unit tests
- [ ] Cypress : please specify
- [X] Manual Test : activate manual layout (-Dsirius.layout.auto.deactivate=true), create a diagram with a fan, change its size => the node is resized

### Checklist

- [X] I have read CONTRIBUTING carefully.
- [X] I have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [X] All my commits are signed-off (`-s`) with my mail address of my Eclipse Account.
- [X] I have covered my changes by unit tests or integration tests or manual tests.
- [X] All tests pass.
- [X] I have updated the documentation accordingly
- [X] New React components are availables in storybook
