### PR TITLE
Cleanup unbound representation

### DIFF
--- a/backend/sirius-web-collaborative-api/src/main/java/org/eclipse/sirius/web/collaborative/api/services/IEditingContextEventProcessorFactory.java
+++ b/backend/sirius-web-collaborative-api/src/main/java/org/eclipse/sirius/web/collaborative/api/services/IEditingContextEventProcessorFactory.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.collaborative.api.services;
+
+import org.eclipse.sirius.web.core.api.IEditingContext;
+
+/**
+ * Interface used to create a {@link IEditingContextEventProcessor}.
+ *
+ * @author gcoutable
+ */
+public interface IEditingContextEventProcessorFactory {
+
+    IEditingContextEventProcessor createEditingContextEventProcessor(IEditingContext editingContext);
+
+}

--- a/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/services/NoOpRepresentationService.java
+++ b/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/services/NoOpRepresentationService.java
@@ -59,4 +59,8 @@ public class NoOpRepresentationService implements IRepresentationService {
     @Override
     public void delete(UUID representationId) {
     }
+
+    @Override
+    public void deleteDanglingRepresentations(UUID editingContextId) {
+    }
 }

--- a/backend/sirius-web-persistence/src/main/java/org/eclipse/sirius/web/persistence/repositories/IRepresentationRepository.java
+++ b/backend/sirius-web-persistence/src/main/java/org/eclipse/sirius/web/persistence/repositories/IRepresentationRepository.java
@@ -18,9 +18,11 @@ import java.util.UUID;
 
 import org.eclipse.sirius.web.annotations.Audited;
 import org.eclipse.sirius.web.persistence.entities.RepresentationEntity;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Persistence layer used to manipulate representations.
@@ -49,6 +51,12 @@ public interface IRepresentationRepository extends PagingAndSortingRepository<Re
     @Audited
     @Override
     <S extends RepresentationEntity> S save(S representationEntity);
+
+    @Audited
+    @Transactional
+    @Modifying
+    @Query(name = "Representation.deleteDanglingRepresentations", nativeQuery = true)
+    int deleteDanglingRepresentations(UUID projectId);
 
     @Audited
     @Override

--- a/backend/sirius-web-persistence/src/main/resources/db/sirius-web-named-queries.properties
+++ b/backend/sirius-web-persistence/src/main/resources/db/sirius-web-named-queries.properties
@@ -4,3 +4,4 @@ Project.findAllVisibleBy=SELECT * FROM project
 Project.findByIdIfVisibleBy=SELECT * FROM project project WHERE project.id=?1
 Project.isOwner=SELECT CASE WHEN COUNT(project)> 0 THEN true ELSE false END FROM ProjectEntity project WHERE project.id=?2 AND project.owner.username=?1
 Document.findAllByType=SELECT * FROM Document document WHERE document.content::::jsonb @> ('{ "ns": { "' || ?1 || '": "' || ?2 ||'" } }')::::jsonb
+Representation.deleteDanglingRepresentations=DELETE FROM Representation representation WHERE representation.project_id=?1 AND NOT EXISTS (SELECT * FROM Document document WHERE document.project_id=?1 AND jsonb_path_exists(document.content::::jsonb, ('strict $.content.**.id ? (@ == "' || representation.targetobjectid || '" ) ')::::jsonpath))

--- a/backend/sirius-web-persistence/src/test/java/org/eclipse/sirius/web/persistence/repositories/JPAConfiguration.java
+++ b/backend/sirius-web-persistence/src/test/java/org/eclipse/sirius/web/persistence/repositories/JPAConfiguration.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.sirius.web.persistence.repositories;
 
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
@@ -22,6 +23,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
  * @author sbegaudeau
  */
 @Configuration
+@EnableAutoConfiguration
 @EntityScan(basePackages = { "org.eclipse.sirius.web.persistence.entities" })
 @EnableJpaRepositories(basePackages = { "org.eclipse.sirius.web.persistence.repositories" }, namedQueriesLocation = "classpath:db/sirius-web-named-queries.properties")
 public class JPAConfiguration {

--- a/backend/sirius-web-services-api/src/main/java/org/eclipse/sirius/web/services/api/representations/IRepresentationService.java
+++ b/backend/sirius-web-services-api/src/main/java/org/eclipse/sirius/web/services/api/representations/IRepresentationService.java
@@ -37,4 +37,6 @@ public interface IRepresentationService {
 
     void delete(UUID representationId);
 
+    void deleteDanglingRepresentations(UUID editingContextId);
+
 }

--- a/backend/sirius-web-services/src/main/java/org/eclipse/sirius/web/services/representations/RepresentationService.java
+++ b/backend/sirius-web-services/src/main/java/org/eclipse/sirius/web/services/representations/RepresentationService.java
@@ -113,4 +113,9 @@ public class RepresentationService implements IRepresentationService {
     public void delete(UUID representationId) {
         this.representationRepository.deleteById(representationId);
     }
+
+    @Override
+    public void deleteDanglingRepresentations(UUID editingContextId) {
+        this.representationRepository.deleteDanglingRepresentations(editingContextId);
+    }
 }

--- a/backend/sirius-web-services/src/test/java/org/eclipse/sirius/web/services/representations/NoOpDocumentRepository.java
+++ b/backend/sirius-web-services/src/test/java/org/eclipse/sirius/web/services/representations/NoOpDocumentRepository.java
@@ -1,0 +1,110 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.services.representations;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.eclipse.sirius.web.persistence.entities.DocumentEntity;
+import org.eclipse.sirius.web.persistence.repositories.IDocumentRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+/**
+ *
+ * Implementation of the document repository which does nothing.
+ *
+ * @author gcoutable
+ */
+public class NoOpDocumentRepository implements IDocumentRepository {
+
+    @Override
+    public Iterable<DocumentEntity> findAll(Sort sort) {
+        return new ArrayList<>();
+    }
+
+    @Override
+    public Page<DocumentEntity> findAll(Pageable pageable) {
+        return Page.empty();
+    }
+
+    @Override
+    public <S extends DocumentEntity> Iterable<S> saveAll(Iterable<S> entities) {
+        return entities;
+    }
+
+    @Override
+    public boolean existsById(UUID id) {
+        return false;
+    }
+
+    @Override
+    public Iterable<DocumentEntity> findAllById(Iterable<UUID> ids) {
+        return new ArrayList<>();
+    }
+
+    @Override
+    public long count() {
+        return 0;
+    }
+
+    @Override
+    public void delete(DocumentEntity entity) {
+    }
+
+    @Override
+    public void deleteAll(Iterable<? extends DocumentEntity> entities) {
+    }
+
+    @Override
+    public void deleteAll() {
+    }
+
+    @Override
+    public Optional<DocumentEntity> findById(UUID id) {
+        return Optional.empty();
+    }
+
+    @Override
+    public Iterable<DocumentEntity> findAll() {
+        return new ArrayList<>();
+    }
+
+    @Override
+    public Iterable<DocumentEntity> findAllByType(String name, String uri) {
+        return new ArrayList<>();
+    }
+
+    @Override
+    public List<DocumentEntity> findAllByProjectId(UUID projectId) {
+        return new ArrayList<>();
+    }
+
+    @Override
+    public Optional<DocumentEntity> findByProjectIdAndId(UUID projectId, UUID documentId) {
+        return Optional.empty();
+    }
+
+    @Override
+    public void deleteById(UUID id) {
+    }
+
+    @Override
+    public <S extends DocumentEntity> S save(S entity) {
+        return entity;
+    }
+
+}

--- a/backend/sirius-web-services/src/test/java/org/eclipse/sirius/web/services/representations/NoOpRepresentationRepository.java
+++ b/backend/sirius-web-services/src/test/java/org/eclipse/sirius/web/services/representations/NoOpRepresentationRepository.java
@@ -1,0 +1,120 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.services.representations;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.eclipse.sirius.web.persistence.entities.RepresentationEntity;
+import org.eclipse.sirius.web.persistence.repositories.IRepresentationRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+/**
+ *
+ * Implementation of the representation repository which does nothing.
+ *
+ * @author gcoutable
+ */
+public class NoOpRepresentationRepository implements IRepresentationRepository {
+
+    @Override
+    public Iterable<RepresentationEntity> findAll(Sort sort) {
+        return new ArrayList<>();
+    }
+
+    @Override
+    public Page<RepresentationEntity> findAll(Pageable pageable) {
+        return Page.empty();
+    }
+
+    @Override
+    public <S extends RepresentationEntity> Iterable<S> saveAll(Iterable<S> entities) {
+        return entities;
+    }
+
+    @Override
+    public boolean existsById(UUID id) {
+        return false;
+    }
+
+    @Override
+    public Iterable<RepresentationEntity> findAll() {
+        return new ArrayList<>();
+    }
+
+    @Override
+    public Iterable<RepresentationEntity> findAllById(Iterable<UUID> ids) {
+        return new ArrayList<>();
+    }
+
+    @Override
+    public long count() {
+        return 0;
+    }
+
+    @Override
+    public void delete(RepresentationEntity entity) {
+    }
+
+    @Override
+    public void deleteAll(Iterable<? extends RepresentationEntity> entities) {
+    }
+
+    @Override
+    public void deleteAll() {
+    }
+
+    @Override
+    public Optional<RepresentationEntity> findById(UUID id) {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<RepresentationEntity> findByIdAndProjectId(UUID id, UUID projectId) {
+        return Optional.empty();
+    }
+
+    @Override
+    public List<RepresentationEntity> findAllByTargetObjectId(String objectId) {
+        return new ArrayList<>();
+    }
+
+    @Override
+    public List<RepresentationEntity> findAllByProjectId(UUID projectId) {
+        return new ArrayList<>();
+    }
+
+    @Override
+    public boolean hasRepresentations(String objectId) {
+        return false;
+    }
+
+    @Override
+    public <S extends RepresentationEntity> S save(S representationEntity) {
+        return representationEntity;
+    }
+
+    @Override
+    public void deleteById(UUID id) {
+    }
+
+    @Override
+    public int deleteDanglingRepresentations(UUID projectId) {
+        return 0;
+    }
+
+}

--- a/backend/sirius-web-spring-collaborative-diagrams/src/test/java/org/eclipse/sirius/web/spring/collaborative/diagrams/handlers/NoOpRepresentationService.java
+++ b/backend/sirius-web-spring-collaborative-diagrams/src/test/java/org/eclipse/sirius/web/spring/collaborative/diagrams/handlers/NoOpRepresentationService.java
@@ -59,4 +59,8 @@ public class NoOpRepresentationService implements IRepresentationService {
     @Override
     public void delete(UUID representationId) {
     }
+
+    @Override
+    public void deleteDanglingRepresentations(UUID editingContextId) {
+    }
 }

--- a/backend/sirius-web-spring-collaborative/src/main/java/org/eclipse/sirius/web/spring/collaborative/projects/EditingContextEventProcessor.java
+++ b/backend/sirius-web-spring-collaborative/src/main/java/org/eclipse/sirius/web/spring/collaborative/projects/EditingContextEventProcessor.java
@@ -47,6 +47,7 @@ import org.eclipse.sirius.web.core.api.IPayload;
 import org.eclipse.sirius.web.core.api.IRepresentationInput;
 import org.eclipse.sirius.web.representations.IRepresentation;
 import org.eclipse.sirius.web.representations.ISemanticRepresentation;
+import org.eclipse.sirius.web.services.api.representations.IRepresentationService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationEventPublisher;
@@ -90,8 +91,12 @@ public class EditingContextEventProcessor implements IEditingContextEventProcess
 
     private final ExecutorService executor;
 
+    private final IRepresentationService representationService;
+
     public EditingContextEventProcessor(IEditingContext editingContext, IEditingContextPersistenceService editingContextPersistenceService, ApplicationEventPublisher applicationEventPublisher,
-            IObjectService objectService, List<IEditingContextEventHandler> editingContextEventHandlers, IRepresentationEventProcessorComposedFactory representationEventProcessorComposedFactory) {
+            IObjectService objectService, List<IEditingContextEventHandler> editingContextEventHandlers, IRepresentationEventProcessorComposedFactory representationEventProcessorComposedFactory,
+            IRepresentationService representationService) {
+        this.representationService = representationService;
         this.editingContext = Objects.requireNonNull(editingContext);
         this.editingContextPersistenceService = Objects.requireNonNull(editingContextPersistenceService);
         this.applicationEventPublisher = Objects.requireNonNull(applicationEventPublisher);
@@ -193,6 +198,7 @@ public class EditingContextEventProcessor implements IEditingContextEventProcess
             if (this.shouldPersistTheEditingContext(response.getChangeDescription())) {
                 this.editingContextPersistenceService.persist(this.editingContext);
             }
+            this.representationService.deleteDanglingRepresentations(this.editingContext.getId());
         }
 
         return optionalResponse;

--- a/backend/sirius-web-spring-collaborative/src/main/java/org/eclipse/sirius/web/spring/collaborative/projects/EditingContextEventProcessorFactory.java
+++ b/backend/sirius-web-spring-collaborative/src/main/java/org/eclipse/sirius/web/spring/collaborative/projects/EditingContextEventProcessorFactory.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.spring.collaborative.projects;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.eclipse.sirius.web.collaborative.api.services.IEditingContextEventHandler;
+import org.eclipse.sirius.web.collaborative.api.services.IEditingContextEventProcessor;
+import org.eclipse.sirius.web.collaborative.api.services.IEditingContextEventProcessorFactory;
+import org.eclipse.sirius.web.collaborative.api.services.IRepresentationEventProcessorComposedFactory;
+import org.eclipse.sirius.web.core.api.IEditingContext;
+import org.eclipse.sirius.web.core.api.IEditingContextPersistenceService;
+import org.eclipse.sirius.web.core.api.IObjectService;
+import org.eclipse.sirius.web.services.api.representations.IRepresentationService;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+
+/**
+ * Used to create an {@link IEditingContextEventProcessor}.
+ *
+ * @author gcoutable
+ */
+@Service
+public class EditingContextEventProcessorFactory implements IEditingContextEventProcessorFactory {
+
+    private final IEditingContextPersistenceService editingContextPersistenceService;
+
+    private final ApplicationEventPublisher applicationEventPublisher;
+
+    private final IObjectService objectService;
+
+    private final List<IEditingContextEventHandler> editingContextEventHandlers;
+
+    private final IRepresentationEventProcessorComposedFactory representationEventProcessorComposedFactory;
+
+    private final IRepresentationService representationService;
+
+    public EditingContextEventProcessorFactory(IEditingContextPersistenceService editingContextPersistenceService, ApplicationEventPublisher applicationEventPublisher, IObjectService objectService,
+            List<IEditingContextEventHandler> editingContextEventHandlers, IRepresentationEventProcessorComposedFactory representationEventProcessorComposedFactory,
+            IRepresentationService representationService) {
+        this.editingContextPersistenceService = Objects.requireNonNull(editingContextPersistenceService);
+        this.applicationEventPublisher = Objects.requireNonNull(applicationEventPublisher);
+        this.objectService = Objects.requireNonNull(objectService);
+        this.editingContextEventHandlers = Objects.requireNonNull(editingContextEventHandlers);
+        this.representationEventProcessorComposedFactory = Objects.requireNonNull(representationEventProcessorComposedFactory);
+        this.representationService = Objects.requireNonNull(representationService);
+    }
+
+    @Override
+    public IEditingContextEventProcessor createEditingContextEventProcessor(IEditingContext editingContext) {
+        return new EditingContextEventProcessor(editingContext, this.editingContextPersistenceService, this.applicationEventPublisher, this.objectService, this.editingContextEventHandlers,
+                this.representationEventProcessorComposedFactory, this.representationService);
+    }
+
+}

--- a/backend/sirius-web-spring-collaborative/src/test/java/org/eclipse/sirius/web/spring/collaborative/handlers/NoOpRepresentationService.java
+++ b/backend/sirius-web-spring-collaborative/src/test/java/org/eclipse/sirius/web/spring/collaborative/handlers/NoOpRepresentationService.java
@@ -59,4 +59,8 @@ public class NoOpRepresentationService implements IRepresentationService {
     @Override
     public void delete(UUID representationId) {
     }
+
+    @Override
+    public void deleteDanglingRepresentations(UUID editingContextId) {
+    }
 }


### PR DESCRIPTION
### Type of this PR 

- [x] Bugfix

### Issue(s)

https://github.com/eclipse-sirius/sirius-components/issues/452

### What does this PR do?

It adds a service used to cleanup representations that are not bound to an object.

### How to test this PR?

- [x] Backend Unit tests
