### PR TITLE
[418] Add the support for list container

### DIFF
--- a/backend/sirius-web-compatibility/src/main/java/org/eclipse/sirius/web/compat/diagrams/AbstractNodeMappingConverter.java
+++ b/backend/sirius-web-compatibility/src/main/java/org/eclipse/sirius/web/compat/diagrams/AbstractNodeMappingConverter.java
@@ -21,7 +21,8 @@ import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import org.eclipse.sirius.diagram.ContainerLayout;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.sirius.diagram.business.api.query.ContainerMappingQuery;
 import org.eclipse.sirius.diagram.description.AbstractNodeMapping;
 import org.eclipse.sirius.diagram.description.ContainerMapping;
 import org.eclipse.sirius.diagram.description.style.FlatContainerStyleDescription;
@@ -115,15 +116,10 @@ public class AbstractNodeMappingConverter {
             String nodeType = NodeType.NODE_RECTANGLE;
             if (style instanceof WorkspaceImageDescription) {
                 nodeType = NodeType.NODE_IMAGE;
-            } else if (style instanceof FlatContainerStyleDescription && abstractNodeMapping instanceof ContainerMapping
-                    && ContainerLayout.LIST.equals(((ContainerMapping) abstractNodeMapping).getChildrenPresentation())) {
+            } else if (style instanceof FlatContainerStyleDescription && this.isListContainer(abstractNodeMapping)) {
                 nodeType = NodeType.NODE_LIST;
-            } else if (style.eContainer() != null && style.eContainer().eContainer() instanceof ContainerMapping) {
-                ContainerMapping parentMapping = (ContainerMapping) style.eContainer().eContainer();
-                org.eclipse.sirius.viewpoint.description.style.LabelStyleDescription labelStyleDescription = new LabelStyleDescriptionProvider(interpreter, parentMapping).apply(variableManager);
-                if (labelStyleDescription instanceof FlatContainerStyleDescription && ContainerLayout.LIST.equals(parentMapping.getChildrenPresentation())) {
-                    nodeType = NodeType.NODE_LIST_ITEM;
-                }
+            } else if (this.isListContainer(abstractNodeMapping.eContainer())) {
+                nodeType = NodeType.NODE_LIST_ITEM;
             }
             return nodeType;
         };
@@ -200,6 +196,10 @@ public class AbstractNodeMappingConverter {
         labelStyle.setShowIcon(true);
         labelStyle.setLabelSize(16);
         return labelStyle;
+    }
+
+    private boolean isListContainer(EObject nodeMapping) {
+        return nodeMapping instanceof ContainerMapping && new ContainerMappingQuery((ContainerMapping) nodeMapping).isListContainer();
     }
 
 }

--- a/backend/sirius-web-compatibility/src/main/java/org/eclipse/sirius/web/compat/diagrams/AbstractNodeMappingStyleProvider.java
+++ b/backend/sirius-web-compatibility/src/main/java/org/eclipse/sirius/web/compat/diagrams/AbstractNodeMappingStyleProvider.java
@@ -16,12 +16,10 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 
-import org.eclipse.sirius.diagram.ContainerLayout;
+import org.eclipse.sirius.diagram.business.api.query.ContainerMappingQuery;
 import org.eclipse.sirius.diagram.description.AbstractNodeMapping;
 import org.eclipse.sirius.diagram.description.ContainerMapping;
-import org.eclipse.sirius.diagram.description.style.EllipseNodeDescription;
 import org.eclipse.sirius.diagram.description.style.FlatContainerStyleDescription;
-import org.eclipse.sirius.diagram.description.style.LozengeNodeDescription;
 import org.eclipse.sirius.diagram.description.style.SquareDescription;
 import org.eclipse.sirius.diagram.description.style.WorkspaceImageDescription;
 import org.eclipse.sirius.viewpoint.description.style.LabelStyleDescription;
@@ -66,7 +64,7 @@ public class AbstractNodeMappingStyleProvider implements Function<VariableManage
             style = this.createRectangularNodeStyle(variableManager, squareDescription);
         } else if (nodeStyleDescription instanceof FlatContainerStyleDescription) {
             FlatContainerStyleDescription flatContainerStyleDescription = (FlatContainerStyleDescription) nodeStyleDescription;
-            if (this.abstractNodeMapping instanceof ContainerMapping && ContainerLayout.LIST.equals(((ContainerMapping) this.abstractNodeMapping).getChildrenPresentation())) {
+            if (this.abstractNodeMapping instanceof ContainerMapping && new ContainerMappingQuery((ContainerMapping) this.abstractNodeMapping).isListContainer()) {
                 style = this.createListNodeStyle(variableManager, flatContainerStyleDescription);
             } else {
                 style = this.createRectangularNodeStyle(variableManager, flatContainerStyleDescription);
@@ -102,11 +100,9 @@ public class AbstractNodeMappingStyleProvider implements Function<VariableManage
      * @return <code>true</code> if the <em>nodeStyleDescription</em> should be considered as a list item node style
      */
     private boolean shouldBeConsideredAsListItemNodeStyle(VariableManager variableManager, LabelStyleDescription nodeStyleDescription) {
-        if ((nodeStyleDescription instanceof SquareDescription || nodeStyleDescription instanceof EllipseNodeDescription || nodeStyleDescription instanceof LozengeNodeDescription)
-                && this.abstractNodeMapping.eContainer() instanceof ContainerMapping) {
+        if (this.abstractNodeMapping.eContainer() instanceof ContainerMapping) {
             ContainerMapping parentMapping = (ContainerMapping) this.abstractNodeMapping.eContainer();
-            LabelStyleDescription labelStyleDescription = new LabelStyleDescriptionProvider(this.interpreter, parentMapping).apply(variableManager);
-            return labelStyleDescription instanceof FlatContainerStyleDescription && ContainerLayout.LIST.equals(parentMapping.getChildrenPresentation());
+            return new ContainerMappingQuery(parentMapping).isListContainer();
         }
         return false;
     }
@@ -120,11 +116,10 @@ public class AbstractNodeMappingStyleProvider implements Function<VariableManage
     }
 
     private INodeStyle createListNodeStyle(VariableManager variableManager, FlatContainerStyleDescription flatContainerStyleDescription) {
-        ColorDescriptionConverter backgroundColorProvider = new ColorDescriptionConverter(this.interpreter, variableManager.getVariables());
-        ColorDescriptionConverter borderColorProvider = new ColorDescriptionConverter(this.interpreter, variableManager.getVariables());
+        ColorDescriptionConverter colorDescriptionConverter = new ColorDescriptionConverter(this.interpreter, variableManager.getVariables());
 
-        String color = backgroundColorProvider.convert(flatContainerStyleDescription.getBackgroundColor());
-        String borderColor = borderColorProvider.convert(flatContainerStyleDescription.getBorderColor());
+        String color = colorDescriptionConverter.convert(flatContainerStyleDescription.getBackgroundColor());
+        String borderColor = colorDescriptionConverter.convert(flatContainerStyleDescription.getBorderColor());
 
         LineStyle borderStyle = new LineStyleConverter().getStyle(flatContainerStyleDescription.getBorderLineStyle());
 

--- a/backend/sirius-web-compatibility/src/main/java/org/eclipse/sirius/web/compat/diagrams/LabelStyleDescriptionConverter.java
+++ b/backend/sirius-web-compatibility/src/main/java/org/eclipse/sirius/web/compat/diagrams/LabelStyleDescriptionConverter.java
@@ -16,8 +16,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
 
-import org.eclipse.emf.common.util.Enumerator;
-import org.eclipse.emf.ecore.EObject;
 import org.eclipse.sirius.viewpoint.FontFormat;
 import org.eclipse.sirius.web.core.api.IObjectService;
 import org.eclipse.sirius.web.diagrams.description.LabelStyleDescription;
@@ -39,19 +37,6 @@ public class LabelStyleDescriptionConverter {
         this.interpreter = Objects.requireNonNull(interpreter);
     }
 
-    private String getImagePath(Object object) {
-        if (object instanceof EObject) {
-            EObject eObject = (EObject) object;
-            if (eObject.eClass().getName().equals("Attribute")) { //$NON-NLS-1$
-                Enumerator value = (Enumerator) eObject.eGet(eObject.eClass().getEStructuralFeature("type")); //$NON-NLS-1$
-                if (value.getName().equals("STRING")) { //$NON-NLS-1$
-                    return "/icons/full/obj16/Attribute.gif"; //$NON-NLS-1$
-                }
-            }
-        }
-        return this.objectService.getImagePath(object);
-    }
-
     public LabelStyleDescription convert(org.eclipse.sirius.viewpoint.description.style.BasicLabelStyleDescription labelStyleDescription) {
         List<FontFormat> fontFormats = labelStyleDescription.getLabelFormat();
 
@@ -67,7 +52,7 @@ public class LabelStyleDescriptionConverter {
                     }
                 } else {
                     iconURL = variableManager.get(VariableManager.SELF, Object.class)
-                            .map(this::getImagePath)
+                            .map(this.objectService::getImagePath)
                             .orElse(""); //$NON-NLS-1$
                 }
                 // @formatter:on

--- a/backend/sirius-web-compatibility/src/main/java/org/eclipse/sirius/web/compat/diagrams/LabelStyleDescriptionConverter.java
+++ b/backend/sirius-web-compatibility/src/main/java/org/eclipse/sirius/web/compat/diagrams/LabelStyleDescriptionConverter.java
@@ -16,6 +16,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
 
+import org.eclipse.emf.common.util.Enumerator;
+import org.eclipse.emf.ecore.EObject;
 import org.eclipse.sirius.viewpoint.FontFormat;
 import org.eclipse.sirius.web.core.api.IObjectService;
 import org.eclipse.sirius.web.diagrams.description.LabelStyleDescription;
@@ -37,6 +39,19 @@ public class LabelStyleDescriptionConverter {
         this.interpreter = Objects.requireNonNull(interpreter);
     }
 
+    private String getImagePath(Object object) {
+        if (object instanceof EObject) {
+            EObject eObject = (EObject) object;
+            if (eObject.eClass().getName().equals("Attribute")) { //$NON-NLS-1$
+                Enumerator value = (Enumerator) eObject.eGet(eObject.eClass().getEStructuralFeature("type")); //$NON-NLS-1$
+                if (value.getName().equals("STRING")) { //$NON-NLS-1$
+                    return "/icons/full/obj16/Attribute.gif"; //$NON-NLS-1$
+                }
+            }
+        }
+        return this.objectService.getImagePath(object);
+    }
+
     public LabelStyleDescription convert(org.eclipse.sirius.viewpoint.description.style.BasicLabelStyleDescription labelStyleDescription) {
         List<FontFormat> fontFormats = labelStyleDescription.getLabelFormat();
 
@@ -52,7 +67,7 @@ public class LabelStyleDescriptionConverter {
                     }
                 } else {
                     iconURL = variableManager.get(VariableManager.SELF, Object.class)
-                            .map(this.objectService::getImagePath)
+                            .map(this::getImagePath)
                             .orElse(""); //$NON-NLS-1$
                 }
                 // @formatter:on

--- a/backend/sirius-web-diagrams-layout/pom.xml
+++ b/backend/sirius-web-diagrams-layout/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- Copyright (c) 2019, 2020 Obeo.
+ Copyright (c) 2019, 2021 Obeo.
  This program and the accompanying materials
  are made available under the terms of the Eclipse Public License v2.0
  which accompanies this distribution, and is available at
@@ -28,7 +28,7 @@
 
 	<properties>
 		<java.version>11</java.version>
-		<elk.version>0.5.0</elk.version>
+		<elk.version>0.7.1</elk.version>
 	</properties>
 
 	<distributionManagement>

--- a/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/LayoutConfiguratorRegistry.java
+++ b/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/LayoutConfiguratorRegistry.java
@@ -77,6 +77,7 @@ public class LayoutConfiguratorRegistry {
 
         configurator.configureByType(NodeType.NODE_LIST)
                     .setProperty(CoreOptions.ALGORITHM, FixedLayouterOptions.ALGORITHM_ID)
+                    .setProperty(CoreOptions.NODE_LABELS_PLACEMENT, NodeLabelPlacement.insideTopCenter())
                     .setProperty(CoreOptions.NODE_SIZE_FIXED_GRAPH_SIZE, true);
 
         configurator.configureByType(NodeType.NODE_LIST_ITEM).setProperty(CoreOptions.NO_LAYOUT, true);

--- a/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/LayoutConfiguratorRegistry.java
+++ b/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/LayoutConfiguratorRegistry.java
@@ -12,24 +12,20 @@
  *******************************************************************************/
 package org.eclipse.sirius.web.diagrams.layout;
 
-import java.util.EnumSet;
 import java.util.List;
 import java.util.Objects;
 
 import org.eclipse.elk.alg.layered.options.LayeredOptions;
 import org.eclipse.elk.alg.layered.options.LayeringStrategy;
-import org.eclipse.elk.alg.layered.options.OrderingStrategy;
 import org.eclipse.elk.core.LayoutConfigurator;
-import org.eclipse.elk.core.math.ElkPadding;
 import org.eclipse.elk.core.math.KVector;
-import org.eclipse.elk.core.options.Alignment;
 import org.eclipse.elk.core.options.CoreOptions;
+import org.eclipse.elk.core.options.FixedLayouterOptions;
 import org.eclipse.elk.core.options.HierarchyHandling;
 import org.eclipse.elk.core.options.NodeLabelPlacement;
 import org.eclipse.elk.core.options.SizeConstraint;
 import org.eclipse.sirius.web.diagrams.Diagram;
 import org.eclipse.sirius.web.diagrams.NodeType;
-import org.eclipse.sirius.web.diagrams.Size;
 import org.eclipse.sirius.web.diagrams.description.DiagramDescription;
 import org.springframework.stereotype.Service;
 
@@ -58,10 +54,7 @@ public class LayoutConfiguratorRegistry {
 
     private final List<IDiagramLayoutConfiguratorProvider> customLayoutProviders;
 
-    private TextBoundsService textBoundsService;
-
-    public LayoutConfiguratorRegistry(List<IDiagramLayoutConfiguratorProvider> customLayoutProviders, TextBoundsService textBoundsService) {
-        this.textBoundsService = textBoundsService;
+    public LayoutConfiguratorRegistry(List<IDiagramLayoutConfiguratorProvider> customLayoutProviders) {
         this.customLayoutProviders = List.copyOf(Objects.requireNonNull(customLayoutProviders));
     }
 
@@ -83,21 +76,10 @@ public class LayoutConfiguratorRegistry {
                 .setProperty(CoreOptions.NODE_LABELS_PLACEMENT, NodeLabelPlacement.insideTopCenter());
 
         configurator.configureByType(NodeType.NODE_LIST)
-                .setProperty(CoreOptions.NODE_SIZE_CONSTRAINTS, SizeConstraint.free())
-                .setProperty(CoreOptions.NODE_SIZE_MINIMUM, new KVector(LayoutOptionValues.MIN_WIDTH_CONSTRAINT, LayoutOptionValues.MIN_HEIGHT_CONSTRAINT))
-                .setProperty(CoreOptions.PADDING, new ElkPadding(LayoutOptionValues.NODE_LIST_ELK_PADDING_TOP, LayoutOptionValues.DEFAULT_ELK_PADDING, LayoutOptionValues.DEFAULT_ELK_PADDING, LayoutOptionValues.NODE_LIST_ELK_PADDING_LEFT))
-                .setProperty(CoreOptions.NODE_LABELS_PADDING, new ElkPadding(LayoutOptionValues.NODE_LIST_ELK_NODE_LABELS_PADDING_TOP, LayoutOptionValues.NODE_LIST_ELK_NODE_LABELS_PADDING_RIGHT, LayoutOptionValues.NODE_LIST_ELK_NODE_LABELS_PADDING_BOTTOM, LayoutOptionValues.NODE_LIST_ELK_NODE_LABELS_PADDING_LEFT))
-                .setProperty(CoreOptions.SPACING_NODE_NODE, LayoutOptionValues.NODE_LIST_ELK_NODE_NODE_GAP)
-                .setProperty(LayeredOptions.CONSIDER_MODEL_ORDER, OrderingStrategy.NODES_AND_EDGES)
-                .setProperty(CoreOptions.NODE_LABELS_PLACEMENT, NodeLabelPlacement.insideTopCenter());
+                    .setProperty(CoreOptions.ALGORITHM, FixedLayouterOptions.ALGORITHM_ID)
+                    .setProperty(CoreOptions.NODE_SIZE_FIXED_GRAPH_SIZE, true);
 
-
-        Size minimumLabelSize = this.textBoundsService.getTextMinimumBounds().getSize();
-        configurator.configureByType(NodeType.NODE_LIST_ITEM)
-                .setProperty(CoreOptions.NODE_SIZE_CONSTRAINTS, EnumSet.of(SizeConstraint.NODE_LABELS, SizeConstraint.MINIMUM_SIZE))
-                .setProperty(CoreOptions.NODE_SIZE_MINIMUM, new KVector(minimumLabelSize.getWidth(), minimumLabelSize.getHeight()))
-                .setProperty(CoreOptions.NODE_LABELS_PLACEMENT, NodeLabelPlacement.insideCenter())
-                .setProperty(CoreOptions.ALIGNMENT, Alignment.LEFT);
+        configurator.configureByType(NodeType.NODE_LIST_ITEM).setProperty(CoreOptions.NO_LAYOUT, true);
 
         configurator.configureByType(NodeType.NODE_IMAGE)
                 .setProperty(CoreOptions.NODE_SIZE_CONSTRAINTS, SizeConstraint.free())

--- a/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/LayoutConfiguratorRegistry.java
+++ b/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/LayoutConfiguratorRegistry.java
@@ -41,19 +41,10 @@ import org.springframework.stereotype.Service;
  *
  * @author sbegaudeau
  * @author hmarchadour
+ * @author gcoutable
  */
 @Service
 public class LayoutConfiguratorRegistry {
-
-    /**
-     * The minimum height constraint value.
-     */
-    private static final int MIN_HEIGHT_CONSTRAINT = 25;
-
-    /**
-     * The minimum width constraint value.
-     */
-    private static final int MIN_WIDTH_CONSTRAINT = 50;
 
     /**
      * The space between two nodes.
@@ -88,15 +79,15 @@ public class LayoutConfiguratorRegistry {
 
         configurator.configureByType(NodeType.NODE_RECTANGLE)
                 .setProperty(CoreOptions.NODE_SIZE_CONSTRAINTS, SizeConstraint.free())
-                .setProperty(CoreOptions.NODE_SIZE_MINIMUM, new KVector(MIN_WIDTH_CONSTRAINT, MIN_HEIGHT_CONSTRAINT))
+                .setProperty(CoreOptions.NODE_SIZE_MINIMUM, new KVector(LayoutOptionValues.MIN_WIDTH_CONSTRAINT, LayoutOptionValues.MIN_HEIGHT_CONSTRAINT))
                 .setProperty(CoreOptions.NODE_LABELS_PLACEMENT, NodeLabelPlacement.insideTopCenter());
 
         configurator.configureByType(NodeType.NODE_LIST)
                 .setProperty(CoreOptions.NODE_SIZE_CONSTRAINTS, SizeConstraint.free())
-                .setProperty(CoreOptions.NODE_SIZE_MINIMUM, new KVector(MIN_WIDTH_CONSTRAINT, MIN_HEIGHT_CONSTRAINT))
-                .setProperty(CoreOptions.PADDING, new ElkPadding(6d, 12d, 12d, 0))
-                .setProperty(CoreOptions.NODE_LABELS_PADDING, new ElkPadding())
-                .setProperty(CoreOptions.SPACING_NODE_NODE, 6d)
+                .setProperty(CoreOptions.NODE_SIZE_MINIMUM, new KVector(LayoutOptionValues.MIN_WIDTH_CONSTRAINT, LayoutOptionValues.MIN_HEIGHT_CONSTRAINT))
+                .setProperty(CoreOptions.PADDING, new ElkPadding(LayoutOptionValues.NODE_LIST_ELK_PADDING_TOP, LayoutOptionValues.DEFAULT_ELK_PADDING, LayoutOptionValues.DEFAULT_ELK_PADDING, LayoutOptionValues.NODE_LIST_ELK_PADDING_LEFT))
+                .setProperty(CoreOptions.NODE_LABELS_PADDING, new ElkPadding(LayoutOptionValues.NODE_LIST_ELK_NODE_LABELS_PADDING_TOP, LayoutOptionValues.NODE_LIST_ELK_NODE_LABELS_PADDING_RIGHT, LayoutOptionValues.NODE_LIST_ELK_NODE_LABELS_PADDING_BOTTOM, LayoutOptionValues.NODE_LIST_ELK_NODE_LABELS_PADDING_LEFT))
+                .setProperty(CoreOptions.SPACING_NODE_NODE, LayoutOptionValues.NODE_LIST_ELK_NODE_NODE_GAP)
                 .setProperty(LayeredOptions.CONSIDER_MODEL_ORDER, OrderingStrategy.NODES_AND_EDGES)
                 .setProperty(CoreOptions.NODE_LABELS_PLACEMENT, NodeLabelPlacement.insideTopCenter());
 

--- a/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/LayoutConfiguratorRegistry.java
+++ b/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/LayoutConfiguratorRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Obeo.
+ * Copyright (c) 2019, 2021 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -12,19 +12,24 @@
  *******************************************************************************/
 package org.eclipse.sirius.web.diagrams.layout;
 
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Objects;
 
 import org.eclipse.elk.alg.layered.options.LayeredOptions;
 import org.eclipse.elk.alg.layered.options.LayeringStrategy;
+import org.eclipse.elk.alg.layered.options.OrderingStrategy;
 import org.eclipse.elk.core.LayoutConfigurator;
+import org.eclipse.elk.core.math.ElkPadding;
 import org.eclipse.elk.core.math.KVector;
+import org.eclipse.elk.core.options.Alignment;
 import org.eclipse.elk.core.options.CoreOptions;
 import org.eclipse.elk.core.options.HierarchyHandling;
 import org.eclipse.elk.core.options.NodeLabelPlacement;
 import org.eclipse.elk.core.options.SizeConstraint;
 import org.eclipse.sirius.web.diagrams.Diagram;
 import org.eclipse.sirius.web.diagrams.NodeType;
+import org.eclipse.sirius.web.diagrams.Size;
 import org.eclipse.sirius.web.diagrams.description.DiagramDescription;
 import org.springframework.stereotype.Service;
 
@@ -62,7 +67,10 @@ public class LayoutConfiguratorRegistry {
 
     private final List<IDiagramLayoutConfiguratorProvider> customLayoutProviders;
 
-    public LayoutConfiguratorRegistry(List<IDiagramLayoutConfiguratorProvider> customLayoutProviders) {
+    private TextBoundsService textBoundsService;
+
+    public LayoutConfiguratorRegistry(List<IDiagramLayoutConfiguratorProvider> customLayoutProviders, TextBoundsService textBoundsService) {
+        this.textBoundsService = textBoundsService;
         this.customLayoutProviders = List.copyOf(Objects.requireNonNull(customLayoutProviders));
     }
 
@@ -82,6 +90,23 @@ public class LayoutConfiguratorRegistry {
                 .setProperty(CoreOptions.NODE_SIZE_CONSTRAINTS, SizeConstraint.free())
                 .setProperty(CoreOptions.NODE_SIZE_MINIMUM, new KVector(MIN_WIDTH_CONSTRAINT, MIN_HEIGHT_CONSTRAINT))
                 .setProperty(CoreOptions.NODE_LABELS_PLACEMENT, NodeLabelPlacement.insideTopCenter());
+
+        configurator.configureByType(NodeType.NODE_LIST)
+                .setProperty(CoreOptions.NODE_SIZE_CONSTRAINTS, SizeConstraint.free())
+                .setProperty(CoreOptions.NODE_SIZE_MINIMUM, new KVector(MIN_WIDTH_CONSTRAINT, MIN_HEIGHT_CONSTRAINT))
+                .setProperty(CoreOptions.PADDING, new ElkPadding(6d, 12d, 12d, 0))
+                .setProperty(CoreOptions.NODE_LABELS_PADDING, new ElkPadding())
+                .setProperty(CoreOptions.SPACING_NODE_NODE, 6d)
+                .setProperty(LayeredOptions.CONSIDER_MODEL_ORDER, OrderingStrategy.NODES_AND_EDGES)
+                .setProperty(CoreOptions.NODE_LABELS_PLACEMENT, NodeLabelPlacement.insideTopCenter());
+
+
+        Size minimumLabelSize = this.textBoundsService.getTextMinimumBounds().getSize();
+        configurator.configureByType(NodeType.NODE_LIST_ITEM)
+                .setProperty(CoreOptions.NODE_SIZE_CONSTRAINTS, EnumSet.of(SizeConstraint.NODE_LABELS, SizeConstraint.MINIMUM_SIZE))
+                .setProperty(CoreOptions.NODE_SIZE_MINIMUM, new KVector(minimumLabelSize.getWidth(), minimumLabelSize.getHeight()))
+                .setProperty(CoreOptions.NODE_LABELS_PLACEMENT, NodeLabelPlacement.insideCenter())
+                .setProperty(CoreOptions.ALIGNMENT, Alignment.LEFT);
 
         configurator.configureByType(NodeType.NODE_IMAGE)
                 .setProperty(CoreOptions.NODE_SIZE_CONSTRAINTS, SizeConstraint.free())

--- a/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/LayoutOptionValues.java
+++ b/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/LayoutOptionValues.java
@@ -34,7 +34,7 @@ public final class LayoutOptionValues {
     /**
      * The minimum height constraint value defined for a node in our elk configuration.
      */
-    public static final int MIN_HEIGHT_CONSTRAINT = 25;
+    public static final int MIN_HEIGHT_CONSTRAINT = 35;
 
     /**
      * The minimum width constraint value defined for a node in our elk configuration.
@@ -45,7 +45,7 @@ public final class LayoutOptionValues {
      * The value defined for NodeList in the elk configuration to set the padding top between a NodeList and its
      * NodeListItems.
      */
-    public static final double NODE_LIST_ELK_PADDING_TOP = 6d;
+    public static final double NODE_LIST_ELK_PADDING_TOP = 13d;
 
     /**
      * The value defined for NodeList in the elk configuration to set the padding left between a NodeList and its

--- a/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/LayoutOptionValues.java
+++ b/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/LayoutOptionValues.java
@@ -42,18 +42,6 @@ public final class LayoutOptionValues {
     public static final int MIN_WIDTH_CONSTRAINT = 50;
 
     /**
-     * The value defined for NodeList in the elk configuration to set the padding top between a NodeListItem to its
-     * label.
-     */
-    public static final double NODE_LIST_ELK_NODE_LABELS_PADDING_TOP = 0d;
-
-    /**
-     * The value defined for NodeList in the elk configuration to set the padding bottom between a NodeListItem to its
-     * label.
-     */
-    public static final double NODE_LIST_ELK_NODE_LABELS_PADDING_BOTTOM = 0d;
-
-    /**
      * The value defined for NodeList in the elk configuration to set the padding top between a NodeList and its
      * NodeListItems.
      */
@@ -64,6 +52,12 @@ public final class LayoutOptionValues {
      * NodeListItems.
      */
     public static final double NODE_LIST_ELK_PADDING_LEFT = 0d;
+
+    /**
+     * The value defined for NodeList in the elk configuration to set the padding right between a NodeList and its
+     * NodeListItems.
+     */
+    public static final double NODE_LIST_ELK_PADDING_RIGHT = 0d;
 
     /**
      * The value defined for NodeList in the elk configuration to set the gap between two containing NodeListItems.
@@ -80,6 +74,18 @@ public final class LayoutOptionValues {
      * The value defined for NodeList in the elk configuration to set the padding right of the containing NodeListItem
      * labels.
      */
-    public static final double NODE_LIST_ELK_NODE_LABELS_PADDING_RIGHT = 2d;
+    public static final double NODE_LIST_ELK_NODE_LABELS_PADDING_RIGHT = 12d;
+
+    /**
+     * The value defined for NodeList in the elk configuration to set the padding top between a NodeListItem to its
+     * label.
+     */
+    public static final double NODE_LIST_ELK_NODE_LABELS_PADDING_TOP = 0d;
+
+    /**
+     * The value defined for NodeList in the elk configuration to set the padding bottom between a NodeListItem to its
+     * label.
+     */
+    public static final double NODE_LIST_ELK_NODE_LABELS_PADDING_BOTTOM = 0d;
 
 }

--- a/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/LayoutOptionValues.java
+++ b/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/LayoutOptionValues.java
@@ -1,0 +1,85 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.diagrams.layout;
+
+/**
+ * The common values needed by both elk layout and incremental layout.
+ *
+ * @author gcoutable
+ */
+public final class LayoutOptionValues {
+
+    /**
+     * The default elk padding between a node and its content. This padding is set on the four direction: top, right,
+     * bottom and left.
+     */
+    public static final double DEFAULT_ELK_PADDING = 12d;
+
+    /**
+     * The default elk padding between a node and its label. This padding is set on the four direction: top, right,
+     * bottom and left.
+     */
+    public static final double DEFAULT_ELK_NODE_LABELS_PADDING = 5d;
+
+    /**
+     * The minimum height constraint value defined for a node in our elk configuration.
+     */
+    public static final int MIN_HEIGHT_CONSTRAINT = 25;
+
+    /**
+     * The minimum width constraint value defined for a node in our elk configuration.
+     */
+    public static final int MIN_WIDTH_CONSTRAINT = 50;
+
+    /**
+     * The value defined for NodeList in the elk configuration to set the padding top between a NodeListItem to its
+     * label.
+     */
+    public static final double NODE_LIST_ELK_NODE_LABELS_PADDING_TOP = 0d;
+
+    /**
+     * The value defined for NodeList in the elk configuration to set the padding bottom between a NodeListItem to its
+     * label.
+     */
+    public static final double NODE_LIST_ELK_NODE_LABELS_PADDING_BOTTOM = 0d;
+
+    /**
+     * The value defined for NodeList in the elk configuration to set the padding top between a NodeList and its
+     * NodeListItems.
+     */
+    public static final double NODE_LIST_ELK_PADDING_TOP = 6d;
+
+    /**
+     * The value defined for NodeList in the elk configuration to set the padding left between a NodeList and its
+     * NodeListItems.
+     */
+    public static final double NODE_LIST_ELK_PADDING_LEFT = 0d;
+
+    /**
+     * The value defined for NodeList in the elk configuration to set the gap between two containing NodeListItems.
+     */
+    public static final double NODE_LIST_ELK_NODE_NODE_GAP = 6d;
+
+    /**
+     * The value defined for NodeList in the elk configuration to set the padding left of the containing NodeListItem
+     * labels.
+     */
+    public static final double NODE_LIST_ELK_NODE_LABELS_PADDING_LEFT = 2d;
+
+    /**
+     * The value defined for NodeList in the elk configuration to set the padding right of the containing NodeListItem
+     * labels.
+     */
+    public static final double NODE_LIST_ELK_NODE_LABELS_PADDING_RIGHT = 2d;
+
+}

--- a/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/TextBoundsService.java
+++ b/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/TextBoundsService.java
@@ -98,7 +98,7 @@ public class TextBoundsService {
     public TextBounds getTextMinimumBounds() {
         // @formatter:off
         LabelStyle labelStyle = LabelStyle.newLabelStyle()
-                .fontSize(16)
+                .fontSize(12) // Should get the value from Sirius NodeMapping
                 .color("#000000") //$NON-NLS-1$
                 .iconURL("") //$NON-NLS-1$
                 .build();

--- a/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/TextBoundsService.java
+++ b/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/TextBoundsService.java
@@ -38,11 +38,6 @@ import org.springframework.stereotype.Service;
 @Service
 public class TextBoundsService {
 
-    /**
-     * The text label minimum characters needed to consider an empty node easily clickable.
-     */
-    private static final String MINIMUM_TEXT_LABEL_CHARACTERS = "    "; //$NON-NLS-1$
-
     private final Logger logger = LoggerFactory.getLogger(TextBoundsService.class);
 
     private final TextBoundsProvider textBoundsProvider;
@@ -93,17 +88,6 @@ public class TextBoundsService {
 
     public TextBounds getBounds(Label label) {
         return this.textBoundsProvider.computeBounds(label.getStyle(), label.getText());
-    }
-
-    public TextBounds getTextMinimumBounds() {
-        // @formatter:off
-        LabelStyle labelStyle = LabelStyle.newLabelStyle()
-                .fontSize(12) // Should get the value from Sirius NodeMapping
-                .color("#000000") //$NON-NLS-1$
-                .iconURL("") //$NON-NLS-1$
-                .build();
-        // @formatter:on
-        return this.textBoundsProvider.computeBounds(labelStyle, MINIMUM_TEXT_LABEL_CHARACTERS);
     }
 
 }

--- a/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/TextBoundsService.java
+++ b/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/TextBoundsService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Obeo.
+ * Copyright (c) 2019, 2021 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -37,6 +37,11 @@ import org.springframework.stereotype.Service;
  */
 @Service
 public class TextBoundsService {
+
+    /**
+     * The text label minimum characters needed to consider an empty node easily clickable.
+     */
+    private static final String MINIMUM_TEXT_LABEL_CHARACTERS = "    "; //$NON-NLS-1$
 
     private final Logger logger = LoggerFactory.getLogger(TextBoundsService.class);
 
@@ -88,6 +93,17 @@ public class TextBoundsService {
 
     public TextBounds getBounds(Label label) {
         return this.textBoundsProvider.computeBounds(label.getStyle(), label.getText());
+    }
+
+    public TextBounds getTextMinimumBounds() {
+        // @formatter:off
+        LabelStyle labelStyle = LabelStyle.newLabelStyle()
+                .fontSize(16)
+                .color("#000000") //$NON-NLS-1$
+                .iconURL("") //$NON-NLS-1$
+                .build();
+        // @formatter:on
+        return this.textBoundsProvider.computeBounds(labelStyle, MINIMUM_TEXT_LABEL_CHARACTERS);
     }
 
 }

--- a/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/incremental/IncrementalLayoutDiagramConverter.java
+++ b/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/incremental/IncrementalLayoutDiagramConverter.java
@@ -130,6 +130,7 @@ public class IncrementalLayoutDiagramConverter {
         id2LayoutData.put(id, layoutData);
 
         layoutData.setPosition(label.getPosition());
+        layoutData.setLabelType(label.getType());
 
         TextBounds textBounds = new TextBoundsProvider().computeBounds(label.getStyle(), label.getText());
         layoutData.setTextBounds(textBounds);

--- a/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/incremental/IncrementalLayoutEngine.java
+++ b/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/incremental/IncrementalLayoutEngine.java
@@ -18,6 +18,7 @@ import java.util.Optional;
 import org.eclipse.sirius.web.diagrams.IDiagramElementEvent;
 import org.eclipse.sirius.web.diagrams.Position;
 import org.eclipse.sirius.web.diagrams.Size;
+import org.eclipse.sirius.web.diagrams.layout.TextBoundsService;
 import org.eclipse.sirius.web.diagrams.layout.incremental.data.DiagramLayoutData;
 import org.eclipse.sirius.web.diagrams.layout.incremental.data.EdgeLayoutData;
 import org.eclipse.sirius.web.diagrams.layout.incremental.data.IContainerLayoutData;
@@ -58,8 +59,11 @@ public class IncrementalLayoutEngine {
 
     private final NodeSizeProvider nodeSizeProvider;
 
-    public IncrementalLayoutEngine(NodeSizeProvider nodeSizeProvider) {
+    private TextBoundsService textBoundsService;
+
+    public IncrementalLayoutEngine(NodeSizeProvider nodeSizeProvider, TextBoundsService textBoundsService) {
         this.nodeSizeProvider = Objects.requireNonNull(nodeSizeProvider);
+        this.textBoundsService = textBoundsService;
     }
 
     public void layout(Optional<IDiagramElementEvent> optionalDiagramElementEvent, DiagramLayoutData diagram) {
@@ -74,7 +78,7 @@ public class IncrementalLayoutEngine {
         new OverlapsUpdater().update(diagram);
 
         // resize according to the content
-        new ContainmentUpdater().update(diagram);
+        new ContainmentUpdater(this.textBoundsService).update(diagram);
 
         // finally we recompute the edges that needs to
         for (EdgeLayoutData edge : diagram.getEdges()) {
@@ -111,7 +115,7 @@ public class IncrementalLayoutEngine {
         new OverlapsUpdater().update(node);
 
         // resize / change position according to the content
-        new ContainmentUpdater().update(node);
+        new ContainmentUpdater(this.textBoundsService).update(node);
 
         // recompute the label
         if (node.getLabel() != null) {

--- a/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/incremental/IncrementalLayoutEngine.java
+++ b/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/incremental/IncrementalLayoutEngine.java
@@ -18,7 +18,6 @@ import java.util.Optional;
 import org.eclipse.sirius.web.diagrams.IDiagramElementEvent;
 import org.eclipse.sirius.web.diagrams.Position;
 import org.eclipse.sirius.web.diagrams.Size;
-import org.eclipse.sirius.web.diagrams.layout.TextBoundsService;
 import org.eclipse.sirius.web.diagrams.layout.incremental.data.DiagramLayoutData;
 import org.eclipse.sirius.web.diagrams.layout.incremental.data.EdgeLayoutData;
 import org.eclipse.sirius.web.diagrams.layout.incremental.data.IContainerLayoutData;
@@ -59,11 +58,8 @@ public class IncrementalLayoutEngine {
 
     private final NodeSizeProvider nodeSizeProvider;
 
-    private TextBoundsService textBoundsService;
-
-    public IncrementalLayoutEngine(NodeSizeProvider nodeSizeProvider, TextBoundsService textBoundsService) {
+    public IncrementalLayoutEngine(NodeSizeProvider nodeSizeProvider) {
         this.nodeSizeProvider = Objects.requireNonNull(nodeSizeProvider);
-        this.textBoundsService = textBoundsService;
     }
 
     public void layout(Optional<IDiagramElementEvent> optionalDiagramElementEvent, DiagramLayoutData diagram) {
@@ -78,7 +74,7 @@ public class IncrementalLayoutEngine {
         new OverlapsUpdater().update(diagram);
 
         // resize according to the content
-        new ContainmentUpdater(this.textBoundsService).update(diagram);
+        new ContainmentUpdater().update(diagram);
 
         // finally we recompute the edges that needs to
         for (EdgeLayoutData edge : diagram.getEdges()) {
@@ -115,7 +111,7 @@ public class IncrementalLayoutEngine {
         new OverlapsUpdater().update(node);
 
         // resize / change position according to the content
-        new ContainmentUpdater(this.textBoundsService).update(node);
+        new ContainmentUpdater().update(node);
 
         // recompute the label
         if (node.getLabel() != null) {

--- a/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/incremental/data/LabelLayoutData.java
+++ b/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/incremental/data/LabelLayoutData.java
@@ -28,6 +28,8 @@ public class LabelLayoutData implements ILayoutData {
 
     private Position position;
 
+    private String labelType;
+
     private UUID id;
 
     @Override
@@ -45,6 +47,14 @@ public class LabelLayoutData implements ILayoutData {
 
     public void setPosition(Position position) {
         this.position = position;
+    }
+
+    public String getLabelType() {
+        return this.labelType;
+    }
+
+    public void setLabelType(String labelType) {
+        this.labelType = labelType;
     }
 
     public TextBounds getTextBounds() {

--- a/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/incremental/provider/NodeLabelPositionProvider.java
+++ b/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/incremental/provider/NodeLabelPositionProvider.java
@@ -14,6 +14,7 @@ package org.eclipse.sirius.web.diagrams.layout.incremental.provider;
 
 import org.eclipse.sirius.web.diagrams.NodeType;
 import org.eclipse.sirius.web.diagrams.Position;
+import org.eclipse.sirius.web.diagrams.layout.LayoutOptionValues;
 import org.eclipse.sirius.web.diagrams.layout.incremental.data.LabelLayoutData;
 import org.eclipse.sirius.web.diagrams.layout.incremental.data.NodeLayoutData;
 
@@ -28,6 +29,10 @@ public class NodeLabelPositionProvider {
     private static final int LABEL_Y_SPACING = 5;
 
     public Position getPosition(NodeLayoutData node, LabelLayoutData label) {
+        if (NodeType.NODE_LIST_ITEM.equals(node.getNodeType())) {
+            return Position.at(LayoutOptionValues.NODE_LIST_ELK_NODE_LABELS_PADDING_LEFT, 0);
+        }
+
         double x = (node.getSize().getWidth() - label.getTextBounds().getSize().getWidth()) / 2;
         double y = 0;
         if (NodeType.NODE_IMAGE.equals(node.getNodeType())) {

--- a/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/incremental/provider/NodeLabelPositionProvider.java
+++ b/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/incremental/provider/NodeLabelPositionProvider.java
@@ -25,21 +25,27 @@ import org.eclipse.sirius.web.diagrams.layout.incremental.data.NodeLayoutData;
  */
 public class NodeLabelPositionProvider {
 
-    /** The Spacing between a label and the element to describe. */
-    private static final int LABEL_Y_SPACING = 5;
-
     public Position getPosition(NodeLayoutData node, LabelLayoutData label) {
-        if (NodeType.NODE_LIST_ITEM.equals(node.getNodeType())) {
-            return Position.at(LayoutOptionValues.NODE_LIST_ELK_NODE_LABELS_PADDING_LEFT, 0);
-        }
-
         double x = (node.getSize().getWidth() - label.getTextBounds().getSize().getWidth()) / 2;
         double y = 0;
-        if (NodeType.NODE_IMAGE.equals(node.getNodeType())) {
-            y = -(label.getTextBounds().getSize().getHeight() + LABEL_Y_SPACING);
-        } else if (NodeType.NODE_RECTANGLE.equals(node.getNodeType())) {
-            y = LABEL_Y_SPACING;
+
+        switch (node.getNodeType()) {
+        case NodeType.NODE_LIST_ITEM:
+            x = LayoutOptionValues.NODE_LIST_ELK_NODE_LABELS_PADDING_LEFT;
+            break;
+        case NodeType.NODE_LIST:
+        case NodeType.NODE_RECTANGLE:
+            y = LayoutOptionValues.DEFAULT_ELK_NODE_LABELS_PADDING;
+            break;
+        case NodeType.NODE_IMAGE:
+            y = -(label.getTextBounds().getSize().getHeight() + LayoutOptionValues.DEFAULT_ELK_NODE_LABELS_PADDING);
+            break;
+        default:
+            x = (node.getSize().getWidth() - label.getTextBounds().getSize().getWidth()) / 2;
+            y = 0;
+            break;
         }
+
         return Position.at(x, y);
     }
 

--- a/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/incremental/provider/NodePositionProvider.java
+++ b/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/incremental/provider/NodePositionProvider.java
@@ -55,7 +55,7 @@ public class NodePositionProvider {
         Optional<Position> optionalPosition = this.getSpecificNodePositionFromEvent(optionalDiagramElementEvent, node);
         if (optionalPosition.isPresent() && !NodeType.NODE_LIST_ITEM.equals(node.getNodeType())) {
             position = optionalPosition.get();
-        } else if (!this.isAlreadyPositioned(node) || !NodeType.NODE_LIST_ITEM.equals(node.getNodeType())) {
+        } else if (!this.isAlreadyPositioned(node) || NodeType.NODE_LIST_ITEM.equals(node.getNodeType())) {
             Optional<Position> optionalStartingPosition = this.getOptionalStartingPositionFromEvent(optionalDiagramElementEvent);
             if (optionalStartingPosition.isPresent() && this.last == null && !NodeType.NODE_LIST_ITEM.equals(node.getNodeType())) {
                 // The node has been created by a tool and has a fixed position

--- a/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/incremental/provider/NodeSizeProvider.java
+++ b/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/incremental/provider/NodeSizeProvider.java
@@ -98,9 +98,9 @@ public class NodeSizeProvider {
             width = imageSize.getWidth() + ELK_SIZE_DIFF;
             height = imageSize.getHeight() + ELK_SIZE_DIFF;
         } else if (NodeType.NODE_LIST_ITEM.equals(node.getNodeType())) {
-            Size nodeItemSize = node.getLabel().getTextBounds().getSize();
-            width = nodeItemSize.getWidth() + LayoutOptionValues.NODE_LIST_ELK_NODE_LABELS_PADDING_RIGHT + LayoutOptionValues.NODE_LIST_ELK_NODE_LABELS_PADDING_LEFT;
-            height = nodeItemSize.getHeight();
+            Size nodeItemLabelSize = node.getLabel().getTextBounds().getSize();
+            width = nodeItemLabelSize.getWidth() + LayoutOptionValues.NODE_LIST_ELK_NODE_LABELS_PADDING_RIGHT + LayoutOptionValues.NODE_LIST_ELK_NODE_LABELS_PADDING_LEFT;
+            height = nodeItemLabelSize.getHeight() + LayoutOptionValues.NODE_LIST_ELK_NODE_LABELS_PADDING_TOP + LayoutOptionValues.NODE_LIST_ELK_NODE_LABELS_PADDING_BOTTOM;
         }
         return Size.of(width, height);
     }

--- a/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/incremental/provider/NodeSizeProvider.java
+++ b/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/incremental/provider/NodeSizeProvider.java
@@ -18,8 +18,10 @@ import java.util.Optional;
 import org.eclipse.sirius.web.diagrams.IDiagramElementEvent;
 import org.eclipse.sirius.web.diagrams.INodeStyle;
 import org.eclipse.sirius.web.diagrams.ImageNodeStyle;
+import org.eclipse.sirius.web.diagrams.NodeType;
 import org.eclipse.sirius.web.diagrams.ResizeEvent;
 import org.eclipse.sirius.web.diagrams.Size;
+import org.eclipse.sirius.web.diagrams.layout.LayoutOptionValues;
 import org.eclipse.sirius.web.diagrams.layout.incremental.data.NodeLayoutData;
 import org.springframework.stereotype.Service;
 
@@ -33,10 +35,10 @@ import org.springframework.stereotype.Service;
 public class NodeSizeProvider {
 
     /**
-     * For ELK, a node with an image style is an image within a node. The margin between a node and its content is 12 on
-     * each side, so to obtain the same result we have to add 12*2 to the width & height.
+     * For ELK, a node with an image style is an image within a node. The padding between a node and its content is 12
+     * on each side, so to obtain the same result we have to add 12*2 to the width & height.
      */
-    private static final int ELK_SIZE_DIFF = 24;
+    private static final double ELK_SIZE_DIFF = 2 * LayoutOptionValues.DEFAULT_ELK_PADDING;
 
     private static final int DEFAULT_WIDTH = 150;
 
@@ -95,6 +97,10 @@ public class NodeSizeProvider {
             Size imageSize = new ImageNodeStyleSizeProvider(this.imageSizeProvider).getSize((ImageNodeStyle) style);
             width = imageSize.getWidth() + ELK_SIZE_DIFF;
             height = imageSize.getHeight() + ELK_SIZE_DIFF;
+        } else if (NodeType.NODE_LIST_ITEM.equals(node.getNodeType())) {
+            Size nodeItemSize = node.getLabel().getTextBounds().getSize();
+            width = nodeItemSize.getWidth() + LayoutOptionValues.NODE_LIST_ELK_NODE_LABELS_PADDING_RIGHT + LayoutOptionValues.NODE_LIST_ELK_NODE_LABELS_PADDING_LEFT;
+            height = nodeItemSize.getHeight();
         }
         return Size.of(width, height);
     }

--- a/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/incremental/updater/ContainmentUpdater.java
+++ b/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/incremental/updater/ContainmentUpdater.java
@@ -12,10 +12,14 @@
  *******************************************************************************/
 package org.eclipse.sirius.web.diagrams.layout.incremental.updater;
 
+import org.eclipse.sirius.web.diagrams.NodeType;
 import org.eclipse.sirius.web.diagrams.Position;
 import org.eclipse.sirius.web.diagrams.Size;
+import org.eclipse.sirius.web.diagrams.layout.LayoutOptionValues;
+import org.eclipse.sirius.web.diagrams.layout.TextBoundsService;
 import org.eclipse.sirius.web.diagrams.layout.incremental.data.IConnectable;
 import org.eclipse.sirius.web.diagrams.layout.incremental.data.IContainerLayoutData;
+import org.eclipse.sirius.web.diagrams.layout.incremental.data.LabelLayoutData;
 import org.eclipse.sirius.web.diagrams.layout.incremental.data.NodeLayoutData;
 
 /**
@@ -26,13 +30,88 @@ import org.eclipse.sirius.web.diagrams.layout.incremental.data.NodeLayoutData;
  */
 public class ContainmentUpdater {
 
+    /**
+     * For elk, all labels have a padding in four directions (top, right, bottom and left). By default the padding value
+     * is 5 on each direction, so to have the real size of a node label we must add the
+     * {@link LayoutOptionValues#DEFAULT_ELK_NODE_LABELS_PADDING} twice to the node label width and the node label
+     * height.
+     */
+    private static final double DEFAULT_NODE_LABELS_PADDING = 2 * LayoutOptionValues.DEFAULT_ELK_NODE_LABELS_PADDING;
+
+    /**
+     * For elk, all labels have a padding in four directions (top, right, bottom and left). In our elk configuration the
+     * default value has been overridden for NodeList, so to have the real width of a node list item label we must add
+     * {@link LayoutOptionValues#NODE_LIST_ELK_NODE_LABELS_PADDING_LEFT} and
+     * {@link LayoutOptionValues#NODE_LIST_ELK_NODE_LABELS_PADDING_RIGHT} to the node list item label width.
+     */
+    private static final double NODE_LIST_NODE_LABELS_PADDING_WIDTH = LayoutOptionValues.NODE_LIST_ELK_NODE_LABELS_PADDING_LEFT + LayoutOptionValues.NODE_LIST_ELK_NODE_LABELS_PADDING_RIGHT;
+
+    /**
+     * For elk, all labels have a padding in four directions (top, right, bottom and left). In our elk configuration the
+     * default value has been overridden for NodeList, so to have the real height of a node list item label we must add
+     * {@link LayoutOptionValues#NODE_LIST_ELK_NODE_LABELS_PADDING_TOP} and
+     * {@link LayoutOptionValues#NODE_LIST_ELK_NODE_LABELS_PADDING_BOTTOM} to the node list item label height.
+     */
+    private static final double NODE_LIST_NODE_LABELS_PADDING_HEIGHT = LayoutOptionValues.NODE_LIST_ELK_NODE_LABELS_PADDING_TOP + LayoutOptionValues.NODE_LIST_ELK_NODE_LABELS_PADDING_BOTTOM;
+
+    /**
+     * For elk, all nodes have a padding in four directions (top, right, bottom and left) to place the node content. In
+     * our elk configuration the default value for the NodeList padding top has been overridden, so to have the real
+     * height of a node we must add the {@link LayoutOptionValues#NODE_LIST_ELK_PADDING_TOP} and the
+     * {@link LayoutOptionValues#DEFAULT_ELK_PADDING} to the node content height.
+     */
+    private static final double NODE_LIST_PADDING_HEIGHT = LayoutOptionValues.NODE_LIST_ELK_PADDING_TOP + LayoutOptionValues.DEFAULT_ELK_PADDING;
+
+    /**
+     * For elk, all nodes have a padding in four directions (top, right, bottom and left) to place the node content. In
+     * our elk configuration the default value for the NodeList padding left has been overridden, so to have the real
+     * width of a node we must add the {@link LayoutOptionValues#NODE_LIST_ELK_PADDING_LEFT} and the
+     * {@link LayoutOptionValues#DEFAULT_ELK_PADDING} to the node content width.
+     */
+    private static final double NODE_LIST_PADDING_WIDTH = LayoutOptionValues.NODE_LIST_ELK_PADDING_LEFT + LayoutOptionValues.DEFAULT_ELK_PADDING;
+
+    private TextBoundsService textBoundsService;
+
+    public ContainmentUpdater(TextBoundsService textBoundsService) {
+        this.textBoundsService = textBoundsService;
+    }
+
     public void update(IContainerLayoutData container) {
-        if (!container.getChildrenNodes().isEmpty()) {
+        if (this.shouldUpdate(container)) {
             if (container instanceof NodeLayoutData) {
+                NodeLayoutData nodeLayoutData = (NodeLayoutData) container;
+                if (NodeType.NODE_LIST.equals(nodeLayoutData.getNodeType())) {
+                    this.updateContentPosition(nodeLayoutData);
+                }
                 // We do not change the position of diagrams as it disturbs the feedback
-                this.updateTopLeft(container);
+                this.updateTopLeft(nodeLayoutData);
             }
             this.updateBottomRight(container);
+        }
+    }
+
+    private boolean shouldUpdate(IContainerLayoutData container) {
+        return !container.getChildrenNodes().isEmpty() || this.isLabelContained(container);
+    }
+
+    private boolean isLabelContained(IContainerLayoutData container) {
+        if (container instanceof NodeLayoutData) {
+            NodeLayoutData nodeLayoutData = (NodeLayoutData) container;
+            return nodeLayoutData.getLabel().getLabelType().contains("inside"); //$NON-NLS-1$
+        }
+
+        return false;
+    }
+
+    private void updateContentPosition(NodeLayoutData nodeLayoutData) {
+        double nextYChildPosition = nodeLayoutData.getLabel().getPosition().getY() + nodeLayoutData.getLabel().getTextBounds().getSize().getHeight() + LayoutOptionValues.NODE_LIST_ELK_PADDING_TOP
+                + LayoutOptionValues.DEFAULT_ELK_NODE_LABELS_PADDING;
+        for (NodeLayoutData childLayoutData : nodeLayoutData.getChildrenNodes()) {
+            double currentYChildPosition = childLayoutData.getPosition().getY();
+            if (currentYChildPosition != nextYChildPosition) {
+                childLayoutData.setPosition(Position.at(childLayoutData.getPosition().getX(), nextYChildPosition));
+            }
+            nextYChildPosition = childLayoutData.getPosition().getY() + childLayoutData.getLabel().getTextBounds().getSize().getHeight() + LayoutOptionValues.NODE_LIST_ELK_NODE_NODE_GAP;
         }
     }
 
@@ -59,18 +138,76 @@ public class ContainmentUpdater {
     private void updateBottomRight(IContainerLayoutData container) {
         double width = container.getSize().getWidth();
         double height = container.getSize().getHeight();
-        double maxWidth = width;
-        double maxHeight = height;
-        for (NodeLayoutData child : container.getChildrenNodes()) {
-            maxWidth = Math.max(maxWidth, child.getPosition().getX() + child.getSize().getWidth());
-            maxHeight = Math.max(maxHeight, child.getPosition().getY() + child.getSize().getHeight());
+        double maxWidth = LayoutOptionValues.MIN_WIDTH_CONSTRAINT;
+        double maxHeight = LayoutOptionValues.MIN_HEIGHT_CONSTRAINT;
+
+        // NodeListItem size is equals to its containing label size
+        if (container instanceof NodeLayoutData) {
+            NodeLayoutData nodeLayoutData = (NodeLayoutData) container;
+            if (NodeType.NODE_LIST_ITEM.equals(nodeLayoutData.getNodeType())) {
+                Size minimumLabelSize = this.textBoundsService.getTextMinimumBounds().getSize();
+                maxWidth = minimumLabelSize.getWidth();
+                maxHeight = minimumLabelSize.getHeight();
+            }
         }
-        if (maxWidth > width || maxHeight > height) {
+
+        if (this.isLabelContained(container)) {
+            LabelLayoutData label = ((NodeLayoutData) container).getLabel();
+            maxWidth = Math.max(maxWidth, label.getTextBounds().getSize().getWidth() + this.getNodeLabelPaddingWidth(container));
+            maxHeight = Math.max(maxHeight, label.getTextBounds().getSize().getHeight() + this.getNodeLabelPaddingHeight(container));
+        }
+
+        for (NodeLayoutData child : container.getChildrenNodes()) {
+            maxWidth = Math.max(maxWidth, child.getPosition().getX() + child.getSize().getWidth() + this.getPaddingWidth(container));
+            maxHeight = Math.max(maxHeight, child.getPosition().getY() + child.getSize().getHeight() + this.getPaddingHeight(container));
+        }
+
+        if (maxWidth != width || maxHeight != height) {
             container.setSize(Size.of(maxWidth, maxHeight));
             if (container instanceof IConnectable) {
                 ((IConnectable) container).setChanged(true);
             }
         }
+    }
+
+    private double getNodeLabelPaddingHeight(IContainerLayoutData container) {
+        return 0;
+    }
+
+    private double getNodeLabelPaddingWidth(IContainerLayoutData container) {
+        double nodeLabelPaddingWidth = 0;
+        if (container instanceof NodeLayoutData) {
+            NodeLayoutData nodeLayoutData = (NodeLayoutData) container;
+            if (NodeType.NODE_LIST.equals(nodeLayoutData.getNodeType())) {
+                nodeLabelPaddingWidth = DEFAULT_NODE_LABELS_PADDING;
+            } else if (NodeType.NODE_LIST_ITEM.equals(nodeLayoutData.getNodeType())) {
+                nodeLabelPaddingWidth = NODE_LIST_NODE_LABELS_PADDING_WIDTH;
+            }
+        }
+        return nodeLabelPaddingWidth;
+    }
+
+    private double getPaddingHeight(IContainerLayoutData container) {
+        double nodeLabelPaddingHeight = 0;
+        if (container instanceof NodeLayoutData) {
+            NodeLayoutData nodeLayoutData = (NodeLayoutData) container;
+            if (NodeType.NODE_LIST.equals(nodeLayoutData.getNodeType())) {
+                nodeLabelPaddingHeight = NODE_LIST_PADDING_HEIGHT;
+            } else if (NodeType.NODE_LIST_ITEM.equals(nodeLayoutData.getNodeType())) {
+                nodeLabelPaddingHeight = NODE_LIST_NODE_LABELS_PADDING_HEIGHT;
+            }
+        }
+        return nodeLabelPaddingHeight;
+    }
+
+    private double getPaddingWidth(IContainerLayoutData container) {
+        if (container instanceof NodeLayoutData) {
+            NodeLayoutData nodeLayoutData = (NodeLayoutData) container;
+            if (NodeType.NODE_LIST.equals(nodeLayoutData.getNodeType())) {
+                return NODE_LIST_PADDING_WIDTH;
+            }
+        }
+        return 0;
     }
 
     private void shift(IContainerLayoutData container, double shiftX, double shiftY) {

--- a/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/incremental/updater/ContainmentUpdater.java
+++ b/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/incremental/updater/ContainmentUpdater.java
@@ -113,8 +113,7 @@ public class ContainmentUpdater {
     }
 
     private void updateContentPosition(NodeLayoutData nodeLayoutData) {
-        double nextYChildPosition = nodeLayoutData.getLabel().getPosition().getY() + nodeLayoutData.getLabel().getTextBounds().getSize().getHeight() + LayoutOptionValues.NODE_LIST_ELK_PADDING_TOP
-                + LayoutOptionValues.DEFAULT_ELK_NODE_LABELS_PADDING;
+        double nextYChildPosition = nodeLayoutData.getLabel().getTextBounds().getSize().getHeight() + LayoutOptionValues.NODE_LIST_ELK_PADDING_TOP + LayoutOptionValues.DEFAULT_ELK_NODE_LABELS_PADDING;
         for (NodeLayoutData childLayoutData : nodeLayoutData.getChildrenNodes()) {
             double currentYChildPosition = childLayoutData.getPosition().getY();
             if (currentYChildPosition != nextYChildPosition) {

--- a/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/ListItemNodeStyle.java
+++ b/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/ListItemNodeStyle.java
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.diagrams;
+
+import java.text.MessageFormat;
+import java.util.Objects;
+
+import org.eclipse.sirius.web.annotations.Immutable;
+import org.eclipse.sirius.web.annotations.graphql.GraphQLField;
+import org.eclipse.sirius.web.annotations.graphql.GraphQLNonNull;
+import org.eclipse.sirius.web.annotations.graphql.GraphQLObjectType;
+
+/**
+ * The list container item node style.
+ *
+ * @author gcoutable
+ */
+@Immutable
+@GraphQLObjectType
+public final class ListItemNodeStyle implements INodeStyle {
+
+    private String backgroundColor;
+
+    private ListItemNodeStyle() {
+        // Prevent instantiation
+    }
+
+    @GraphQLNonNull
+    @GraphQLField
+    public String getBackgroundColor() {
+        return this.backgroundColor;
+    }
+
+    public static Builder newListItemNodeStyle() {
+        return new Builder();
+    }
+
+    @Override
+    public String toString() {
+        String pattern = "{0} '{'backgroundColor: {1}'}'"; //$NON-NLS-1$
+        return MessageFormat.format(pattern, this.getClass().getSimpleName(), this.backgroundColor);
+    }
+
+    /**
+     * The builder used to create the list container item node style.
+     *
+     * @author gcoutable
+     */
+    @SuppressWarnings("checkstyle:HiddenField")
+    public static final class Builder {
+
+        private String backgroundColor;
+
+        private Builder() {
+            // Prevent instantiation
+        }
+
+        public Builder backgroundColor(String backgroundColor) {
+            this.backgroundColor = Objects.requireNonNull(backgroundColor);
+            return this;
+        }
+
+        public ListItemNodeStyle build() {
+            ListItemNodeStyle nodeStyleDescription = new ListItemNodeStyle();
+            nodeStyleDescription.backgroundColor = Objects.requireNonNull(this.backgroundColor);
+            return nodeStyleDescription;
+        }
+    }
+}

--- a/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/ListNodeStyle.java
+++ b/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/ListNodeStyle.java
@@ -1,0 +1,129 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.diagrams;
+
+import java.text.MessageFormat;
+import java.util.Objects;
+
+import org.eclipse.sirius.web.annotations.Immutable;
+import org.eclipse.sirius.web.annotations.graphql.GraphQLField;
+import org.eclipse.sirius.web.annotations.graphql.GraphQLNonNull;
+import org.eclipse.sirius.web.annotations.graphql.GraphQLObjectType;
+
+/**
+ * The list container node style.
+ *
+ * @author gcoutable
+ */
+@Immutable
+@GraphQLObjectType
+public final class ListNodeStyle implements INodeStyle {
+
+    private String color;
+
+    private String borderColor;
+
+    private int borderSize;
+
+    private LineStyle borderStyle;
+
+    private ListNodeStyle() {
+        // Prevent instantiation
+    }
+
+    @GraphQLNonNull
+    @GraphQLField
+    public String getColor() {
+        return this.color;
+    }
+
+    @GraphQLNonNull
+    @GraphQLField
+    public String getBorderColor() {
+        return this.borderColor;
+    }
+
+    @GraphQLNonNull
+    @GraphQLField
+    public int getBorderSize() {
+        return this.borderSize;
+    }
+
+    @GraphQLNonNull
+    @GraphQLField
+    public LineStyle getBorderStyle() {
+        return this.borderStyle;
+    }
+
+    public static Builder newListNodeStyle() {
+        return new Builder();
+    }
+
+    @Override
+    public String toString() {
+        String pattern = "{0} '{'color: {1}, borderColor: {2}, borderSize: {3}, borderStyle: {4}'}'"; //$NON-NLS-1$
+        return MessageFormat.format(pattern, this.getClass().getSimpleName(), this.color, this.borderColor, this.borderSize, this.borderStyle);
+    }
+
+    /**
+     * The builder used to create the list container node style.
+     *
+     * @author gcoutable
+     */
+    @SuppressWarnings("checkstyle:HiddenField")
+    public static final class Builder {
+
+        private String color;
+
+        private String borderColor;
+
+        private int borderSize;
+
+        private LineStyle borderStyle;
+
+        private Builder() {
+            // Prevent instantiation
+        }
+
+        public Builder color(String color) {
+            this.color = Objects.requireNonNull(color);
+            return this;
+        }
+
+        public Builder borderColor(String borderColor) {
+            this.borderColor = Objects.requireNonNull(borderColor);
+            return this;
+        }
+
+        public Builder borderSize(int borderSize) {
+            this.borderSize = Objects.requireNonNull(borderSize);
+            return this;
+        }
+
+        public Builder borderStyle(LineStyle borderStyle) {
+            this.borderStyle = Objects.requireNonNull(borderStyle);
+            return this;
+        }
+
+        public ListNodeStyle build() {
+            ListNodeStyle nodeStyleDescription = new ListNodeStyle();
+            nodeStyleDescription.color = Objects.requireNonNull(this.color);
+            nodeStyleDescription.borderColor = Objects.requireNonNull(this.borderColor);
+            nodeStyleDescription.borderSize = Objects.requireNonNull(this.borderSize);
+            nodeStyleDescription.borderStyle = Objects.requireNonNull(this.borderStyle);
+            return nodeStyleDescription;
+        }
+
+    }
+
+}

--- a/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/NodeType.java
+++ b/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/NodeType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Obeo.
+ * Copyright (c) 2019, 2021 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -21,6 +21,10 @@ public final class NodeType {
     public static final String NODE_RECTANGLE = "node:rectangle"; //$NON-NLS-1$
 
     public static final String NODE_IMAGE = "node:image"; //$NON-NLS-1$
+
+    public static final String NODE_LIST = "node:list"; //$NON-NLS-1$
+
+    public static final String NODE_LIST_ITEM = "node:list:item"; //$NON-NLS-1$
 
     private NodeType() {
         // Prevent instantiation

--- a/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/components/LabelType.java
+++ b/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/components/LabelType.java
@@ -20,6 +20,7 @@ package org.eclipse.sirius.web.diagrams.components;
 public enum LabelType {
 
     INSIDE_CENTER("label:inside-center"), //$NON-NLS-1$
+    OUTSIDE_CENTER("label:outside-center"), //$NON-NLS-1$
     EDGE_BEGIN("label:edge-begin"), //$NON-NLS-1$
     EDGE_CENTER("label:edge-center"), //$NON-NLS-1$
     EDGE_END("label:edge-end"); //$NON-NLS-1$

--- a/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/components/NodeComponent.java
+++ b/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/components/NodeComponent.java
@@ -28,6 +28,7 @@ import org.eclipse.sirius.web.diagrams.CustomizableProperties;
 import org.eclipse.sirius.web.diagrams.INodeStyle;
 import org.eclipse.sirius.web.diagrams.Label;
 import org.eclipse.sirius.web.diagrams.Node;
+import org.eclipse.sirius.web.diagrams.NodeType;
 import org.eclipse.sirius.web.diagrams.Position;
 import org.eclipse.sirius.web.diagrams.Size;
 import org.eclipse.sirius.web.diagrams.description.LabelDescription;
@@ -121,7 +122,13 @@ public class NodeComponent implements IComponent {
 
         LabelDescription labelDescription = nodeDescription.getLabelDescription();
         nodeVariableManager.put(LabelDescription.OWNER_ID, nodeId);
-        LabelComponentProps labelComponentProps = new LabelComponentProps(nodeVariableManager, labelDescription, optionalPreviousLabel, LabelType.INSIDE_CENTER.getValue());
+
+        LabelType nodeLabelType = LabelType.INSIDE_CENTER;
+        if (NodeType.NODE_IMAGE.equals(type)) {
+            nodeLabelType = LabelType.OUTSIDE_CENTER;
+        }
+
+        LabelComponentProps labelComponentProps = new LabelComponentProps(nodeVariableManager, labelDescription, optionalPreviousLabel, nodeLabelType.getValue());
         Element labelElement = new Element(LabelComponent.class, labelComponentProps);
 
         List<Element> nodeChildren = new ArrayList<>();

--- a/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/INodeStyleDeserializer.java
+++ b/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/INodeStyleDeserializer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Obeo.
+ * Copyright (c) 2019, 2021 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -24,6 +24,10 @@ import java.io.IOException;
 
 import org.eclipse.sirius.web.diagrams.INodeStyle;
 import org.eclipse.sirius.web.diagrams.ImageNodeStyle;
+import org.eclipse.sirius.web.diagrams.ListItemNodeStyle;
+import org.eclipse.sirius.web.diagrams.ListNodeStyle;
+import org.eclipse.sirius.web.diagrams.Node;
+import org.eclipse.sirius.web.diagrams.NodeType;
 import org.eclipse.sirius.web.diagrams.RectangularNodeStyle;
 
 /**
@@ -51,10 +55,26 @@ public class INodeStyleDeserializer extends StdDeserializer<INodeStyle> {
             ObjectMapper mapper = (ObjectMapper) objectCodec;
             ObjectNode root = mapper.readTree(jsonParser);
 
-            if (root.has("imageURL")) { //$NON-NLS-1$
-                nodeStyle = mapper.readValue(root.toString(), ImageNodeStyle.class);
-            } else {
-                nodeStyle = mapper.readValue(root.toString(), RectangularNodeStyle.class);
+            Object parent = jsonParser.getParsingContext().getCurrentValue();
+            if (parent instanceof Node) {
+                Node parentNode = (Node) parent;
+                switch (parentNode.getType()) {
+                case NodeType.NODE_RECTANGLE:
+                    nodeStyle = mapper.readValue(root.toString(), RectangularNodeStyle.class);
+                    break;
+                case NodeType.NODE_IMAGE:
+                    nodeStyle = mapper.readValue(root.toString(), ImageNodeStyle.class);
+                    break;
+                case NodeType.NODE_LIST:
+                    nodeStyle = mapper.readValue(root.toString(), ListNodeStyle.class);
+                    break;
+                case NodeType.NODE_LIST_ITEM:
+                    nodeStyle = mapper.readValue(root.toString(), ListItemNodeStyle.class);
+                    break;
+                default:
+                    nodeStyle = mapper.readValue(root.toString(), RectangularNodeStyle.class);
+                    break;
+                }
             }
         }
         return nodeStyle;

--- a/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/graphql/DiagramTypesProvider.java
+++ b/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/graphql/DiagramTypesProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Obeo.
+ * Copyright (c) 2019, 2021 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -26,6 +26,8 @@ import org.eclipse.sirius.web.diagrams.ImageNodeStyle;
 import org.eclipse.sirius.web.diagrams.Label;
 import org.eclipse.sirius.web.diagrams.LabelStyle;
 import org.eclipse.sirius.web.diagrams.LineStyle;
+import org.eclipse.sirius.web.diagrams.ListItemNodeStyle;
+import org.eclipse.sirius.web.diagrams.ListNodeStyle;
 import org.eclipse.sirius.web.diagrams.Node;
 import org.eclipse.sirius.web.diagrams.Position;
 import org.eclipse.sirius.web.diagrams.RectangularNodeStyle;
@@ -78,6 +80,8 @@ public class DiagramTypesProvider implements ITypeProvider {
             LabelStyle.class,
             RectangularNodeStyle.class,
             ImageNodeStyle.class,
+            ListNodeStyle.class,
+            ListItemNodeStyle.class,
             Edge.class,
             EdgeStyle.class,
             DiagramDescription.class,
@@ -113,6 +117,8 @@ public class DiagramTypesProvider implements ITypeProvider {
                 .name(INodeStyle.class.getSimpleName())
                 .possibleType(new GraphQLTypeReference(RectangularNodeStyle.class.getSimpleName()))
                 .possibleType(new GraphQLTypeReference(ImageNodeStyle.class.getSimpleName()))
+                .possibleType(new GraphQLTypeReference(ListNodeStyle.class.getSimpleName()))
+                .possibleType(new GraphQLTypeReference(ListItemNodeStyle.class.getSimpleName()))
                 .build();
         // @formatter:on
     }

--- a/frontend/src/diagram/operations.ts
+++ b/frontend/src/diagram/operations.ts
@@ -114,8 +114,17 @@ export const diagramEventSubscription = gql`
         borderStyle
         borderSize
       }
+      ... on ListNodeStyle {
+        color
+        borderColor
+        borderStyle
+        borderSize
+      }
       ... on ImageNodeStyle {
         imageURL
+      }
+      ... on ListItemNodeStyle {
+        backgroundColor
       }
     }
     position {

--- a/frontend/src/diagram/sprotty/DependencyInjection.ts
+++ b/frontend/src/diagram/sprotty/DependencyInjection.ts
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Obeo.
+ * Copyright (c) 2019, 2021 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -18,6 +18,8 @@ import { DiagramView } from 'diagram/sprotty/views/DiagramView';
 import { EdgeView } from 'diagram/sprotty/views/EdgeView';
 import { ImageView } from 'diagram/sprotty/views/ImageView';
 import { LabelView } from 'diagram/sprotty/views/LabelView';
+import { ListItemView } from 'diagram/sprotty/views/ListItemView';
+import { ListView } from 'diagram/sprotty/views/ListView';
 import { RectangleView } from 'diagram/sprotty/views/RectangleView';
 import {
   ACTIVE_TOOL_ACTION,
@@ -85,6 +87,10 @@ const siriusWebContainerModule = new ContainerModule((bind, unbind, isBound, reb
   configureModelElement(context, 'node:rectangle', SNode, RectangleView);
   // @ts-ignore
   configureModelElement(context, 'node:image', SNode, ImageView);
+  // @ts-ignore
+  configureModelElement(context, 'node:list', SNode, ListView);
+  // @ts-ignore
+  configureModelElement(context, 'node:list:item', SNode, ListItemView);
   // @ts-ignore
   configureView({ bind, isBound }, 'port:square', RectangleView);
   configureView({ bind, isBound }, 'edge:straight', EdgeView);

--- a/frontend/src/diagram/sprotty/DependencyInjection.ts
+++ b/frontend/src/diagram/sprotty/DependencyInjection.ts
@@ -97,14 +97,14 @@ const siriusWebContainerModule = new ContainerModule((bind, unbind, isBound, reb
   // @ts-ignore
   configureModelElement(context, 'label:inside-center', SLabel, LabelView);
   // @ts-ignore
+  configureModelElement(context, 'label:outside-center', SLabel, LabelView);
+  // @ts-ignore
   configureModelElement(context, 'label:edge-begin', SLabel, LabelView);
   // @ts-ignore
   configureModelElement(context, 'label:edge-center', SLabel, LabelView);
   // @ts-ignore
   configureModelElement(context, 'label:edge-end', SLabel, LabelView);
   // @ts-ignore
-  configureModelElement(context, 'label:text', SLabel, LabelView);
-
   configureView({ bind, isBound }, 'comp:main', SCompartmentView);
   configureView({ bind, isBound }, 'html', HtmlRootView);
   // @ts-ignore

--- a/frontend/src/diagram/sprotty/convertDiagram.tsx
+++ b/frontend/src/diagram/sprotty/convertDiagram.tsx
@@ -17,6 +17,7 @@ import {
   deletableFeature,
   editLabelFeature,
   fadeFeature,
+  FeatureSet,
   hoverFeedbackFeature,
   layoutContainerFeature,
   moveFeature,
@@ -84,7 +85,7 @@ const convertNode = (node, httpOrigin: string, readOnly: boolean) => {
   const convertedLabel = convertLabel(label, httpOrigin, readOnly);
   const convertedStyle = convertNodeStyle(style, httpOrigin);
 
-  const features = handleNodeFeatures(readOnly);
+  const features = handleNodeFeatures(node, readOnly);
 
   const editableLabel = handleNodeLabel(convertedLabel, readOnly);
 
@@ -113,20 +114,8 @@ const handleNodeLabel = (label, readOnly: boolean) => {
   return editableLabel;
 };
 
-const handleNodeFeatures = (readOnly: boolean) => {
-  if (readOnly) {
-    return createFeatureSet([
-      connectableFeature,
-      selectFeature,
-      boundsFeature,
-      layoutContainerFeature,
-      fadeFeature,
-      hoverFeedbackFeature,
-      popupFeature,
-    ]);
-  }
-
-  return createFeatureSet([
+const handleNodeFeatures = (node, readOnly: boolean): FeatureSet => {
+  const features = new Set<symbol>([
     connectableFeature,
     deletableFeature,
     selectFeature,
@@ -139,6 +128,22 @@ const handleNodeFeatures = (readOnly: boolean) => {
     resizeFeature,
     withEditLabelFeature,
   ]);
+
+  if (node.type === 'node:list') {
+    features.delete(resizeFeature);
+  } else if (node.type === 'node:list:item') {
+    features.delete(resizeFeature);
+    features.delete(connectableFeature);
+    features.delete(moveFeature);
+  }
+
+  if (readOnly) {
+    features.delete(resizeFeature);
+    features.delete(moveFeature);
+    features.delete(withEditLabelFeature);
+  }
+
+  return features;
 };
 
 const convertLabel = (label, httpOrigin: string, readOnly: boolean) => {

--- a/frontend/src/diagram/sprotty/views/LabelView.tsx
+++ b/frontend/src/diagram/sprotty/views/LabelView.tsx
@@ -48,8 +48,7 @@ export class LabelView extends SLabelView {
         styleObject['text-decoration'] += ' line-through';
       }
     }
-
-    const iconVerticalOffset = label.text ? -12 : -6;
+    const iconVerticalOffset = -12;
     const vnode = (
       <g attrs-data-testid={`Label - ${label.text}`}>
         {iconURL ? <image href={iconURL} y={iconVerticalOffset} x="-20" /> : ''}

--- a/frontend/src/diagram/sprotty/views/ListItemView.tsx
+++ b/frontend/src/diagram/sprotty/views/ListItemView.tsx
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+/** @jsx svg */
+import { svg } from 'snabbdom-jsx';
+import { SLabelView } from 'sprotty';
+
+/**
+ * The view used to display nodes with a rectangle style.
+ *
+ * @gcoutable
+ */
+export class ListItemView extends SLabelView {
+  /**
+   * Renders the given node in the context.
+   * @param node The node
+   * @param context The context
+   */
+  // @ts-ignore
+  render(node, context) {
+    const nodeStyle = node.style;
+    const styleObject = {
+      fill: nodeStyle.backgroundColor,
+    };
+
+    if (node.selected) {
+      styleObject['outline'] = 'var(--blue-lagoon) solid 1px';
+    }
+
+    if (node.hoverFeedback) {
+      styleObject['outline'] = 'var(--blue-lagoon) solid 2px';
+    }
+
+    const nodeLabel = node.children[0];
+
+    return (
+      <g
+        attrs-data-testid={`Item - ${nodeLabel?.text}`}
+        attrs-data-testselected={`${node.selected}`}
+        attrs-data-nodeid={node.id}
+        attrs-data-descriptionid={node.descriptionId}>
+        <rect
+          class-selected={node.selected}
+          class-mouseover={node.hoverFeedback}
+          x={0}
+          y={0}
+          width={Math.max(0, node.bounds.width)}
+          height={Math.max(0, node.bounds.height)}
+          style={styleObject}
+        />
+        {context.renderChildren(node)}
+      </g>
+    );
+  }
+}

--- a/frontend/src/diagram/sprotty/views/ListItemView.tsx
+++ b/frontend/src/diagram/sprotty/views/ListItemView.tsx
@@ -15,7 +15,7 @@ import { svg } from 'snabbdom-jsx';
 import { SLabelView } from 'sprotty';
 
 /**
- * The view used to display nodes with a rectangle style.
+ * The view used to display nodes with a list item style.
  *
  * @gcoutable
  */

--- a/frontend/src/diagram/sprotty/views/ListView.tsx
+++ b/frontend/src/diagram/sprotty/views/ListView.tsx
@@ -1,0 +1,102 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+/** @jsx svg */
+import { svg } from 'snabbdom-jsx';
+import { RectangularNodeView } from 'sprotty';
+
+/**
+ * The view used to display nodes with a rectangle style.
+ *
+ * @gcoutable
+ */
+export class ListView extends RectangularNodeView {
+  /**
+   * Renders the given node in the context.
+   * @param node The node
+   * @param context The context
+   */
+  // @ts-ignore
+  render(node, context) {
+    const nodeStyle = node.style;
+    const styleObject = {
+      fill: nodeStyle.color,
+      stroke: nodeStyle.borderColor,
+      'stroke-width': nodeStyle.borderSize,
+    };
+
+    if (node.selected) {
+      styleObject['outline'] = 'var(--blue-lagoon) solid 1px';
+    }
+
+    if (node.hoverFeedback) {
+      styleObject['outline'] = 'var(--blue-lagoon) solid 2px';
+    }
+
+    switch (nodeStyle.borderStyle) {
+      case 'Dash':
+        styleObject['stroke-dasharray'] = '4,4';
+        break;
+      case 'Dot':
+        styleObject['stroke-dasharray'] = '2,2';
+        break;
+      case 'Dash_Dot':
+        styleObject['stroke-dasharray'] = '2,4,2';
+        break;
+      default:
+        break;
+    }
+
+    // renders the label and other children separately in order to add the horizontal separator.
+    let children = [...node.children];
+
+    const nodeLabel = children.shift();
+    const renderedNodeLabel = context.renderElement(nodeLabel);
+
+    const headerSeparatorStyle = {
+      stroke: nodeStyle.borderColor,
+      'stroke-width': nodeStyle.borderSize,
+    };
+    const headerSeparator = (
+      <line
+        x1={0}
+        y1={nodeLabel.bounds.height}
+        x2={node.bounds.width}
+        y2={nodeLabel.bounds.height}
+        style={headerSeparatorStyle}
+      />
+    );
+
+    const itemGroup = children.map((item) => context.renderElement(item));
+
+    return (
+      <g
+        attrs-data-testid={`List - ${nodeLabel?.text}`}
+        attrs-data-testselected={`${node.selected}`}
+        attrs-data-nodeid={node.id}
+        attrs-data-descriptionid={node.descriptionId}>
+        <rect
+          class-selected={node.selected}
+          class-mouseover={node.hoverFeedback}
+          x={0}
+          y={0}
+          width={Math.max(0, node.bounds.width)}
+          height={Math.max(0, node.bounds.height)}
+          style={styleObject}
+        />
+        {renderedNodeLabel}
+        {headerSeparator}
+        {itemGroup}
+      </g>
+    );
+  }
+}

--- a/frontend/src/diagram/sprotty/views/ListView.tsx
+++ b/frontend/src/diagram/sprotty/views/ListView.tsx
@@ -15,7 +15,7 @@ import { svg } from 'snabbdom-jsx';
 import { RectangularNodeView } from 'sprotty';
 
 /**
- * The view used to display nodes with a rectangle style.
+ * The view used to display nodes with a list style.
  *
  * @gcoutable
  */
@@ -66,12 +66,16 @@ export class ListView extends RectangularNodeView {
       stroke: nodeStyle.borderColor,
       'stroke-width': nodeStyle.borderSize,
     };
+
+    // The label y position indicates the padding top, we suppose the same padding is applied to the bottom.
+    const headerLabelPadding = nodeLabel?.bounds?.y;
+
     const headerSeparator = (
       <line
         x1={0}
-        y1={nodeLabel.bounds.height}
+        y1={nodeLabel.bounds.height + 2 * headerLabelPadding}
         x2={node.bounds.width}
-        y2={nodeLabel.bounds.height}
+        y2={nodeLabel.bounds.height + 2 * headerLabelPadding}
         style={headerSeparatorStyle}
       />
     );

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -50,6 +50,8 @@ export * from './diagram/sprotty/views/DiagramView';
 export * from './diagram/sprotty/views/EdgeView';
 export * from './diagram/sprotty/views/ImageView';
 export * from './diagram/sprotty/views/LabelView';
+export * from './diagram/sprotty/views/ListItemView';
+export * from './diagram/sprotty/views/ListView';
 export * from './diagram/sprotty/views/RectangleView';
 export * from './diagram/sprotty/WebSocketDiagramServer';
 export * from './diagram/Toolbar';


### PR DESCRIPTION
- Creates a node list when the Sirius container mapping style is "LIST"
- Creates a node list item when a Sirius node mapping style represents a
simple figure (ellipse, lozenge, square)
- Improves ELK configuration to support these node types
- Updates ELK dependency to 0.7.1 because a bug prevents
NodeSizeConstraints option to be correctly applied
- Provides an OS aware minimum size for empty labels.

Bug: eclipse-sirius/sirius-components#418
Signed-off-by: Guillaume Coutable <guillaume.coutable@obeo.fr>

### Type of this PR 

- [ ] Bug fix
- [x] New feature or improvement
- [ ] Documentation
- [ ] Cleanup
- [ ] Test
- [ ] Build/Releng

### Issue(s)

https://github.com/eclipse-sirius/sirius-components/issues/418

### What does this PR do?

This PR provides the first support of NodeList and NodeListItem for sirius-component with the ELK configuration.

### Screenshot/screencast of this PR

...
 

### Potential side effects

Does not work well with the incremental layout yet.

### How to test this PR?

- [ ] Frontend Unit tests
- [ ] Backend Unit tests
- [ ] Cypress : please specify
- [x] Manual Test : 
  - From the Model explorer :
    - Creates an empty model
    - Creates a Domain
    - Creates an Entity
    - Creates many attributes (event with empty labels)
    - Creates a _Domain_ representation

### Checklist

- [x] I have read CONTRIBUTING carefully.
- [x] I have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All my commits are signed-off (`-s`) with my mail address of my Eclipse Account.
- [ ] I have covered my changes by unit tests or integration tests or manual tests.
- [ ] All tests pass.
- [ ] I have updated the documentation accordingly
- [ ] New React components are availables in storybook
