### PR TITLE
[397] Be more specific when looking for potential domain or view documents

### DIFF
--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/services/EditingContextEPackageService.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/services/EditingContextEPackageService.java
@@ -27,6 +27,7 @@ import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
 import org.eclipse.sirius.emfjson.resource.JsonResource;
 import org.eclipse.sirius.web.domain.Domain;
+import org.eclipse.sirius.web.domain.DomainPackage;
 import org.eclipse.sirius.web.emf.domain.DomainConverter;
 import org.eclipse.sirius.web.persistence.entities.DocumentEntity;
 import org.eclipse.sirius.web.persistence.repositories.IDocumentRepository;
@@ -56,7 +57,7 @@ public class EditingContextEPackageService implements IEditingContextEPackageSer
     @Override
     public List<EPackage> getEPackages(UUID editingContextId) {
         // @formatter:off
-        List<DocumentEntity> entities = StreamSupport.stream(this.documentRepository.findAll().spliterator(), false)
+        List<DocumentEntity> entities = StreamSupport.stream(this.documentRepository.findAllByType(DomainPackage.eNAME, DomainPackage.eNS_URI).spliterator(), false)
             .collect(Collectors.toList());
         // @formatter:on
 

--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/view/DynamicRepresentationDescriptionService.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/view/DynamicRepresentationDescriptionService.java
@@ -34,6 +34,7 @@ import org.eclipse.sirius.web.persistence.repositories.IDocumentRepository;
 import org.eclipse.sirius.web.representations.IRepresentationDescription;
 import org.eclipse.sirius.web.services.api.representations.IDynamicRepresentationDescriptionService;
 import org.eclipse.sirius.web.view.View;
+import org.eclipse.sirius.web.view.ViewPackage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -63,7 +64,7 @@ public class DynamicRepresentationDescriptionService implements IDynamicRepresen
     @Override
     public List<IRepresentationDescription> findDynamicRepresentationDescriptions(UUID editingContextId) {
         List<IRepresentationDescription> dynamicRepresentationDescriptions = new ArrayList<>();
-        this.documentRepository.findAll().forEach(documentEntity -> {
+        this.documentRepository.findAllByType(ViewPackage.eNAME, ViewPackage.eNS_URI).forEach(documentEntity -> {
             Resource res = this.loadDocumentAsEMF(documentEntity);
             this.getViewDefinition(res).ifPresent(view -> this.viewConverter.convert(view).forEach(dynamicRepresentationDescriptions::add));
         });

--- a/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/services/NoOpDocumentRepository.java
+++ b/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/services/NoOpDocumentRepository.java
@@ -102,4 +102,9 @@ public class NoOpDocumentRepository implements IDocumentRepository {
         return Optional.empty();
     }
 
+    @Override
+    public Iterable<DocumentEntity> findAllByType(String name, String uri) {
+        return List.of();
+    }
+
 }

--- a/backend/sirius-web-persistence/src/main/java/org/eclipse/sirius/web/persistence/repositories/IDocumentRepository.java
+++ b/backend/sirius-web-persistence/src/main/java/org/eclipse/sirius/web/persistence/repositories/IDocumentRepository.java
@@ -39,6 +39,10 @@ public interface IDocumentRepository extends PagingAndSortingRepository<Document
     Iterable<DocumentEntity> findAll();
 
     @Audited
+    @Query(name = "Document.findAllByType", nativeQuery = true)
+    Iterable<DocumentEntity> findAllByType(String name, String uri);
+
+    @Audited
     List<DocumentEntity> findAllByProjectId(UUID projectId);
 
     @Audited

--- a/backend/sirius-web-persistence/src/main/resources/db/sirius-web-named-queries.properties
+++ b/backend/sirius-web-persistence/src/main/resources/db/sirius-web-named-queries.properties
@@ -3,3 +3,4 @@ Project.existsByIdAndIsVisibleBy=SELECT CASE WHEN COUNT(project)> 0 THEN true EL
 Project.findAllVisibleBy=SELECT * FROM project
 Project.findByIdIfVisibleBy=SELECT * FROM project project WHERE project.id=?1
 Project.isOwner=SELECT CASE WHEN COUNT(project)> 0 THEN true ELSE false END FROM ProjectEntity project WHERE project.id=?2 AND project.owner.username=?1
+Document.findAllByType=SELECT * FROM Document document WHERE document.content::::jsonb @> ('{ "ns": { "' || ?1 || '": "' || ?2 ||'" } }')::::jsonb


### PR DESCRIPTION
@sbegaudeau I'm not entirely sure about the new API this introduces: `Iterable<DocumentEntity> findAllByType(String name, String uri)`.

Another option would be to have explicit `findAllDomainDefinitions` and `findAllViewDefinitions`, but that seems overly specific and IMO `IDocumentRepository` should stay agnostic about the kind of documents we store. If tomorrow we want to hadd new kinds which are treated somewhat specially by other parts of the system, we shouldn't have to touch this API every time.

OTOH, the `(String name, String uri)` also leak EMF-specific concepts, even if they are just strings here. Between the name (`findAll**ByType**`) and these arguments, it implicitly introduces a notion of document type identified by name/uri, which we do not have at the moment.

Otherwise the actual technique you suggested works :+1:, and prevents loading & parsing unrelated documents when we are looking for domains or views, so it's also a nice performance improvement.