### PR TITLE
[360] Restore the use of the auto layout on diagram creation

### DIFF
--- a/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/DiagramCreationService.java
+++ b/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/DiagramCreationService.java
@@ -108,7 +108,6 @@ public class DiagramCreationService implements IDiagramCreationService {
     }
 
     private Diagram doRender(String label, Object targetObject, IEditingContext editingContext, DiagramDescription diagramDescription, Optional<IDiagramContext> optionalDiagramContext) {
-
         long start = System.currentTimeMillis();
 
         VariableManager variableManager = new VariableManager();
@@ -137,7 +136,9 @@ public class DiagramCreationService implements IDiagramCreationService {
         Element element = new Element(DiagramComponent.class, props);
 
         Diagram newDiagram = new DiagramRenderer(this.logger).render(element);
-        if (this.activateAutoLayout) {
+
+        // The auto layout is used for the first rendering and after that if it is activated
+        if (optionalDiagramContext.isEmpty() || this.activateAutoLayout) {
             newDiagram = this.layoutService.layout(newDiagram);
         }
         RepresentationDescriptor representationDescriptor = this.getRepresentationDescriptor(editingContext.getId(), newDiagram);


### PR DESCRIPTION
### Type of this PR 

- [ ] Bug fix
- [ ] New feature or improvement
- [ ] Documentation
- [ ] Cleanup
- [ ] Test
- [ ] Build/Releng

### Issue(s)

...

### What does this PR do?

...

### Screenshot/screencast of this PR

...
 

### Potential side effects

...

### How to test this PR?

- [ ] Frontend Unit tests
- [ ] Backend Unit tests
- [ ] Cypress : please specify
- [ ] Manual Test : please specify

### Checklist

- [ ] I have read CONTRIBUTING carefully.
- [ ] I have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [ ] All my commits are signed-off (`-s`) with my mail address of my Eclipse Account.
- [ ] I have covered my changes by unit tests or integration tests or manual tests.
- [ ] All tests pass.
- [ ] I have updated the documentation accordingly
- [ ] New React components are availables in storybook
