### PR TITLE
[318] Register all ELK layout meta data providers

### DIFF
--- a/backend/sirius-web-diagrams-layout/pom.xml
+++ b/backend/sirius-web-diagrams-layout/pom.xml
@@ -73,6 +73,46 @@
 			<artifactId>org.eclipse.elk.alg.layered</artifactId>
 			<version>${elk.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>org.eclipse.elk</groupId>
+			<artifactId>org.eclipse.elk.alg.common</artifactId>
+			<version>${elk.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.elk</groupId>
+			<artifactId>org.eclipse.elk.alg.disco</artifactId>
+			<version>${elk.version}</version>
+		</dependency>
+			<dependency>
+			<groupId>org.eclipse.elk</groupId>
+			<artifactId>org.eclipse.elk.alg.force</artifactId>
+			<version>${elk.version}</version>
+		</dependency>
+			<dependency>
+			<groupId>org.eclipse.elk</groupId>
+			<artifactId>org.eclipse.elk.alg.graphviz.dot</artifactId>
+			<version>${elk.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.elk</groupId>
+			<artifactId>org.eclipse.elk.alg.mrtree</artifactId>
+			<version>${elk.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.elk</groupId>
+			<artifactId>org.eclipse.elk.alg.radial</artifactId>
+			<version>${elk.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.elk</groupId>
+			<artifactId>org.eclipse.elk.alg.force</artifactId>
+			<version>${elk.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.elk</groupId>
+			<artifactId>org.eclipse.elk.alg.spore</artifactId>
+			<version>${elk.version}</version>
+		</dependency>
  		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-services-api</artifactId>

--- a/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/LayoutService.java
+++ b/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/LayoutService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Obeo.
+ * Copyright (c) 2019, 2021 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -15,7 +15,15 @@ package org.eclipse.sirius.web.diagrams.layout;
 import java.util.Map;
 import java.util.Objects;
 
+import org.eclipse.elk.alg.common.compaction.options.PolyominoOptions;
+import org.eclipse.elk.alg.disco.options.DisCoMetaDataProvider;
+import org.eclipse.elk.alg.force.options.ForceMetaDataProvider;
+import org.eclipse.elk.alg.force.options.StressMetaDataProvider;
+import org.eclipse.elk.alg.layered.options.LayeredMetaDataProvider;
 import org.eclipse.elk.alg.layered.options.LayeredOptions;
+import org.eclipse.elk.alg.mrtree.options.MrTreeMetaDataProvider;
+import org.eclipse.elk.alg.radial.options.RadialMetaDataProvider;
+import org.eclipse.elk.alg.spore.options.SporeMetaDataProvider;
 import org.eclipse.elk.core.IGraphLayoutEngine;
 import org.eclipse.elk.core.LayoutConfigurator;
 import org.eclipse.elk.core.RecursiveGraphLayoutEngine;
@@ -67,7 +75,18 @@ public class LayoutService implements ILayoutService {
             layoutConfigurator = this.layoutConfiguratorRegistry.getDefaultLayoutConfigurator();
         }
 
-        LayoutMetaDataService.getInstance().registerLayoutMetaDataProviders(new LayeredOptions());
+        // @formatter:off
+        LayoutMetaDataService.getInstance().registerLayoutMetaDataProviders(
+                new LayeredOptions(),
+                new ForceMetaDataProvider(),
+                new LayeredMetaDataProvider(),
+                new MrTreeMetaDataProvider(),
+                new RadialMetaDataProvider(),
+                new StressMetaDataProvider(),
+                new PolyominoOptions(),
+                new DisCoMetaDataProvider(),
+                new SporeMetaDataProvider());
+        // @formatter:on
 
         ElkUtil.applyVisitors(elkDiagram, layoutConfigurator);
         IGraphLayoutEngine engine = new RecursiveGraphLayoutEngine();


### PR DESCRIPTION
Only the layered algorithm was supported, this fix initializes the
layout metadata service with the following ELK algorithms:

- Force: Simulating forces that move the nodes into a balanced distribution
- MrTree: A spanning tree of the input graph and arranges all nodes according to the resulting parent-children hierarchy
- Radial: Radial layouter takes a tree and places the nodes in radial order around the root
- Stress: Simulating forces that move the nodes into a balanced distribution
- Polyomino
- DisCo: Layouter for arranging unconnected subgraphs
- Spore

Fixes #318.

Bug: eclipse-sirius/sirius-components#318
Signed-off-by: Mélanie Bats <melanie.bats@obeo.fr>
Signed-off-by: Pierre-Charles David <pierre-charles.david@obeo.fr>
