### PR TITLE
[412] Fix edge handling in ViewConverter

### DIFF
--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/diagrams/CanCreateDiagramPredicate.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/diagrams/CanCreateDiagramPredicate.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.sirius.web.emf.compatibility.diagrams;
 
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Predicate;
 
@@ -37,8 +38,8 @@ public class CanCreateDiagramPredicate implements Predicate<VariableManager> {
     private final AQLInterpreter interpreter;
 
     public CanCreateDiagramPredicate(DiagramDescription diagramDescription, AQLInterpreter interpreter) {
-        this.diagramDescription = diagramDescription;
-        this.interpreter = interpreter;
+        this.diagramDescription = Objects.requireNonNull(diagramDescription);
+        this.interpreter = Objects.requireNonNull(interpreter);
     }
 
     @Override
@@ -48,9 +49,7 @@ public class CanCreateDiagramPredicate implements Predicate<VariableManager> {
         String domainClass = this.diagramDescription.getDomainClass();
 
         // @formatter:off
-        Optional<EObject> optionalEObject = Optional.ofNullable(variableManager.getVariables().get(IRepresentationDescription.CLASS))
-                .filter(EClass.class::isInstance)
-                .map(EClass.class::cast)
+        Optional<EObject> optionalEObject = variableManager.get(IRepresentationDescription.CLASS, EClass.class)
                 .map(EcoreUtil::create)
                 .filter(new DomainClassPredicate(domainClass));
         // @formatter:on

--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/view/TargetNodesProvider.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/view/TargetNodesProvider.java
@@ -76,7 +76,7 @@ public class TargetNodesProvider implements Function<VariableManager, List<Eleme
     private boolean isFromDescription(Element nodeElement, DiagramElementDescription description) {
         if (nodeElement.getProps() instanceof NodeElementProps) {
             NodeElementProps props = (NodeElementProps) nodeElement.getProps();
-            return Objects.equals(this.idProvider.apply(description), props.getDescriptionId().toString());
+            return Objects.equals(this.idProvider.apply(description), props.getDescriptionId());
         }
         return false;
     }

--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/view/ViewConverter.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/view/ViewConverter.java
@@ -217,7 +217,7 @@ public class ViewConverter {
 
                 // @formatter:off
                 return nodeCandidates
-                        .filter(nodeElement -> viewEdgeDescription.getSourceNodeDescriptions().stream().anyMatch(srcMapping -> this.isFromDescription(nodeElement, viewEdgeDescription)))
+                        .filter(nodeElement -> viewEdgeDescription.getSourceNodeDescriptions().stream().anyMatch(srcMapping -> this.isFromDescription(nodeElement, srcMapping)))
                         .filter(Objects::nonNull)
                         .collect(Collectors.toList());
                 // @formatter:on
@@ -285,7 +285,7 @@ public class ViewConverter {
     private boolean isFromDescription(Element nodeElement, DiagramElementDescription diagramElementDescription) {
         if (nodeElement.getProps() instanceof NodeElementProps) {
             NodeElementProps props = (NodeElementProps) nodeElement.getProps();
-            return Objects.equals(EcoreUtil.getURI(diagramElementDescription).toString(), props.getDescriptionId().toString());
+            return Objects.equals(this.idProvider.apply(diagramElementDescription), props.getDescriptionId());
         }
         return false;
     }

--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/view/ViewConverter.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/view/ViewConverter.java
@@ -251,7 +251,7 @@ public class ViewConverter {
                     .lineStyle(LineStyle.Solid)
                     .size(1)
                     .sourceArrow(ArrowStyle.None)
-                    .targetArrow(ArrowStyle.OutputArrow)
+                    .targetArrow(ArrowStyle.InputArrow)
                     .build();
             // @formatter:on
         };


### PR DESCRIPTION
With these fixes and a sample `View` definition (programmatically defined to workaround currentl limitations in our properties view), I get the following result on the sample Robot:

![2021-03-26_10-12](https://user-images.githubusercontent.com/10608/112609654-1192e480-8e1c-11eb-8d5b-1e18e4d1cc59.png)

The edges in black are domain-based, and represent `DataFlow` elements.
The edges in blue are reference-based and represent the containment between `CompositeProcessors` and `Processors`.

Here is the full definition of the `View` model used, in Java:

```java
    private View getSampleView() {
        View view = ViewFactory.eINSTANCE.createView();

        DiagramDescription diagramDescription = ViewFactory.eINSTANCE.createDiagramDescription();
        diagramDescription.setName("Flow Edges Test"); //$NON-NLS-1$
        diagramDescription.setDomainType("System"); //$NON-NLS-1$
        diagramDescription.setTitleExpression("aql:'Flow Edges'"); //$NON-NLS-1$
        view.getDescriptions().add(diagramDescription);

        NodeDescription processorNode = ViewFactory.eINSTANCE.createNodeDescription();
        processorNode.setDomainType("Processor"); //$NON-NLS-1$
        processorNode.setSemanticCandidatesExpression("aql:self.eAllContents()"); //$NON-NLS-1$
        processorNode.setLabelExpression("aql:self.name"); //$NON-NLS-1$
        Style processorStyle = ViewFactory.eINSTANCE.createStyle();
        processorStyle.setColor("lightblue"); //$NON-NLS-1$
        processorNode.setStyle(processorStyle);
        diagramDescription.getNodeDescriptions().add(processorNode);

        EdgeDescription dataFlowEdge = ViewFactory.eINSTANCE.createEdgeDescription();
        dataFlowEdge.setDomainType("DataFlow"); //$NON-NLS-1$
        dataFlowEdge.setSemanticCandidatesExpression("aql:self.eAllContents()"); //$NON-NLS-1$
        dataFlowEdge.setIsDomainBasedEdge(true);
        dataFlowEdge.setSourceNodesExpression("aql:self.source"); //$NON-NLS-1$
        dataFlowEdge.setTargetNodesExpression("aql:self.target"); //$NON-NLS-1$
        dataFlowEdge.getSourceNodeDescriptions().add(processorNode);
        dataFlowEdge.getTargetNodeDescriptions().add(processorNode);
        Style edgeStyle = ViewFactory.eINSTANCE.createStyle();
        edgeStyle.setColor("black"); //$NON-NLS-1$
        dataFlowEdge.setStyle(edgeStyle);
        diagramDescription.getEdgeDescriptions().add(dataFlowEdge);

        NodeDescription compositeProcessorNode = ViewFactory.eINSTANCE.createNodeDescription();
        compositeProcessorNode.setDomainType("CompositeProcessor"); //$NON-NLS-1$
        compositeProcessorNode.setSemanticCandidatesExpression("aql:self.elements"); //$NON-NLS-1$
        compositeProcessorNode.setLabelExpression("aql:self.name"); //$NON-NLS-1$
        Style compositeProcessorStyle = ViewFactory.eINSTANCE.createStyle();
        compositeProcessorStyle.setColor("lightgreen"); //$NON-NLS-1$
        compositeProcessorNode.setStyle(compositeProcessorStyle);
        diagramDescription.getNodeDescriptions().add(compositeProcessorNode);

        EdgeDescription elementEdge = ViewFactory.eINSTANCE.createEdgeDescription();
        elementEdge.setDomainType("CompositeProcessor"); //$NON-NLS-1$
        elementEdge.setSemanticCandidatesExpression("aql:self.eAllContents()"); //$NON-NLS-1$
        elementEdge.setIsDomainBasedEdge(false);
        elementEdge.setTargetNodesExpression("aql:self.elements"); //$NON-NLS-1$
        elementEdge.getSourceNodeDescriptions().add(compositeProcessorNode);
        elementEdge.getTargetNodeDescriptions().add(processorNode);
        Style elementEdgeStyle = ViewFactory.eINSTANCE.createStyle();
        elementEdgeStyle.setColor("blue"); //$NON-NLS-1$
        elementEdge.setStyle(elementEdgeStyle);
        diagramDescription.getEdgeDescriptions().add(elementEdge);

        return view;
    }
```