### PR TITLE
[335] Fix Properties ListComponent items' icons

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -15,7 +15,7 @@
 
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-components</artifactId>
-	<version>0.2.7</version>
+	<version>0.2.8</version>
 
 	<name>sirius-components</name>
 	<description>Sirius Components</description>

--- a/backend/sirius-web-annotations-spring/pom.xml
+++ b/backend/sirius-web-annotations-spring/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-annotations-spring</artifactId>
-	<version>0.2.7</version>
+	<version>0.2.8</version>
 	<name>sirius-web-annotations-spring</name>
 	<description>Sirius Web Annotations Spring</description>
 

--- a/backend/sirius-web-annotations/pom.xml
+++ b/backend/sirius-web-annotations/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-annotations</artifactId>
-	<version>0.2.7</version>
+	<version>0.2.8</version>
 	<name>sirius-web-annotations</name>
 	<description>Sirius Web Annotations</description>
 

--- a/backend/sirius-web-api/pom.xml
+++ b/backend/sirius-web-api/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-api</artifactId>
-	<version>0.2.7</version>
+	<version>0.2.8</version>
 	<name>sirius-web-api</name>
 	<description>Sirius Web API</description>
 
@@ -42,17 +42,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-annotations</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-representations</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-forms</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>io.projectreactor</groupId>
@@ -61,7 +61,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend/sirius-web-collaborative-api/pom.xml
+++ b/backend/sirius-web-collaborative-api/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-collaborative-api</artifactId>
-	<version>0.2.7</version>
+	<version>0.2.8</version>
 	<name>sirius-web-collaborative-api</name>
 	<description>Sirius Web Collaborative API</description>
 
@@ -46,17 +46,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-core-api</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-representations</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend/sirius-web-collaborative-diagrams-api/pom.xml
+++ b/backend/sirius-web-collaborative-diagrams-api/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-collaborative-diagrams-api</artifactId>
-	<version>0.2.7</version>
+	<version>0.2.8</version>
 	<name>sirius-web-collaborative-diagrams-api</name>
 	<description>Sirius Web Collaborative Diagrams API</description>
 
@@ -42,17 +42,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-collaborative-api</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-diagrams</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend/sirius-web-collaborative-diagrams-api/src/main/java/org/eclipse/sirius/web/collaborative/diagrams/api/dto/DiagramEventInput.java
+++ b/backend/sirius-web-collaborative-diagrams-api/src/main/java/org/eclipse/sirius/web/collaborative/diagrams/api/dto/DiagramEventInput.java
@@ -13,6 +13,7 @@
 package org.eclipse.sirius.web.collaborative.diagrams.api.dto;
 
 import java.text.MessageFormat;
+import java.util.Objects;
 import java.util.UUID;
 
 import org.eclipse.sirius.web.annotations.graphql.GraphQLField;
@@ -33,6 +34,16 @@ public final class DiagramEventInput implements IInput {
     private UUID projectId;
 
     private UUID diagramId;
+
+    public DiagramEventInput() {
+        // Used by Jackson
+    }
+
+    public DiagramEventInput(UUID id, UUID projectId, UUID diagramId) {
+        this.id = Objects.requireNonNull(id);
+        this.projectId = Objects.requireNonNull(projectId);
+        this.diagramId = Objects.requireNonNull(diagramId);
+    }
 
     @Override
     @GraphQLID

--- a/backend/sirius-web-collaborative-forms-api/pom.xml
+++ b/backend/sirius-web-collaborative-forms-api/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-collaborative-forms-api</artifactId>
-	<version>0.2.7</version>
+	<version>0.2.8</version>
 	<name>sirius-web-collaborative-forms-api</name>
 	<description>Sirius Web Collaborative Forms API</description>
 
@@ -42,17 +42,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-collaborative-api</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-forms</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend/sirius-web-collaborative-forms-api/src/main/java/org/eclipse/sirius/web/collaborative/forms/api/dto/FormEventInput.java
+++ b/backend/sirius-web-collaborative-forms-api/src/main/java/org/eclipse/sirius/web/collaborative/forms/api/dto/FormEventInput.java
@@ -13,6 +13,7 @@
 package org.eclipse.sirius.web.collaborative.forms.api.dto;
 
 import java.text.MessageFormat;
+import java.util.Objects;
 import java.util.UUID;
 
 import org.eclipse.sirius.web.annotations.graphql.GraphQLField;
@@ -35,6 +36,16 @@ public final class FormEventInput implements IInput {
     private UUID projectId;
 
     private UUID formId;
+
+    public FormEventInput() {
+        // Used by Jackson
+    }
+
+    public FormEventInput(UUID id, UUID projectId, UUID formId) {
+        this.id = Objects.requireNonNull(id);
+        this.projectId = Objects.requireNonNull(projectId);
+        this.formId = Objects.requireNonNull(formId);
+    }
 
     @Override
     @GraphQLID

--- a/backend/sirius-web-collaborative-trees-api/pom.xml
+++ b/backend/sirius-web-collaborative-trees-api/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-collaborative-trees-api</artifactId>
-	<version>0.2.7</version>
+	<version>0.2.8</version>
 	<name>sirius-web-collaborative-trees-api</name>
 	<description>Sirius Web Collaborative Trees API</description>
 
@@ -42,17 +42,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-collaborative-api</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-trees</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend/sirius-web-collaborative-trees-api/src/main/java/org/eclipse/sirius/web/collaborative/trees/api/TreeEventInput.java
+++ b/backend/sirius-web-collaborative-trees-api/src/main/java/org/eclipse/sirius/web/collaborative/trees/api/TreeEventInput.java
@@ -14,6 +14,7 @@ package org.eclipse.sirius.web.collaborative.trees.api;
 
 import java.text.MessageFormat;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 
 import org.eclipse.sirius.web.annotations.graphql.GraphQLField;
@@ -34,6 +35,16 @@ public final class TreeEventInput implements IInput {
     private UUID editingContextId;
 
     private List<String> expanded;
+
+    public TreeEventInput() {
+        // Used by Jackson
+    }
+
+    public TreeEventInput(UUID id, UUID editingContextId, List<String> expanded) {
+        this.id = Objects.requireNonNull(id);
+        this.editingContextId = Objects.requireNonNull(editingContextId);
+        this.expanded = Objects.requireNonNull(expanded);
+    }
 
     @Override
     @GraphQLID

--- a/backend/sirius-web-compatibility/pom.xml
+++ b/backend/sirius-web-compatibility/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-compatibility</artifactId>
-	<version>0.2.7</version>
+	<version>0.2.8</version>
 	<name>sirius-web-compatibility</name>
 	<description>Sirius Web Compatibility</description>
 
@@ -77,7 +77,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -87,33 +87,33 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-tests</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-services-api</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-diagrams</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-forms</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-trees</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-interpreter</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.emf</groupId>

--- a/backend/sirius-web-components/pom.xml
+++ b/backend/sirius-web-components/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-components</artifactId>
-	<version>0.2.7</version>
+	<version>0.2.8</version>
 	<name>sirius-web-components</name>
 	<description>Sirius Web Components</description>
 
@@ -47,7 +47,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend/sirius-web-core-api/pom.xml
+++ b/backend/sirius-web-core-api/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-core-api</artifactId>
-	<version>0.2.7</version>
+	<version>0.2.8</version>
 	<name>sirius-web-core-api</name>
 	<description>Sirius Web Core API</description>
 
@@ -42,12 +42,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-annotations</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend/sirius-web-diagrams-layout-api/pom.xml
+++ b/backend/sirius-web-diagrams-layout-api/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-diagrams-layout-api</artifactId>
-	<version>0.2.7</version>
+	<version>0.2.8</version>
 	<name>sirius-web-diagrams-layout-api</name>
 	<description>Sirius Web Diagrams Layout API</description>
 
@@ -42,7 +42,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-diagrams</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 	</dependencies>
 

--- a/backend/sirius-web-diagrams-layout/pom.xml
+++ b/backend/sirius-web-diagrams-layout/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-diagrams-layout</artifactId>
-	<version>0.2.7</version>
+	<version>0.2.8</version>
 	<name>sirius-web-diagrams-layout</name>
 	<description>Sirius Web Diagrams layout</description>
 
@@ -51,12 +51,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-annotations</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-diagrams-layout-api</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.elk</groupId>
@@ -76,12 +76,12 @@
  		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-services-api</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -101,12 +101,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-diagrams</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-diagrams-tests</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend/sirius-web-diagrams-services-api/pom.xml
+++ b/backend/sirius-web-diagrams-services-api/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-diagrams-services-api</artifactId>
-	<version>0.2.7</version>
+	<version>0.2.8</version>
 	<name>sirius-web-diagrams-services-api</name>
 	<description>Sirius Web Diagrams Servuces API</description>
 
@@ -42,12 +42,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-core-api</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-diagrams</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 	</dependencies>
 

--- a/backend/sirius-web-diagrams-services/pom.xml
+++ b/backend/sirius-web-diagrams-services/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-diagrams-services</artifactId>
-	<version>0.2.7</version>
+	<version>0.2.8</version>
 	<name>sirius-web-diagrams-services</name>
 	<description>Sirius Web Diagrams Servuces</description>
 
@@ -42,12 +42,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-diagrams-services-api</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-services</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 	</dependencies>
 

--- a/backend/sirius-web-diagrams-tests/pom.xml
+++ b/backend/sirius-web-diagrams-tests/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-diagrams-tests</artifactId>
-	<version>0.2.7</version>
+	<version>0.2.8</version>
 	<name>sirius-web-diagrams-tests</name>
 	<description>Sirius Web Diagrams Tests</description>
 
@@ -42,7 +42,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-diagrams</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.assertj</groupId>

--- a/backend/sirius-web-diagrams/pom.xml
+++ b/backend/sirius-web-diagrams/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-diagrams</artifactId>
-	<version>0.2.7</version>
+	<version>0.2.8</version>
 	<name>sirius-web-diagrams</name>
 	<description>Sirius Web Diagrams</description>
 
@@ -42,12 +42,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-components</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-representations</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>
@@ -62,7 +62,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/backend/sirius-web-emf/pom.xml
+++ b/backend/sirius-web-emf/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-emf</artifactId>
-	<version>0.2.7</version>
+	<version>0.2.8</version>
 	<name>sirius-web-emf</name>
 	<description>Sirius Web EMF</description>
 
@@ -70,42 +70,42 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-graphql-api</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-collaborative-api</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-collaborative-forms-api</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-collaborative-trees-api</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-compatibility</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-services-api</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-persistence</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-interpreter</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.emf</groupId>
@@ -165,19 +165,19 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-tests</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-collaborative</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/properties/MultiValuedNonContainmentReferenceIfDescriptionProvider.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/properties/MultiValuedNonContainmentReferenceIfDescriptionProvider.java
@@ -90,7 +90,7 @@ public class MultiValuedNonContainmentReferenceIfDescriptionProvider {
     private Function<VariableManager, String> getImageURLProvider() {
         return variableManager -> {
             // @formatter:off
-            return variableManager.get(VariableManager.SELF, EObject.class)
+            return variableManager.get(ListComponent.CANDIDATE_VARIABLE, EObject.class)
                                   .map(this.objectService::getImagePath)
                                   .orElse(ImageConstants.DEFAULT_SVG);
             // @formatter:on

--- a/backend/sirius-web-forms-tests/pom.xml
+++ b/backend/sirius-web-forms-tests/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-forms-tests</artifactId>
-	<version>0.2.7</version>
+	<version>0.2.8</version>
 	<name>sirius-web-forms-tests</name>
 	<description>Sirius Web Forms Tests</description>
 
@@ -42,7 +42,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-forms</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.assertj</groupId>

--- a/backend/sirius-web-forms/pom.xml
+++ b/backend/sirius-web-forms/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-forms</artifactId>
-	<version>0.2.7</version>
+	<version>0.2.8</version>
 	<name>sirius-web-forms</name>
 	<description>Sirius Web Forms</description>
 
@@ -46,22 +46,22 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-annotations</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-components</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-representations</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/components/ListComponent.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/components/ListComponent.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Obeo.
+ * Copyright (c) 2019, 2021 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -54,7 +54,7 @@ public class ListComponent implements IComponent {
 
             String itemId = listDescription.getItemIdProvider().apply(itemVariableManager);
             String itemLabel = listDescription.getItemLabelProvider().apply(itemVariableManager);
-            String itemImageURL = listDescription.getItemImageURLProvider().apply(variableManager);
+            String itemImageURL = listDescription.getItemImageURLProvider().apply(itemVariableManager);
 
             // @formatter:off
             ListItem item = ListItem.newListItem(itemId)

--- a/backend/sirius-web-graphiql/pom.xml
+++ b/backend/sirius-web-graphiql/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-graphiql</artifactId>
-	<version>0.2.7</version>
+	<version>0.2.8</version>
 	<name>sirius-web-graphiql</name>
 	<description>Sirius Web Graphiql support. This project contribute a GraphQL query tool on the /graphiql/index.html URI.</description>
 

--- a/backend/sirius-web-graphql-schema/pom.xml
+++ b/backend/sirius-web-graphql-schema/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-graphql-schema</artifactId>
-	<version>0.2.7</version>
+	<version>0.2.8</version>
 	<name>sirius-web-graphql-schema</name>
 	<description>Sirius Web GraphQL Schema</description>
 
@@ -46,38 +46,38 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-graphql-utils</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-graphql-api</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-services-api</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-collaborative-api</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-collaborative-trees-api</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-tests</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend/sirius-web-graphql-utils/pom.xml
+++ b/backend/sirius-web-graphql-utils/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-graphql-utils</artifactId>
-	<version>0.2.7</version>
+	<version>0.2.8</version>
 	<name>sirius-web-graphql-utils</name>
 	<description>Sirius Web GraphQL Utils</description>
 
@@ -43,7 +43,7 @@
 		<dependency>
         	<groupId>org.eclipse.sirius.web</groupId>
         	<artifactId>sirius-web-annotations</artifactId>
-        	<version>0.2.7</version>
+        	<version>0.2.8</version>
     	</dependency>
 		<dependency>
         	<groupId>com.graphql-java</groupId>
@@ -53,7 +53,7 @@
     	<dependency>
    			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 			<scope>test</scope>
     	</dependency>
     	<dependency>

--- a/backend/sirius-web-graphql-voyager/pom.xml
+++ b/backend/sirius-web-graphql-voyager/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-graphql-voyager</artifactId>
-	<version>0.2.7</version>
+	<version>0.2.8</version>
 	<name>sirius-web-graphql-voyager</name>
 	<description>Sirius Web Graph Voyager. This project contribute a GraphQL API UX thanks to the https://github.com/APIs-guru/graphql-voyager project.</description>
 

--- a/backend/sirius-web-graphql/pom.xml
+++ b/backend/sirius-web-graphql/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-graphql</artifactId>
-	<version>0.2.7</version>
+	<version>0.2.8</version>
 	<name>sirius-web-graphql</name>
 	<description>Sirius Web GraphQL</description>
 
@@ -42,58 +42,58 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-interpreter</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-annotations</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-annotations-spring</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-graphql-api</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-graphql-schema</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-services-api</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-collaborative-api</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-collaborative-forms-api</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-collaborative-trees-api</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-tests</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend/sirius-web-interpreter/pom.xml
+++ b/backend/sirius-web-interpreter/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-interpreter</artifactId>
-	<version>0.2.7</version>
+	<version>0.2.8</version>
 	<name>sirius-web-interpreter</name>
 	<description>Sirius Web Intepreter</description>
 

--- a/backend/sirius-web-persistence/pom.xml
+++ b/backend/sirius-web-persistence/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-persistence</artifactId>
-	<version>0.2.7</version>
+	<version>0.2.8</version>
 	<name>sirius-web-persistence</name>
 	<description>Sirius Web Persistence</description>
 
@@ -60,7 +60,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-annotations</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -81,13 +81,13 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-tests</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/backend/sirius-web-representations/pom.xml
+++ b/backend/sirius-web-representations/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-representations</artifactId>
-	<version>0.2.7</version>
+	<version>0.2.8</version>
 	<name>sirius-web-representations</name>
 	<description>Sirius Web Representations</description>
 
@@ -42,7 +42,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-annotations</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 	</dependencies>
 

--- a/backend/sirius-web-services-api/pom.xml
+++ b/backend/sirius-web-services-api/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-services-api</artifactId>
-	<version>0.2.7</version>
+	<version>0.2.8</version>
 	<name>sirius-web-services-api</name>
 	<description>Sirius Web Services API</description>
 
@@ -46,27 +46,27 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-api</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-core-api</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-representations</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-graphql-api</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend/sirius-web-services/pom.xml
+++ b/backend/sirius-web-services/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-services</artifactId>
-	<version>0.2.7</version>
+	<version>0.2.8</version>
 	<name>sirius-web-services</name>
 	<description>Sirius Web Services</description>
 
@@ -50,17 +50,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-services-api</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-persistence</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/backend/sirius-web-spring-collaborative-diagrams/pom.xml
+++ b/backend/sirius-web-spring-collaborative-diagrams/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-spring-collaborative-diagrams</artifactId>
-	<version>0.2.7</version>
+	<version>0.2.8</version>
 	<name>sirius-web-spring-collaborative-diagrams</name>
 	<description>Sirius Web Spring Collaborative Diagrams</description>
 
@@ -50,49 +50,49 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-collaborative-diagrams-api</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-collaborative</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-diagrams-services-api</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-diagrams-layout</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-graphql-utils</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-graphql</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
     		<groupId>org.eclipse.sirius.web</groupId>
     		<artifactId>sirius-web-tests</artifactId>
-    		<version>0.2.7</version>
+    		<version>0.2.8</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius.web</groupId>
     		<artifactId>sirius-web-spring-tests</artifactId>
-    		<version>0.2.7</version>
+    		<version>0.2.8</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-diagrams-tests</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend/sirius-web-spring-collaborative-forms/pom.xml
+++ b/backend/sirius-web-spring-collaborative-forms/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-spring-collaborative-forms</artifactId>
-	<version>0.2.7</version>
+	<version>0.2.8</version>
 	<name>sirius-web-spring-collaborative-forms</name>
 	<description>Sirius Web Spring Collaborative Forms</description>
 
@@ -50,33 +50,33 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-collaborative-forms-api</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-collaborative</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-services</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-graphql-utils</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
     		<groupId>org.eclipse.sirius.web</groupId>
     		<artifactId>sirius-web-tests</artifactId>
-    		<version>0.2.7</version>
+    		<version>0.2.8</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius.web</groupId>
     		<artifactId>sirius-web-spring-tests</artifactId>
-    		<version>0.2.7</version>
+    		<version>0.2.8</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>

--- a/backend/sirius-web-spring-collaborative-trees/pom.xml
+++ b/backend/sirius-web-spring-collaborative-trees/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-spring-collaborative-trees</artifactId>
-	<version>0.2.7</version>
+	<version>0.2.8</version>
 	<name>sirius-web-spring-collaborative-trees</name>
 	<description>Sirius Web Spring Collaborative Trees</description>
 
@@ -54,28 +54,28 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-collaborative-trees-api</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-services-api</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-graphql-utils</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
     		<groupId>org.eclipse.sirius.web</groupId>
     		<artifactId>sirius-web-tests</artifactId>
-    		<version>0.2.7</version>
+    		<version>0.2.8</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius.web</groupId>
     		<artifactId>sirius-web-spring-tests</artifactId>
-    		<version>0.2.7</version>
+    		<version>0.2.8</version>
     		<scope>test</scope>
     	</dependency>
 	</dependencies>

--- a/backend/sirius-web-spring-collaborative/pom.xml
+++ b/backend/sirius-web-spring-collaborative/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-spring-collaborative</artifactId>
-	<version>0.2.7</version>
+	<version>0.2.8</version>
 	<name>sirius-web-spring-collaborative</name>
 	<description>Sirius Web Spring Collaborative</description>
 
@@ -62,23 +62,23 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-services-api</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-collaborative-api</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
     		<groupId>org.eclipse.sirius.web</groupId>
     		<artifactId>sirius-web-tests</artifactId>
-    		<version>0.2.7</version>
+    		<version>0.2.8</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius.web</groupId>
     		<artifactId>sirius-web-spring-tests</artifactId>
-    		<version>0.2.7</version>
+    		<version>0.2.8</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>

--- a/backend/sirius-web-spring-graphql-api/pom.xml
+++ b/backend/sirius-web-spring-graphql-api/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-spring-graphql-api</artifactId>
-	<version>0.2.7</version>
+	<version>0.2.8</version>
 	<name>sirius-web-spring-graphql-api</name>
 	<description>Sirius Web Spring GraphQL API</description>
 
@@ -48,7 +48,7 @@
     	<dependency>
         	<groupId>org.eclipse.sirius.web</groupId>
         	<artifactId>sirius-web-annotations-spring</artifactId>
-        	<version>0.2.7</version>
+        	<version>0.2.8</version>
     	</dependency>
 	</dependencies>
 

--- a/backend/sirius-web-spring-graphql/pom.xml
+++ b/backend/sirius-web-spring-graphql/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-spring-graphql</artifactId>
-	<version>0.2.7</version>
+	<version>0.2.8</version>
 	<name>sirius-web-spring-graphql</name>
 	<description>Sirius Web Spring GraphQL</description>
 
@@ -68,17 +68,17 @@
     	<dependency>
     		<groupId>org.eclipse.sirius.web</groupId>
     		<artifactId>sirius-web-annotations</artifactId>
-    		<version>0.2.7</version>
+    		<version>0.2.8</version>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius.web</groupId>
     		<artifactId>sirius-web-graphql-utils</artifactId>
-    		<version>0.2.7</version>
+    		<version>0.2.8</version>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius.web</groupId>
     		<artifactId>sirius-web-spring-graphql-api</artifactId>
-    		<version>0.2.7</version>
+    		<version>0.2.8</version>
     	</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -99,13 +99,13 @@
     	<dependency>
     		<groupId>org.eclipse.sirius.web</groupId>
     		<artifactId>sirius-web-tests</artifactId>
-    		<version>0.2.7</version>
+    		<version>0.2.8</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius.web</groupId>
     		<artifactId>sirius-web-spring-tests</artifactId>
-    		<version>0.2.7</version>
+    		<version>0.2.8</version>
     		<scope>test</scope>
     	</dependency>
 	</dependencies>

--- a/backend/sirius-web-spring-starter/pom.xml
+++ b/backend/sirius-web-spring-starter/pom.xml
@@ -15,7 +15,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-spring-starter</artifactId>
-	<version>0.2.7</version>
+	<version>0.2.8</version>
 	<name>sirius-web-spring-starter</name>
 	<description>Sirius Web Spring Starter</description>
 
@@ -39,62 +39,62 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-graphql</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-graphql</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-diagrams-layout</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-diagrams-services</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-collaborative</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-collaborative-diagrams</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-collaborative-forms</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-collaborative-trees</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-services</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-emf</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-compatibility</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 	</dependencies>
 

--- a/backend/sirius-web-spring-tests/pom.xml
+++ b/backend/sirius-web-spring-tests/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-spring-tests</artifactId>
-	<version>0.2.7</version>
+	<version>0.2.8</version>
 	<name>sirius-web-spring-tests</name>
 	<description>Sirius Web Spring Tests</description>
 
@@ -42,7 +42,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-annotations</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>

--- a/backend/sirius-web-spring/pom.xml
+++ b/backend/sirius-web-spring/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-spring</artifactId>
-	<version>0.2.7</version>
+	<version>0.2.8</version>
 	<name>sirius-web-spring</name>
 	<description>Sirius Web Spring</description>
 
@@ -50,7 +50,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-services-api</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -71,13 +71,13 @@
 		<dependency>
     		<groupId>org.eclipse.sirius.web</groupId>
     		<artifactId>sirius-web-tests</artifactId>
-    		<version>0.2.7</version>
+    		<version>0.2.8</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius.web</groupId>
     		<artifactId>sirius-web-spring-tests</artifactId>
-    		<version>0.2.7</version>
+    		<version>0.2.8</version>
     		<scope>test</scope>
     	</dependency>
 	</dependencies>

--- a/backend/sirius-web-test-diagrams-only-application/pom.xml
+++ b/backend/sirius-web-test-diagrams-only-application/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-test-diagrams-only-application</artifactId>
-	<version>0.2.7</version>
+	<version>0.2.8</version>
 	<name>sirius-web-test-diagrams-only-application</name>
 	<description>Sirius Web Test Diagrams Only Application</description>
 
@@ -93,17 +93,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-starter</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-graphiql</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-graphql-voyager</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>fr.obeo.dsl.designer.sample.flow</groupId>

--- a/backend/sirius-web-test-sample-application/pom.xml
+++ b/backend/sirius-web-test-sample-application/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-test-sample-application</artifactId>
-	<version>0.2.7</version>
+	<version>0.2.8</version>
 	<name>sirius-web-test-sample-application</name>
 	<description>Sirius Web Test Sample Application</description>
 
@@ -97,17 +97,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-starter</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-graphiql</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-graphql-voyager</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>fr.obeo.dsl.designer.sample.flow</groupId>

--- a/backend/sirius-web-tests/pom.xml
+++ b/backend/sirius-web-tests/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-tests</artifactId>
-	<version>0.2.7</version>
+	<version>0.2.8</version>
 	<name>sirius-web-tests</name>
 	<description>Sirius Web Tests</description>
 
@@ -51,7 +51,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-annotations</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 	</dependencies>
 

--- a/backend/sirius-web-trees/pom.xml
+++ b/backend/sirius-web-trees/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-trees</artifactId>
-	<version>0.2.7</version>
+	<version>0.2.8</version>
 	<name>sirius-web-trees</name>
 	<description>Sirius Web Trees</description>
 
@@ -42,17 +42,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-annotations</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-representations</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>0.2.7</version>
+			<version>0.2.8</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-sirius/sirius-components",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-sirius/sirius-components",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "author": "Eclipse Sirius",
   "license": "EPL-2.0",
   "description": "Reusable components used to build the Sirius Web frontend",

--- a/frontend/src/properties/propertysections/ListPropertySection.tsx
+++ b/frontend/src/properties/propertysections/ListPropertySection.tsx
@@ -15,6 +15,7 @@ import Table from '@material-ui/core/Table';
 import TableBody from '@material-ui/core/TableBody';
 import TableCell from '@material-ui/core/TableCell';
 import TableRow from '@material-ui/core/TableRow';
+import { httpOrigin } from 'common/URL';
 import { Permission } from 'project/Permission';
 import { ListPropertySectionProps } from 'properties/propertysections/ListPropertySection.types';
 import { PropertySectionLabel } from 'properties/propertysections/PropertySectionLabel';
@@ -25,6 +26,16 @@ const useListPropertySectionStyles = makeStyles((theme) => ({
     borderStyle: 'solid',
     borderWidth: '1px',
     borderColor: theme.palette.divider,
+  },
+  cell: {
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  icon: {
+    width: '16px',
+    height: '16px',
+    marginRight: theme.spacing(2),
   },
 }));
 
@@ -48,7 +59,18 @@ export const ListPropertySection = ({ widget, subscribers }: ListPropertySection
           <TableBody>
             {widget.items.map((item) => (
               <TableRow key={item.id}>
-                <TableCell>{item.label}</TableCell>
+                <TableCell className={classes.cell}>
+                  {item.imageURL ? (
+                    <img
+                      className={classes.icon}
+                      width="16"
+                      height="16"
+                      alt={item.label}
+                      src={httpOrigin + item.imageURL}
+                    />
+                  ) : null}
+                  {item.label}
+                </TableCell>
               </TableRow>
             ))}
           </TableBody>


### PR DESCRIPTION
In the PropertiesView, the items' icons are now be the ones
corresponding to the items' types instead of the one corresponding to
the selected element's type.

Bug: https://github.com/eclipse-sirius/sirius-components/issues/335
Signed-off-by: Axel RICHARD <axel.richard@obeo.fr>

### Type of this PR 

- [x] Bug fix
- [ ] New feature or improvement
- [ ] Documentation
- [ ] Cleanup
- [ ] Test
- [ ] Build/Releng

### Issue(s)
In the Properties View, the items' icons are the ones corresponding to the selected element's type.

### What does this PR do?
The items' icons are now the ones corresponding to the items' types.

### How to test this PR?

- [ ] Frontend Unit tests
- [ ] Backend Unit tests
- [ ] Cypress : please specify
- [ ] Manual Test : please specify

### Checklist

- [x] I have read CONTRIBUTING carefully.
- [x] I have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All my commits are signed-off (`-s`) with my mail address of my Eclipse Account.
- [ ] I have covered my changes by unit tests or integration tests or manual tests.
- [ ] All tests pass.
- [ ] I have updated the documentation accordingly
- [ ] New React components are availables in storybook
