### PR TITLE
[314] Handle iconPath property

### DIFF
--- a/backend/sirius-web-compatibility/src/main/java/org/eclipse/sirius/web/compat/diagrams/LabelStyleDescriptionConverter.java
+++ b/backend/sirius-web-compatibility/src/main/java/org/eclipse/sirius/web/compat/diagrams/LabelStyleDescriptionConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Obeo.
+ * Copyright (c) 2019, 2021 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -23,7 +23,7 @@ import org.eclipse.sirius.web.interpreter.AQLInterpreter;
 import org.eclipse.sirius.web.representations.VariableManager;
 
 /**
- * This class is used to convert a Sirius LabelStyleDescription to an Sirius Web LabelStyleDescription.
+ * This class is used to convert a Sirius LabelStyleDescription to a Sirius Web LabelStyleDescription.
  *
  * @author hmarchadour
  */
@@ -45,9 +45,17 @@ public class LabelStyleDescriptionConverter {
             String iconURL = ""; //$NON-NLS-1$
             if (labelStyleDescription.isShowIcon()) {
                 // @formatter:off
-                iconURL = variableManager.get(VariableManager.SELF, Object.class)
-                    .map(this.objectService::getImagePath)
-                    .orElse(""); //$NON-NLS-1$
+                String iconPath = labelStyleDescription.getIconPath();
+                if (iconPath != null && !iconPath.isEmpty()) {
+                    int indexOfSecondSlash = iconPath.indexOf('/', 1);
+                    if (indexOfSecondSlash != -1) {
+                        iconURL = iconPath.substring(indexOfSecondSlash);
+                    }
+                } else {
+                    iconURL = variableManager.get(VariableManager.SELF, Object.class)
+                            .map(this.objectService::getImagePath)
+                            .orElse(""); //$NON-NLS-1$
+                }
                 // @formatter:on
             }
             return iconURL;

--- a/backend/sirius-web-compatibility/src/test/java/org/eclipse/sirius/web/compat/AllSiriusWebCompatibilityTests.java
+++ b/backend/sirius-web-compatibility/src/test/java/org/eclipse/sirius/web/compat/AllSiriusWebCompatibilityTests.java
@@ -21,6 +21,7 @@ import org.eclipse.sirius.web.compat.diagrams.ContainerMappingStyleProviderTestC
 import org.eclipse.sirius.web.compat.diagrams.DiagramLabelProviderTestCases;
 import org.eclipse.sirius.web.compat.diagrams.DomainBasedSourceNodesProviderTestCases;
 import org.eclipse.sirius.web.compat.diagrams.EdgeMappingStyleProviderTestCases;
+import org.eclipse.sirius.web.compat.diagrams.LabelStyleDescriptionConverterTestCases;
 import org.eclipse.sirius.web.compat.diagrams.NodeMappingStyleProviderTestCases;
 import org.eclipse.sirius.web.compat.diagrams.RelationBasedSourceNodesProviderTestCases;
 import org.eclipse.sirius.web.compat.diagrams.WorkspaceImageDescriptionConverterTestCases;
@@ -47,6 +48,7 @@ import org.junit.runners.Suite.SuiteClasses;
     DomainBasedSourceNodesProviderTestCases.class,
 
     EdgeMappingStyleProviderTestCases.class,
+    LabelStyleDescriptionConverterTestCases.class,
     NodeMappingStyleProviderTestCases.class,
     RelationBasedSourceNodesProviderTestCases.class,
     WorkspaceImageDescriptionConverterTestCases.class,

--- a/backend/sirius-web-compatibility/src/test/java/org/eclipse/sirius/web/compat/diagrams/LabelStyleDescriptionConverterTestCases.java
+++ b/backend/sirius-web-compatibility/src/test/java/org/eclipse/sirius/web/compat/diagrams/LabelStyleDescriptionConverterTestCases.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.compat.diagrams;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.function.Function;
+
+import org.eclipse.emf.ecore.EcorePackage;
+import org.eclipse.sirius.diagram.description.style.ShapeContainerStyleDescription;
+import org.eclipse.sirius.diagram.description.style.StyleFactory;
+import org.eclipse.sirius.web.diagrams.description.LabelStyleDescription;
+import org.eclipse.sirius.web.interpreter.AQLInterpreter;
+import org.eclipse.sirius.web.representations.VariableManager;
+import org.junit.Test;
+
+/**
+ * Tests of the transformation of Sirius label style.
+ *
+ * @author arichard
+ */
+public class LabelStyleDescriptionConverterTestCases {
+
+    @Test
+    public void testConvertIconPath() {
+        String pluginName = "my.sirius.plugin"; //$NON-NLS-1$
+        String iconPath = "/my/icon/path/MyIcon.gif"; //$NON-NLS-1$
+        String iconFullPath = pluginName + iconPath;
+
+        ShapeContainerStyleDescription styleDescription = StyleFactory.eINSTANCE.createShapeContainerStyleDescription();
+        styleDescription.setIconPath(iconFullPath);
+
+        AQLInterpreter interpreter = new AQLInterpreter(List.of(), List.of(EcorePackage.eINSTANCE));
+        VariableManager variableManager = new VariableManager();
+
+        LabelStyleDescriptionConverter labelStyleDescriptionConverter = new LabelStyleDescriptionConverter(interpreter, new NoOpObjectService());
+        LabelStyleDescription labelStyleDescriptionConverted = labelStyleDescriptionConverter.convert(styleDescription);
+
+        assertThat(labelStyleDescriptionConverted).isNotNull();
+
+        Function<VariableManager, String> iconURLProvider = labelStyleDescriptionConverted.getIconURLProvider();
+        assertThat(iconURLProvider.apply(variableManager)).isEqualTo(iconPath);
+    }
+}


### PR DESCRIPTION
- handle iconPath property from odesign files to be able to display
icons specified in odesign files

Bug: https://github.com/eclipse-sirius/sirius-components/issues/314
Signed-off-by: Axel RICHARD <axel.richard@obeo.fr>

### Type of this PR 

- [ ] Bug fix
- [x] New feature or improvement
- [ ] Documentation
- [ ] Cleanup
- [ ] Test
- [ ] Build/Releng

### What does this PR do?
This PR handles the 'iconPath' property from odesign files

### How to test this PR?

- [ ] Frontend Unit tests
- [x] Backend Unit tests
- [ ] Cypress : please specify
- [ ] Manual Test : please specify

### Checklist

- [x] I have read CONTRIBUTING carefully.
- [ x I have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All my commits are signed-off (`-s`) with my mail address of my Eclipse Account.
- [x] I have covered my changes by unit tests or integration tests or manual tests.
- [x] All tests pass.
- [ ] I have updated the documentation accordingly
- [ ] New React components are availables in storybook
