### PR TITLE
[333] Fix package delegation logic

### DIFF
--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/services/EditService.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/services/EditService.java
@@ -96,7 +96,8 @@ public class EditService implements IEditService {
     }
 
     private EPackage.Registry getPackageRegistry(UUID editingContextId) {
-        EPackageRegistryImpl ePackageRegistry = new EPackageRegistryImpl(this.globalEPackageRegistry);
+        EPackageRegistryImpl ePackageRegistry = new EPackageRegistryImpl();
+        this.globalEPackageRegistry.forEach(ePackageRegistry::put);
         List<EPackage> additionalEPackages = this.editingContextEPackageService.getEPackages(editingContextId);
         additionalEPackages.forEach(ePackage -> ePackageRegistry.put(ePackage.getNsURI(), ePackage));
         return ePackageRegistry;

--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/services/EditingContextEPackageService.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/services/EditingContextEPackageService.java
@@ -60,7 +60,8 @@ public class EditingContextEPackageService implements IEditingContextEPackageSer
             .collect(Collectors.toList());
         // @formatter:on
 
-        EPackageRegistryImpl ePackageRegistry = new EPackageRegistryImpl(this.globalEPackageRegistry);
+        EPackageRegistryImpl ePackageRegistry = new EPackageRegistryImpl();
+        this.globalEPackageRegistry.forEach(ePackageRegistry::put);
         ResourceSet resourceSet = new ResourceSetImpl();
         resourceSet.setPackageRegistry(ePackageRegistry);
 

--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/services/EditingContextSearchService.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/services/EditingContextSearchService.java
@@ -90,7 +90,8 @@ public class EditingContextSearchService implements IEditingContextSearchService
         this.logger.debug("Loading the editing context {}", editingContextId); //$NON-NLS-1$
         ResourceSet resourceSet = new ResourceSetImpl();
 
-        EPackageRegistryImpl ePackageRegistry = new EPackageRegistryImpl(this.globalEPackageRegistry);
+        EPackageRegistryImpl ePackageRegistry = new EPackageRegistryImpl();
+        this.globalEPackageRegistry.forEach(ePackageRegistry::put);
         List<EPackage> additionalEPackages = this.editingContextEPackageService.getEPackages(editingContextId);
         additionalEPackages.forEach(ePackage -> ePackageRegistry.put(ePackage.getNsURI(), ePackage));
         resourceSet.setPackageRegistry(ePackageRegistry);

--- a/backend/sirius-web-graphql-schema/src/main/java/org/eclipse/sirius/web/graphql/schema/PageInfoTypeProvider.java
+++ b/backend/sirius-web-graphql-schema/src/main/java/org/eclipse/sirius/web/graphql/schema/PageInfoTypeProvider.java
@@ -90,7 +90,7 @@ public class PageInfoTypeProvider implements ITypeProvider {
         // @formatter:off
         return GraphQLFieldDefinition.newFieldDefinition()
                 .name(START_CURSOR_FIELD)
-                .type(new GraphQLNonNull(Scalars.GraphQLString))
+                .type(Scalars.GraphQLString)
                 .build();
         // @formatter:on
     }
@@ -99,7 +99,7 @@ public class PageInfoTypeProvider implements ITypeProvider {
         // @formatter:off
         return GraphQLFieldDefinition.newFieldDefinition()
                 .name(END_CURSOR_FIELD)
-                .type(new GraphQLNonNull(Scalars.GraphQLString))
+                .type(Scalars.GraphQLString)
                 .build();
         // @formatter:on
     }


### PR DESCRIPTION
Building an EMF EPackageRegistryImpl with a "delegate" does not seem
to work like the code expects it to. Calling values() on such an
EPackage does not return any of the packages in the delegate. In this
case this makes all the globaly registered EPackages invisible to this
code. As this is called from e.g.
EditingContextRepresentationDescriptionsDataFetcher this makes it
impossible to create a new representation as the target CLASS_ID is
never properly resolved