### PR TITLE
[341] Add useful variables to edge-related expressions

### DIFF
--- a/backend/sirius-web-compatibility/src/main/java/org/eclipse/sirius/web/compat/services/diagrams/ToolProvider.java
+++ b/backend/sirius-web-compatibility/src/main/java/org/eclipse/sirius/web/compat/services/diagrams/ToolProvider.java
@@ -65,6 +65,16 @@ import org.springframework.stereotype.Service;
 @Service
 public class ToolProvider implements IToolProvider {
 
+    /**
+     * The name of the compatibility variable used to store and retrieve the edge source from a variable manager.
+     */
+    public static final String EDGE_SOURCE = "source"; //$NON-NLS-1$
+
+    /**
+     * The name of the compatibility variable used to store and retrieve the edge target from a variable manager.
+     */
+    public static final String EDGE_TARGET = "target"; //$NON-NLS-1$
+
     private final IAQLInterpreterFactory interpreterFactory;
 
     private final IIdentifierProvider identifierProvider;
@@ -354,6 +364,9 @@ public class ToolProvider implements IToolProvider {
             InitEdgeCreationOperation initialOperation = edgeCreationDescription.getInitialOperation();
             return variableManager -> {
                 Map<String, Object> variables = variableManager.getVariables();
+                // Provide compatibility aliases for these two variables
+                variables.put(EDGE_SOURCE, variables.get(EdgeDescription.SEMANTIC_EDGE_SOURCE));
+                variables.put(EDGE_TARGET, variables.get(EdgeDescription.SEMANTIC_EDGE_TARGET));
                 var modelOperationHandlerSwitch = this.modelOperationHandlerSwitchProvider.getModelOperationHandlerSwitch(interpreter);
                 return modelOperationHandlerSwitch.apply(initialOperation.getFirstModelOperations()).map(handler -> {
                     return handler.handle(variables);

--- a/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/components/EdgeComponent.java
+++ b/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/components/EdgeComponent.java
@@ -93,12 +93,16 @@ public class EdgeComponent implements IComponent {
                         for (Element targetNode : targetNodes) {
                             UUID id = this.computeEdgeId(sourceNode, targetNode, count);
                             var optionalPreviousEdge = edgesRequestor.getById(id);
+                            var edgeInstanceVariableManager = edgeVariableManager.createChild();
+                            edgeInstanceVariableManager.put(EdgeDescription.SEMANTIC_EDGE_SOURCE, cache.getNodeToObject().get(sourceNode));
+                            edgeInstanceVariableManager.put(EdgeDescription.SEMANTIC_EDGE_TARGET, cache.getNodeToObject().get(targetNode));
+
                             SynchronizationPolicy synchronizationPolicy = edgeDescription.getSynchronizationPolicy();
                             boolean shouldRender = synchronizationPolicy == SynchronizationPolicy.SYNCHRONIZED
                                     || (synchronizationPolicy == SynchronizationPolicy.UNSYNCHRONIZED && optionalPreviousEdge.isPresent());
 
                             if (shouldRender) {
-                                EdgeStyle style = edgeDescription.getStyleProvider().apply(edgeVariableManager);
+                                EdgeStyle style = edgeDescription.getStyleProvider().apply(edgeInstanceVariableManager);
 
                                 UUID sourceId = this.getId(sourceNode);
                                 UUID targetId = this.getId(targetNode);

--- a/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/description/EdgeDescription.java
+++ b/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/description/EdgeDescription.java
@@ -31,6 +31,15 @@ import org.eclipse.sirius.web.representations.VariableManager;
  */
 @Immutable
 public final class EdgeDescription {
+    /**
+     * The name of the variables which points to the semantic element at the source/origin of a particular edge.
+     */
+    public static final String SEMANTIC_EDGE_SOURCE = "semanticEdgeSource"; //$NON-NLS-1$
+
+    /**
+     * The name of the variables which points to the semantic element at the destination/target of a particular edge.
+     */
+    public static final String SEMANTIC_EDGE_TARGET = "semanticEdgeTarget"; //$NON-NLS-1$
 
     private UUID id;
 

--- a/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/tools/CreateEdgeTool.java
+++ b/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/tools/CreateEdgeTool.java
@@ -35,16 +35,6 @@ import org.eclipse.sirius.web.representations.VariableManager;
 @GraphQLObjectType
 public final class CreateEdgeTool implements ITool {
 
-    /**
-     * The name of the variable used to store and retrieve the edge source from a variable manager.
-     */
-    public static final String EDGE_SOURCE = "source"; //$NON-NLS-1$
-
-    /**
-     * The name of the variable used to store and retrieve the edge target from a variable manager.
-     */
-    public static final String EDGE_TARGET = "target"; //$NON-NLS-1$
-
     private String id;
 
     private String imageURL;

--- a/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/handlers/DeleteFromDiagramEventHandler.java
+++ b/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/handlers/DeleteFromDiagramEventHandler.java
@@ -190,6 +190,14 @@ public class DeleteFromDiagramEventHandler implements IDiagramEventHandler {
                 VariableManager variableManager = new VariableManager();
                 variableManager.put(VariableManager.SELF, optionalSelf.get());
                 variableManager.put(IDiagramContext.DIAGRAM_CONTEXT, diagramContext);
+                // @formatter:off
+                this.diagramService.findNodeById(diagramContext.getDiagram(), edge.getSourceId())
+                                   .flatMap(node -> this.objectService.getObject(editingContext, node.getTargetObjectId()))
+                                   .ifPresent(semanticElement -> variableManager.put(EdgeDescription.SEMANTIC_EDGE_SOURCE, semanticElement));
+                this.diagramService.findNodeById(diagramContext.getDiagram(), edge.getTargetId())
+                                   .flatMap(node -> this.objectService.getObject(editingContext, node.getTargetObjectId()))
+                                   .ifPresent(semanticElement -> variableManager.put(EdgeDescription.SEMANTIC_EDGE_TARGET, semanticElement));
+                // @formatter:on
                 EdgeDescription edgeDescription = optionalEdgeDescription.get();
                 this.logger.debug("Deleted diagram edge {}", edge.getId()); //$NON-NLS-1$
                 result = edgeDescription.getDeleteHandler().apply(variableManager);

--- a/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/handlers/InvokeEdgeToolOnDiagramEventHandler.java
+++ b/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/handlers/InvokeEdgeToolOnDiagramEventHandler.java
@@ -31,6 +31,7 @@ import org.eclipse.sirius.web.core.api.IEditingContext;
 import org.eclipse.sirius.web.core.api.IObjectService;
 import org.eclipse.sirius.web.diagrams.Diagram;
 import org.eclipse.sirius.web.diagrams.Node;
+import org.eclipse.sirius.web.diagrams.description.EdgeDescription;
 import org.eclipse.sirius.web.diagrams.services.api.IDiagramService;
 import org.eclipse.sirius.web.diagrams.tools.CreateEdgeTool;
 import org.eclipse.sirius.web.representations.Status;
@@ -121,6 +122,8 @@ public class InvokeEdgeToolOnDiagramEventHandler implements IDiagramEventHandler
             variableManager.put(IEditingContext.EDITING_CONTEXT, editingContext);
             variableManager.put(CreateEdgeTool.EDGE_SOURCE, source.get());
             variableManager.put(CreateEdgeTool.EDGE_TARGET, target.get());
+            variableManager.put(EdgeDescription.SEMANTIC_EDGE_SOURCE, source.get());
+            variableManager.put(EdgeDescription.SEMANTIC_EDGE_TARGET, target.get());
 
             result = tool.getHandler().apply(variableManager);
         }

--- a/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/handlers/InvokeEdgeToolOnDiagramEventHandler.java
+++ b/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/handlers/InvokeEdgeToolOnDiagramEventHandler.java
@@ -120,8 +120,6 @@ public class InvokeEdgeToolOnDiagramEventHandler implements IDiagramEventHandler
             VariableManager variableManager = new VariableManager();
             variableManager.put(IDiagramContext.DIAGRAM_CONTEXT, diagramContext);
             variableManager.put(IEditingContext.EDITING_CONTEXT, editingContext);
-            variableManager.put(CreateEdgeTool.EDGE_SOURCE, source.get());
-            variableManager.put(CreateEdgeTool.EDGE_TARGET, target.get());
             variableManager.put(EdgeDescription.SEMANTIC_EDGE_SOURCE, source.get());
             variableManager.put(EdgeDescription.SEMANTIC_EDGE_TARGET, target.get());
 


### PR DESCRIPTION
The work is not finished (no tests).

I've added 2 new variables. The initial request was to have them available in the context of labels computation; then we had a second request to make them available to edge delete tool. While trying to add them to all relevant locations I note that we already have 2 variables with the same values (but different names) in the context of edge creation (`InvokeEdgeToolOnDiagramEventHandler`).

I find the names I used (`semanticEdgeSource` & `semanticEdgeTarget`) more explicit than the ones we already have for edge creation (just `source` and `target`), but those are the ones used by Sirius Desktop (see `org.eclipse.sirius.diagram.description.tool.impl.ToolFactoryImpl.createEdgeCreationDescription()`).
