### PR TITLE
[411] Add canonical behaviors to dynamic view definitions

### DIFF
--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/view/CanonicalBehaviors.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/view/CanonicalBehaviors.java
@@ -1,0 +1,129 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.emf.view;
+
+import java.util.Collection;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.EPackage;
+import org.eclipse.sirius.web.core.api.IEditingContext;
+import org.eclipse.sirius.web.core.api.IObjectService;
+import org.eclipse.sirius.web.emf.services.EditingContext;
+import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.VariableManager;
+import org.eclipse.sirius.web.services.api.objects.IEditService;
+import org.eclipse.sirius.web.view.EdgeDescription;
+
+/**
+ * Canonical implementations of the basic behaviors/tools expected on a diagram. The implementation makes some
+ * assumptions on both the structure of the domain and that of the view definition, and may not work (or not as
+ * expected) on pretty normal but non trivial cases.
+ *
+ * @author pcdavid
+ */
+public class CanonicalBehaviors {
+    private final IObjectService objectService;
+
+    private final IEditService editService;
+
+    public CanonicalBehaviors(IObjectService objectService, IEditService editService) {
+        this.objectService = Objects.requireNonNull(objectService);
+        this.editService = Objects.requireNonNull(editService);
+    }
+
+    public Status createNewNode(org.eclipse.sirius.web.view.NodeDescription nodeDescription, VariableManager variableManager) {
+        EObject self = variableManager.get(VariableManager.SELF, EObject.class).orElse(null);
+        String domainType = nodeDescription.getDomainType();
+        EObject instance = this.createSemanticInstance(self, domainType, variableManager);
+        this.addInParent(self, instance);
+        return Status.OK;
+    }
+
+    public Status createNewEdge(VariableManager variableManager, EdgeDescription edgeDescription) {
+        EObject semanticSource = variableManager.get(org.eclipse.sirius.web.diagrams.description.EdgeDescription.SEMANTIC_EDGE_SOURCE, EObject.class).get();
+        EObject semanticTarget = variableManager.get(org.eclipse.sirius.web.diagrams.description.EdgeDescription.SEMANTIC_EDGE_TARGET, EObject.class).get();
+        if (edgeDescription.isIsDomainBasedEdge()) {
+            EObject instance = this.createSemanticInstance(semanticSource, edgeDescription.getDomainType(), variableManager);
+            this.addInParent(semanticSource, instance);
+            this.addReferenceTo(instance, semanticSource);
+            this.addReferenceTo(instance, semanticTarget);
+        } else {
+            this.addReferenceTo(semanticSource, semanticTarget);
+        }
+        return Status.OK;
+    }
+
+    public Status editLabel(VariableManager variableManager, String newLabel) {
+        this.self(variableManager).ifPresent(self -> {
+            Optional<String> optionalLabelField = this.objectService.getLabelField(self);
+            if (optionalLabelField.isPresent()) {
+                this.editService.editLabel(self, optionalLabelField.get(), newLabel);
+            }
+        });
+        return Status.OK;
+    }
+
+    public Status deleteElement(VariableManager variableManager) {
+        this.self(variableManager).ifPresent(this.editService::delete);
+        return Status.OK;
+    }
+
+    private Optional<Object> self(VariableManager variableManager) {
+        return variableManager.get(VariableManager.SELF, Object.class);
+    }
+
+    private EObject createSemanticInstance(EObject self, String domainType, VariableManager variableManager) {
+        EditingContext editingContext = variableManager.get(IEditingContext.EDITING_CONTEXT, EditingContext.class).orElse(null);
+        // @formatter:off
+        EPackage ePackage = editingContext.getDomain().getResourceSet().getPackageRegistry().getEPackage(self.eClass().getEPackage().getNsURI());
+        EClass klass = ePackage
+                      .getEClassifiers().stream()
+                      .filter(classifier -> classifier instanceof EClass && Objects.equals(domainType, classifier.getName()))
+                      .map(EClass.class::cast)
+                      .findFirst()
+                      .get();
+        // @formatter:on
+        EObject instance = ePackage.getEFactoryInstance().create(klass);
+        // @formatter:off
+        // Assume the first stringly-typed attribute represents the object's name/label
+        klass.getEAllAttributes().stream().filter(attr -> Objects.equals(String.class, attr.getEType().getInstanceClass())).findFirst().ifPresent(labelAttribute -> {
+            instance.eSet(labelAttribute, "New " + klass.getName()); //$NON-NLS-1$
+        });
+        // @formatter:on
+        return instance;
+    }
+
+    private void addInParent(EObject parent, EObject instance) {
+        parent.eClass().getEAllContainments().stream().filter(ref -> ref.getEType().isInstance(instance)).findFirst().ifPresent(ref -> {
+            if (ref.isMany()) {
+                ((Collection<EObject>) parent.eGet(ref)).add(instance);
+            } else {
+                parent.eSet(ref, instance);
+            }
+        });
+    }
+
+    private void addReferenceTo(EObject source, EObject target) {
+        source.eClass().getEAllReferences().stream().filter(ref -> ref.getEType().isInstance(target)).findFirst().ifPresent(ref -> {
+            if (ref.isMany()) {
+                ((Collection<EObject>) source.eGet(ref)).add(target);
+            } else {
+                source.eSet(ref, target);
+            }
+        });
+    }
+
+}

--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/view/DynamicRepresentationDescriptionService.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/view/DynamicRepresentationDescriptionService.java
@@ -32,6 +32,7 @@ import org.eclipse.sirius.web.interpreter.AQLInterpreter;
 import org.eclipse.sirius.web.persistence.entities.DocumentEntity;
 import org.eclipse.sirius.web.persistence.repositories.IDocumentRepository;
 import org.eclipse.sirius.web.representations.IRepresentationDescription;
+import org.eclipse.sirius.web.services.api.objects.IEditService;
 import org.eclipse.sirius.web.services.api.representations.IDynamicRepresentationDescriptionService;
 import org.eclipse.sirius.web.view.View;
 import org.slf4j.Logger;
@@ -53,11 +54,11 @@ public class DynamicRepresentationDescriptionService implements IDynamicRepresen
 
     private final ViewConverter viewConverter;
 
-    public DynamicRepresentationDescriptionService(IDocumentRepository documentRepository, EPackage.Registry ePackageRegistry, IObjectService objectService) {
+    public DynamicRepresentationDescriptionService(IDocumentRepository documentRepository, EPackage.Registry ePackageRegistry, IObjectService objectService, IEditService editService) {
         this.documentRepository = Objects.requireNonNull(documentRepository);
         this.ePackageRegistry = Objects.requireNonNull(ePackageRegistry);
         AQLInterpreter interpreter = new AQLInterpreter(List.of(), List.of());
-        this.viewConverter = new ViewConverter(Objects.requireNonNull(interpreter), Objects.requireNonNull(objectService));
+        this.viewConverter = new ViewConverter(Objects.requireNonNull(interpreter), Objects.requireNonNull(objectService), Objects.requireNonNull(editService));
     }
 
     @Override

--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/view/StylesFactory.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/view/StylesFactory.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.emf.view;
+
+import org.eclipse.sirius.web.diagrams.ArrowStyle;
+import org.eclipse.sirius.web.diagrams.EdgeStyle;
+import org.eclipse.sirius.web.diagrams.INodeStyle;
+import org.eclipse.sirius.web.diagrams.LineStyle;
+import org.eclipse.sirius.web.diagrams.RectangularNodeStyle;
+import org.eclipse.sirius.web.diagrams.description.LabelStyleDescription;
+
+/**
+ * Factory to create the basic style descriptions used by {@link ViewConverter}.
+ *
+ * @author pcdavid
+ */
+public final class StylesFactory {
+    public LabelStyleDescription createLabelStyleDescription(String color) {
+        // @formatter:off
+        return LabelStyleDescription.newLabelStyleDescription()
+                                    .colorProvider(variableManager -> color)
+                                    .fontSizeProvider(variableManager -> 16)
+                                    .boldProvider(variableManager -> false)
+                                    .italicProvider(variableManager -> false)
+                                    .underlineProvider(variableManager -> false)
+                                    .strikeThroughProvider(variableManager -> false)
+                                    .iconURLProvider(variableManager -> "") //$NON-NLS-1$
+                                    .build();
+        // @formatter:on
+    }
+
+    public EdgeStyle createEdgeStyle(String color) {
+        // @formatter:off
+        return EdgeStyle.newEdgeStyle()
+                        .color(color)
+                        .lineStyle(LineStyle.Solid)
+                        .size(1)
+                        .sourceArrow(ArrowStyle.None)
+                        .targetArrow(ArrowStyle.InputArrow)
+                        .build();
+        // @formatter:on
+    }
+
+    public INodeStyle createNodeStyle(String color) {
+        // @formatter:off
+        return RectangularNodeStyle.newRectangularNodeStyle()
+                                   .color(color)
+                                   .borderColor("rgb(0, 0, 0)") //$NON-NLS-1$
+                                   .borderSize(1)
+                                   .borderStyle(LineStyle.Solid)
+                                   .build();
+        // @formatter:on
+    }
+}

--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/view/ViewConverter.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/view/ViewConverter.java
@@ -106,13 +106,19 @@ public class ViewConverter {
      * {@link DiagramDescription}s are supported. <b>Warning:</b> this code is not re-entrant.
      */
     public List<IRepresentationDescription> convert(View view) {
-        // @formatter:off
-        return view.getDescriptions().stream()
-                   .filter(org.eclipse.sirius.web.view.DiagramDescription.class::isInstance)
-                   .map(org.eclipse.sirius.web.view.DiagramDescription.class::cast)
-                   .map(this::convert)
-                   .collect(Collectors.toList());
-        // @formatter:on
+        try {
+            // @formatter:off
+            return view.getDescriptions().stream()
+                       .filter(org.eclipse.sirius.web.view.DiagramDescription.class::isInstance)
+                       .map(org.eclipse.sirius.web.view.DiagramDescription.class::cast)
+                       .map(this::convert)
+                       .collect(Collectors.toList());
+            // @formatter:on
+        } catch (NullPointerException e) {
+            // Can easily happen if the View model is currently invalid/inconsistent, typically because it is
+            // currently being created or edited.
+            return List.of();
+        }
     }
 
     private DiagramDescription convert(org.eclipse.sirius.web.view.DiagramDescription viewDiagramDescription) {


### PR DESCRIPTION
Add support for:
- node and edge creation tools
- initial name for newly created elements
- direct-edit
- deletion

The first commit in the series, "dep: fixes for edge handling and direct edit on diagrams" is needed for testing, but it's actually a squash of the commits in PRs #413 https://github.com/eclipse-sirius/sirius-components/pull/421 so should not be merged as part of this.

To test this patch, the easiest way is to also get the programmatically defined View definition mentioned in PR #413 .

The result can be seen here: https://www.youtube.com/watch?v=ZWfNVqORGrU