### PR TITLE
[407] Add support for edges' sizeComputationExpression

### DIFF
--- a/backend/sirius-web-compatibility/src/main/java/org/eclipse/sirius/web/compat/diagrams/ColorDescriptionConverter.java
+++ b/backend/sirius-web-compatibility/src/main/java/org/eclipse/sirius/web/compat/diagrams/ColorDescriptionConverter.java
@@ -19,7 +19,6 @@ import org.eclipse.sirius.viewpoint.description.ColorDescription;
 import org.eclipse.sirius.viewpoint.description.ComputedColor;
 import org.eclipse.sirius.viewpoint.description.FixedColor;
 import org.eclipse.sirius.web.interpreter.AQLInterpreter;
-import org.eclipse.sirius.web.representations.VariableManager;
 
 /**
  * Provides a unified color format from a Sirius {@link ColorDescription}.
@@ -32,11 +31,11 @@ public class ColorDescriptionConverter {
 
     private final AQLInterpreter interpreter;
 
-    private final VariableManager variableManager;
+    private final Map<String, Object> variables;
 
-    public ColorDescriptionConverter(AQLInterpreter interpreter, VariableManager variableManager) {
+    public ColorDescriptionConverter(AQLInterpreter interpreter, Map<String, Object> variables) {
         this.interpreter = Objects.requireNonNull(interpreter);
-        this.variableManager = Objects.requireNonNull(variableManager);
+        this.variables = Objects.requireNonNull(variables);
     }
 
     public String convert(ColorDescription colorDescription) {
@@ -46,11 +45,9 @@ public class ColorDescriptionConverter {
             value = this.toHex(fixedColor.getRed(), fixedColor.getGreen(), fixedColor.getBlue());
         } else if (colorDescription instanceof ComputedColor) {
             ComputedColor computedColor = (ComputedColor) colorDescription;
-
-            Map<String, Object> variables = this.variableManager.getVariables();
-            int red = this.interpreter.evaluateExpression(variables, computedColor.getRed()).asInt().orElse(0);
-            int green = this.interpreter.evaluateExpression(variables, computedColor.getGreen()).asInt().orElse(0);
-            int blue = this.interpreter.evaluateExpression(variables, computedColor.getBlue()).asInt().orElse(0);
+            int red = this.interpreter.evaluateExpression(this.variables, computedColor.getRed()).asInt().orElse(0);
+            int green = this.interpreter.evaluateExpression(this.variables, computedColor.getGreen()).asInt().orElse(0);
+            int blue = this.interpreter.evaluateExpression(this.variables, computedColor.getBlue()).asInt().orElse(0);
 
             value = this.toHex(red, green, blue);
         }

--- a/backend/sirius-web-compatibility/src/main/java/org/eclipse/sirius/web/compat/diagrams/ContainerMappingStyleProvider.java
+++ b/backend/sirius-web-compatibility/src/main/java/org/eclipse/sirius/web/compat/diagrams/ContainerMappingStyleProvider.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.sirius.web.compat.diagrams;
 
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 
@@ -64,15 +65,15 @@ public class ContainerMappingStyleProvider implements Function<VariableManager, 
     }
 
     private RectangularNodeStyle createRectangularNodeStyle(VariableManager variableManager, FlatContainerStyleDescription flatContainerStyleDescription) {
-        ColorDescriptionConverter backgroundColorProvider = new ColorDescriptionConverter(this.interpreter, variableManager);
-        ColorDescriptionConverter borderColorProvider = new ColorDescriptionConverter(this.interpreter, variableManager);
+        Map<String, Object> variables = variableManager.getVariables();
+        ColorDescriptionConverter colorProvider = new ColorDescriptionConverter(this.interpreter, variables);
 
-        String color = backgroundColorProvider.convert(flatContainerStyleDescription.getBackgroundColor());
-        String borderColor = borderColorProvider.convert(flatContainerStyleDescription.getBorderColor());
+        String color = colorProvider.convert(flatContainerStyleDescription.getBackgroundColor());
+        String borderColor = colorProvider.convert(flatContainerStyleDescription.getBorderColor());
 
         LineStyle borderStyle = new LineStyleConverter().getStyle(flatContainerStyleDescription.getBorderLineStyle());
 
-        Result result = this.interpreter.evaluateExpression(variableManager.getVariables(), flatContainerStyleDescription.getBorderSizeComputationExpression());
+        Result result = this.interpreter.evaluateExpression(variables, flatContainerStyleDescription.getBorderSizeComputationExpression());
         int borderSize = result.asInt().getAsInt();
 
         // @formatter:off

--- a/backend/sirius-web-compatibility/src/main/java/org/eclipse/sirius/web/compat/diagrams/EdgeMappingStyleProvider.java
+++ b/backend/sirius-web-compatibility/src/main/java/org/eclipse/sirius/web/compat/diagrams/EdgeMappingStyleProvider.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.sirius.web.compat.diagrams;
 
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 
@@ -46,11 +47,12 @@ public class EdgeMappingStyleProvider implements Function<VariableManager, EdgeS
     }
 
     private EdgeStyle getEdgeStyle(VariableManager variableManager, EdgeStyleDescription style) {
-        ColorDescriptionConverter colorDescriptionConverter = new ColorDescriptionConverter(this.interpreter, variableManager);
+        Map<String, Object> variables = variableManager.getVariables();
+        ColorDescriptionConverter colorDescriptionConverter = new ColorDescriptionConverter(this.interpreter, variables);
         LineStyleConverter lineStyleConverter = new LineStyleConverter();
         ArrowStyleConverter arrowStyleConverter = new ArrowStyleConverter();
 
-        int size = 1;
+        int size = this.interpreter.evaluateExpression(variables, style.getSizeComputationExpression()).asInt().orElse(1);
         LineStyle lineStyle = lineStyleConverter.getStyle(style.getLineStyle());
         ArrowStyle sourceArrow = arrowStyleConverter.getStyle(style.getSourceArrow());
         ArrowStyle targetArrow = arrowStyleConverter.getStyle(style.getTargetArrow());

--- a/backend/sirius-web-compatibility/src/main/java/org/eclipse/sirius/web/compat/diagrams/LabelStyleDescriptionConverter.java
+++ b/backend/sirius-web-compatibility/src/main/java/org/eclipse/sirius/web/compat/diagrams/LabelStyleDescriptionConverter.java
@@ -69,7 +69,7 @@ public class LabelStyleDescriptionConverter {
         };
 
         Function<VariableManager, String> colorProvider = variableManager -> {
-            return new ColorDescriptionConverter(this.interpreter, variableManager).convert(labelStyleDescription.getLabelColor());
+            return new ColorDescriptionConverter(this.interpreter, variableManager.getVariables()).convert(labelStyleDescription.getLabelColor());
         };
 
         // @formatter:off

--- a/backend/sirius-web-compatibility/src/main/java/org/eclipse/sirius/web/compat/diagrams/NodeMappingStyleProvider.java
+++ b/backend/sirius-web-compatibility/src/main/java/org/eclipse/sirius/web/compat/diagrams/NodeMappingStyleProvider.java
@@ -76,11 +76,10 @@ public class NodeMappingStyleProvider implements Function<VariableManager, INode
     }
 
     private RectangularNodeStyle createRectangularNodeStyle(VariableManager variableManager, SquareDescription squareDescription) {
-        ColorDescriptionConverter colorProvider = new ColorDescriptionConverter(this.interpreter, variableManager);
-        ColorDescriptionConverter borderColorProvider = new ColorDescriptionConverter(this.interpreter, variableManager);
+        ColorDescriptionConverter colorProvider = new ColorDescriptionConverter(this.interpreter, variableManager.getVariables());
 
         String color = colorProvider.convert(squareDescription.getColor());
-        String borderColor = borderColorProvider.convert(squareDescription.getBorderColor());
+        String borderColor = colorProvider.convert(squareDescription.getBorderColor());
 
         LineStyle borderStyle = new LineStyleConverter().getStyle(squareDescription.getBorderLineStyle());
 

--- a/backend/sirius-web-compatibility/src/test/java/org/eclipse/sirius/web/compat/diagrams/ColorDescriptionConverterTestCases.java
+++ b/backend/sirius-web-compatibility/src/test/java/org/eclipse/sirius/web/compat/diagrams/ColorDescriptionConverterTestCases.java
@@ -14,13 +14,13 @@ package org.eclipse.sirius.web.compat.diagrams;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Collections;
 import java.util.List;
 
 import org.eclipse.emf.ecore.EcorePackage;
 import org.eclipse.sirius.viewpoint.description.DescriptionFactory;
 import org.eclipse.sirius.viewpoint.description.FixedColor;
 import org.eclipse.sirius.web.interpreter.AQLInterpreter;
-import org.eclipse.sirius.web.representations.VariableManager;
 import org.junit.Test;
 
 /**
@@ -38,8 +38,7 @@ public class ColorDescriptionConverterTestCases {
         fixedColor.setBlue(16);
 
         AQLInterpreter interpreter = new AQLInterpreter(List.of(), List.of(EcorePackage.eINSTANCE));
-        VariableManager variableManager = new VariableManager();
-        ColorDescriptionConverter colorProvider = new ColorDescriptionConverter(interpreter, variableManager);
+        ColorDescriptionConverter colorProvider = new ColorDescriptionConverter(interpreter, Collections.emptyMap());
         String color = colorProvider.convert(fixedColor);
         assertThat(color).isEqualTo("#0f0110"); //$NON-NLS-1$
     }


### PR DESCRIPTION
Also adjust some APIs to reduce the number of unneeded calls to
VariablesManager.getVariables() which is not free when repeated in hot
loops like during a render.

- [ ] Hover feedback uses the wrong size (when the edge is selected, the width is OK though).
- [ ]  Some non-regression tests are needed before this can actually be merged.