### PR TITLE
Domain DSL: Add support for single inheritance and abstract entities

### DIFF
--- a/backend/sirius-web-domain-edit/src/main/java/org/eclipse/sirius/web/domain/provider/EntityItemProvider.java
+++ b/backend/sirius-web-domain-edit/src/main/java/org/eclipse/sirius/web/domain/provider/EntityItemProvider.java
@@ -18,6 +18,7 @@ import java.util.List;
 import org.eclipse.emf.common.notify.AdapterFactory;
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.ecore.EStructuralFeature;
+import org.eclipse.emf.edit.provider.ComposeableAdapterFactory;
 import org.eclipse.emf.edit.provider.IItemPropertyDescriptor;
 import org.eclipse.emf.edit.provider.ViewerNotification;
 import org.eclipse.sirius.web.domain.DomainFactory;
@@ -50,8 +51,21 @@ public class EntityItemProvider extends NamedElementItemProvider {
         if (this.itemPropertyDescriptors == null) {
             super.getPropertyDescriptors(object);
 
+            this.addSuperTypePropertyDescriptor(object);
         }
         return this.itemPropertyDescriptors;
+    }
+
+    /**
+     * This adds a property descriptor for the Super Type feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     */
+    protected void addSuperTypePropertyDescriptor(Object object) {
+        this.itemPropertyDescriptors.add(
+                this.createItemPropertyDescriptor(((ComposeableAdapterFactory) this.adapterFactory).getRootAdapterFactory(), this.getResourceLocator(), this.getString("_UI_Entity_superType_feature"), //$NON-NLS-1$
+                        this.getString("_UI_PropertyDescriptor_description", "_UI_Entity_superType_feature", "_UI_Entity_type"), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+                        DomainPackage.Literals.ENTITY__SUPER_TYPE, true, false, true, null, null, null));
     }
 
     /**

--- a/backend/sirius-web-domain-edit/src/main/java/org/eclipse/sirius/web/domain/provider/EntityItemProvider.java
+++ b/backend/sirius-web-domain-edit/src/main/java/org/eclipse/sirius/web/domain/provider/EntityItemProvider.java
@@ -20,6 +20,7 @@ import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.edit.provider.ComposeableAdapterFactory;
 import org.eclipse.emf.edit.provider.IItemPropertyDescriptor;
+import org.eclipse.emf.edit.provider.ItemPropertyDescriptor;
 import org.eclipse.emf.edit.provider.ViewerNotification;
 import org.eclipse.sirius.web.domain.DomainFactory;
 import org.eclipse.sirius.web.domain.DomainPackage;
@@ -52,6 +53,7 @@ public class EntityItemProvider extends NamedElementItemProvider {
             super.getPropertyDescriptors(object);
 
             this.addSuperTypePropertyDescriptor(object);
+            this.addAbstractPropertyDescriptor(object);
         }
         return this.itemPropertyDescriptors;
     }
@@ -66,6 +68,18 @@ public class EntityItemProvider extends NamedElementItemProvider {
                 this.createItemPropertyDescriptor(((ComposeableAdapterFactory) this.adapterFactory).getRootAdapterFactory(), this.getResourceLocator(), this.getString("_UI_Entity_superType_feature"), //$NON-NLS-1$
                         this.getString("_UI_PropertyDescriptor_description", "_UI_Entity_superType_feature", "_UI_Entity_type"), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
                         DomainPackage.Literals.ENTITY__SUPER_TYPE, true, false, true, null, null, null));
+    }
+
+    /**
+     * This adds a property descriptor for the Abstract feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     */
+    protected void addAbstractPropertyDescriptor(Object object) {
+        this.itemPropertyDescriptors.add(
+                this.createItemPropertyDescriptor(((ComposeableAdapterFactory) this.adapterFactory).getRootAdapterFactory(), this.getResourceLocator(), this.getString("_UI_Entity_abstract_feature"), //$NON-NLS-1$
+                        this.getString("_UI_PropertyDescriptor_description", "_UI_Entity_abstract_feature", "_UI_Entity_type"), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+                        DomainPackage.Literals.ENTITY__ABSTRACT, true, false, false, ItemPropertyDescriptor.BOOLEAN_VALUE_IMAGE, null, null));
     }
 
     /**
@@ -143,6 +157,9 @@ public class EntityItemProvider extends NamedElementItemProvider {
         this.updateChildren(notification);
 
         switch (notification.getFeatureID(Entity.class)) {
+        case DomainPackage.ENTITY__ABSTRACT:
+            this.fireNotifyChanged(new ViewerNotification(notification, notification.getNotifier(), false, true));
+            return;
         case DomainPackage.ENTITY__ATTRIBUTES:
         case DomainPackage.ENTITY__RELATIONS:
             this.fireNotifyChanged(new ViewerNotification(notification, notification.getNotifier(), true, false));

--- a/backend/sirius-web-domain-edit/src/main/resources/plugin.properties
+++ b/backend/sirius-web-domain-edit/src/main/resources/plugin.properties
@@ -36,6 +36,7 @@ _UI_Domain_uri_feature = Uri
 _UI_Domain_types_feature = Types
 _UI_Entity_attributes_feature = Attributes
 _UI_Entity_relations_feature = Relations
+_UI_Entity_superType_feature = Super Type
 _UI_Feature_optional_feature = Optional
 _UI_Feature_many_feature = Many
 _UI_Attribute_type_feature = Type

--- a/backend/sirius-web-domain-edit/src/main/resources/plugin.properties
+++ b/backend/sirius-web-domain-edit/src/main/resources/plugin.properties
@@ -37,6 +37,7 @@ _UI_Domain_types_feature = Types
 _UI_Entity_attributes_feature = Attributes
 _UI_Entity_relations_feature = Relations
 _UI_Entity_superType_feature = Super Type
+_UI_Entity_abstract_feature = Abstract
 _UI_Feature_optional_feature = Optional
 _UI_Feature_many_feature = Many
 _UI_Attribute_type_feature = Type

--- a/backend/sirius-web-domain/plugin.xml
+++ b/backend/sirius-web-domain/plugin.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?eclipse version="3.0"?>
+
+<!--
+ Copyright (c) 2021 Obeo.
+ This program and the accompanying materials
+ are made available under the terms of the Eclipse Public License v2.0
+ which accompanies this distribution, and is available at
+ https://www.eclipse.org/legal/epl-2.0/
+ 
+ SPDX-License-Identifier: EPL-2.0
+ 
+ Contributors:
+      Obeo - initial API and implementation
+-->
+
+<plugin
+      name="%pluginName"
+      id="sirius-web-domain"
+      version="1.0.0"
+      provider-name="%providerName">
+
+   <requires>
+      <import plugin="org.eclipse.core.runtime"/>
+      <import plugin="org.eclipse.emf.ecore" export="true"/>
+   </requires>
+
+   <runtime>
+      <library name=".">
+         <export name="*"/>
+      </library>
+   </runtime>
+
+   <extension point="org.eclipse.emf.ecore.generated_package">
+      <!-- @generated domain -->
+      <package
+            uri="http://www.eclipse.org/sirius-web/domain"
+            class="org.eclipse.sirius.web.domain.DomainPackage"
+            genModel="src/main/resources/model/domain.genmodel"/>
+   </extension>
+
+</plugin>

--- a/backend/sirius-web-domain/src/main/java/org/eclipse/sirius/web/domain/DomainPackage.java
+++ b/backend/sirius-web-domain/src/main/java/org/eclipse/sirius/web/domain/DomainPackage.java
@@ -193,12 +193,20 @@ public interface DomainPackage extends EPackage {
     int ENTITY__SUPER_TYPE = NAMED_ELEMENT_FEATURE_COUNT + 2;
 
     /**
+     * The feature id for the '<em><b>Abstract</b></em>' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     * @ordered
+     */
+    int ENTITY__ABSTRACT = NAMED_ELEMENT_FEATURE_COUNT + 3;
+
+    /**
      * The number of structural features of the '<em>Entity</em>' class. <!-- begin-user-doc --> <!-- end-user-doc -->
      *
      * @generated
      * @ordered
      */
-    int ENTITY_FEATURE_COUNT = NAMED_ELEMENT_FEATURE_COUNT + 3;
+    int ENTITY_FEATURE_COUNT = NAMED_ELEMENT_FEATURE_COUNT + 4;
 
     /**
      * The number of operations of the '<em>Entity</em>' class. <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -492,6 +500,17 @@ public interface DomainPackage extends EPackage {
     EReference getEntity_SuperType();
 
     /**
+     * Returns the meta object for the attribute '{@link org.eclipse.sirius.web.domain.Entity#isAbstract
+     * <em>Abstract</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @return the meta object for the attribute '<em>Abstract</em>'.
+     * @see org.eclipse.sirius.web.domain.Entity#isAbstract()
+     * @see #getEntity()
+     * @generated
+     */
+    EAttribute getEntity_Abstract();
+
+    /**
      * Returns the meta object for class '{@link org.eclipse.sirius.web.domain.Feature <em>Feature</em>}'. <!--
      * begin-user-doc --> <!-- end-user-doc -->
      *
@@ -685,6 +704,14 @@ public interface DomainPackage extends EPackage {
          * @generated
          */
         EReference ENTITY__SUPER_TYPE = eINSTANCE.getEntity_SuperType();
+
+        /**
+         * The meta object literal for the '<em><b>Abstract</b></em>' attribute feature. <!-- begin-user-doc --> <!--
+         * end-user-doc -->
+         *
+         * @generated
+         */
+        EAttribute ENTITY__ABSTRACT = eINSTANCE.getEntity_Abstract();
 
         /**
          * The meta object literal for the '{@link org.eclipse.sirius.web.domain.impl.FeatureImpl <em>Feature</em>}'

--- a/backend/sirius-web-domain/src/main/java/org/eclipse/sirius/web/domain/DomainPackage.java
+++ b/backend/sirius-web-domain/src/main/java/org/eclipse/sirius/web/domain/DomainPackage.java
@@ -185,12 +185,20 @@ public interface DomainPackage extends EPackage {
     int ENTITY__RELATIONS = NAMED_ELEMENT_FEATURE_COUNT + 1;
 
     /**
+     * The feature id for the '<em><b>Super Type</b></em>' reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     * @ordered
+     */
+    int ENTITY__SUPER_TYPE = NAMED_ELEMENT_FEATURE_COUNT + 2;
+
+    /**
      * The number of structural features of the '<em>Entity</em>' class. <!-- begin-user-doc --> <!-- end-user-doc -->
      *
      * @generated
      * @ordered
      */
-    int ENTITY_FEATURE_COUNT = NAMED_ELEMENT_FEATURE_COUNT + 2;
+    int ENTITY_FEATURE_COUNT = NAMED_ELEMENT_FEATURE_COUNT + 3;
 
     /**
      * The number of operations of the '<em>Entity</em>' class. <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -473,6 +481,17 @@ public interface DomainPackage extends EPackage {
     EReference getEntity_Relations();
 
     /**
+     * Returns the meta object for the reference '{@link org.eclipse.sirius.web.domain.Entity#getSuperType <em>Super
+     * Type</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @return the meta object for the reference '<em>Super Type</em>'.
+     * @see org.eclipse.sirius.web.domain.Entity#getSuperType()
+     * @see #getEntity()
+     * @generated
+     */
+    EReference getEntity_SuperType();
+
+    /**
      * Returns the meta object for class '{@link org.eclipse.sirius.web.domain.Feature <em>Feature</em>}'. <!--
      * begin-user-doc --> <!-- end-user-doc -->
      *
@@ -658,6 +677,14 @@ public interface DomainPackage extends EPackage {
          * @generated
          */
         EReference ENTITY__RELATIONS = eINSTANCE.getEntity_Relations();
+
+        /**
+         * The meta object literal for the '<em><b>Super Type</b></em>' reference feature. <!-- begin-user-doc --> <!--
+         * end-user-doc -->
+         *
+         * @generated
+         */
+        EReference ENTITY__SUPER_TYPE = eINSTANCE.getEntity_SuperType();
 
         /**
          * The meta object literal for the '{@link org.eclipse.sirius.web.domain.impl.FeatureImpl <em>Feature</em>}'

--- a/backend/sirius-web-domain/src/main/java/org/eclipse/sirius/web/domain/Entity.java
+++ b/backend/sirius-web-domain/src/main/java/org/eclipse/sirius/web/domain/Entity.java
@@ -24,6 +24,7 @@ import org.eclipse.emf.common.util.EList;
  * <li>{@link org.eclipse.sirius.web.domain.Entity#getAttributes <em>Attributes</em>}</li>
  * <li>{@link org.eclipse.sirius.web.domain.Entity#getRelations <em>Relations</em>}</li>
  * <li>{@link org.eclipse.sirius.web.domain.Entity#getSuperType <em>Super Type</em>}</li>
+ * <li>{@link org.eclipse.sirius.web.domain.Entity#isAbstract <em>Abstract</em>}</li>
  * </ul>
  *
  * @see org.eclipse.sirius.web.domain.DomainPackage#getEntity()
@@ -74,5 +75,27 @@ public interface Entity extends NamedElement {
      * @generated
      */
     void setSuperType(Entity value);
+
+    /**
+     * Returns the value of the '<em><b>Abstract</b></em>' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @return the value of the '<em>Abstract</em>' attribute.
+     * @see #setAbstract(boolean)
+     * @see org.eclipse.sirius.web.domain.DomainPackage#getEntity_Abstract()
+     * @model required="true"
+     * @generated
+     */
+    boolean isAbstract();
+
+    /**
+     * Sets the value of the '{@link org.eclipse.sirius.web.domain.Entity#isAbstract <em>Abstract</em>}' attribute. <!--
+     * begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @param value
+     *            the new value of the '<em>Abstract</em>' attribute.
+     * @see #isAbstract()
+     * @generated
+     */
+    void setAbstract(boolean value);
 
 } // Entity

--- a/backend/sirius-web-domain/src/main/java/org/eclipse/sirius/web/domain/Entity.java
+++ b/backend/sirius-web-domain/src/main/java/org/eclipse/sirius/web/domain/Entity.java
@@ -23,6 +23,7 @@ import org.eclipse.emf.common.util.EList;
  * <ul>
  * <li>{@link org.eclipse.sirius.web.domain.Entity#getAttributes <em>Attributes</em>}</li>
  * <li>{@link org.eclipse.sirius.web.domain.Entity#getRelations <em>Relations</em>}</li>
+ * <li>{@link org.eclipse.sirius.web.domain.Entity#getSuperType <em>Super Type</em>}</li>
  * </ul>
  *
  * @see org.eclipse.sirius.web.domain.DomainPackage#getEntity()
@@ -51,5 +52,27 @@ public interface Entity extends NamedElement {
      * @generated
      */
     EList<Relation> getRelations();
+
+    /**
+     * Returns the value of the '<em><b>Super Type</b></em>' reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @return the value of the '<em>Super Type</em>' reference.
+     * @see #setSuperType(Entity)
+     * @see org.eclipse.sirius.web.domain.DomainPackage#getEntity_SuperType()
+     * @model
+     * @generated
+     */
+    Entity getSuperType();
+
+    /**
+     * Sets the value of the '{@link org.eclipse.sirius.web.domain.Entity#getSuperType <em>Super Type</em>}' reference.
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @param value
+     *            the new value of the '<em>Super Type</em>' reference.
+     * @see #getSuperType()
+     * @generated
+     */
+    void setSuperType(Entity value);
 
 } // Entity

--- a/backend/sirius-web-domain/src/main/java/org/eclipse/sirius/web/domain/impl/DomainPackageImpl.java
+++ b/backend/sirius-web-domain/src/main/java/org/eclipse/sirius/web/domain/impl/DomainPackageImpl.java
@@ -230,6 +230,16 @@ public class DomainPackageImpl extends EPackageImpl implements DomainPackage {
      * @generated
      */
     @Override
+    public EReference getEntity_SuperType() {
+        return (EReference) this.entityEClass.getEStructuralFeatures().get(2);
+    }
+
+    /**
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     */
+    @Override
     public EClass getFeature() {
         return this.featureEClass;
     }
@@ -353,6 +363,7 @@ public class DomainPackageImpl extends EPackageImpl implements DomainPackage {
         this.entityEClass = this.createEClass(ENTITY);
         this.createEReference(this.entityEClass, ENTITY__ATTRIBUTES);
         this.createEReference(this.entityEClass, ENTITY__RELATIONS);
+        this.createEReference(this.entityEClass, ENTITY__SUPER_TYPE);
 
         this.featureEClass = this.createEClass(FEATURE);
         this.createEAttribute(this.featureEClass, FEATURE__OPTIONAL);
@@ -418,6 +429,8 @@ public class DomainPackageImpl extends EPackageImpl implements DomainPackage {
         this.initEReference(this.getEntity_Attributes(), this.getAttribute(), null, "attributes", null, 0, -1, Entity.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, //$NON-NLS-1$
                 !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
         this.initEReference(this.getEntity_Relations(), this.getRelation(), null, "relations", null, 0, -1, Entity.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, //$NON-NLS-1$
+                !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+        this.initEReference(this.getEntity_SuperType(), this.getEntity(), null, "superType", null, 0, 1, Entity.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, //$NON-NLS-1$
                 !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
         this.initEClass(this.featureEClass, Feature.class, "Feature", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$

--- a/backend/sirius-web-domain/src/main/java/org/eclipse/sirius/web/domain/impl/DomainPackageImpl.java
+++ b/backend/sirius-web-domain/src/main/java/org/eclipse/sirius/web/domain/impl/DomainPackageImpl.java
@@ -240,6 +240,16 @@ public class DomainPackageImpl extends EPackageImpl implements DomainPackage {
      * @generated
      */
     @Override
+    public EAttribute getEntity_Abstract() {
+        return (EAttribute) this.entityEClass.getEStructuralFeatures().get(3);
+    }
+
+    /**
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     */
+    @Override
     public EClass getFeature() {
         return this.featureEClass;
     }
@@ -364,6 +374,7 @@ public class DomainPackageImpl extends EPackageImpl implements DomainPackage {
         this.createEReference(this.entityEClass, ENTITY__ATTRIBUTES);
         this.createEReference(this.entityEClass, ENTITY__RELATIONS);
         this.createEReference(this.entityEClass, ENTITY__SUPER_TYPE);
+        this.createEAttribute(this.entityEClass, ENTITY__ABSTRACT);
 
         this.featureEClass = this.createEClass(FEATURE);
         this.createEAttribute(this.featureEClass, FEATURE__OPTIONAL);
@@ -432,6 +443,8 @@ public class DomainPackageImpl extends EPackageImpl implements DomainPackage {
                 !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
         this.initEReference(this.getEntity_SuperType(), this.getEntity(), null, "superType", null, 0, 1, Entity.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, //$NON-NLS-1$
                 !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+        this.initEAttribute(this.getEntity_Abstract(), this.ecorePackage.getEBoolean(), "abstract", null, 1, 1, Entity.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, //$NON-NLS-1$
+                IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
         this.initEClass(this.featureEClass, Feature.class, "Feature", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
         this.initEAttribute(this.getFeature_Optional(), this.ecorePackage.getEBoolean(), "optional", "false", 1, 1, Feature.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, //$NON-NLS-1$//$NON-NLS-2$

--- a/backend/sirius-web-domain/src/main/java/org/eclipse/sirius/web/domain/impl/EntityImpl.java
+++ b/backend/sirius-web-domain/src/main/java/org/eclipse/sirius/web/domain/impl/EntityImpl.java
@@ -36,6 +36,7 @@ import org.eclipse.sirius.web.domain.Relation;
  * <li>{@link org.eclipse.sirius.web.domain.impl.EntityImpl#getAttributes <em>Attributes</em>}</li>
  * <li>{@link org.eclipse.sirius.web.domain.impl.EntityImpl#getRelations <em>Relations</em>}</li>
  * <li>{@link org.eclipse.sirius.web.domain.impl.EntityImpl#getSuperType <em>Super Type</em>}</li>
+ * <li>{@link org.eclipse.sirius.web.domain.impl.EntityImpl#isAbstract <em>Abstract</em>}</li>
  * </ul>
  *
  * @generated
@@ -70,6 +71,26 @@ public class EntityImpl extends NamedElementImpl implements Entity {
      * @ordered
      */
     protected Entity superType;
+
+    /**
+     * The default value of the '{@link #isAbstract() <em>Abstract</em>}' attribute. <!-- begin-user-doc --> <!--
+     * end-user-doc -->
+     *
+     * @see #isAbstract()
+     * @generated
+     * @ordered
+     */
+    protected static final boolean ABSTRACT_EDEFAULT = false;
+
+    /**
+     * The cached value of the '{@link #isAbstract() <em>Abstract</em>}' attribute. <!-- begin-user-doc --> <!--
+     * end-user-doc -->
+     *
+     * @see #isAbstract()
+     * @generated
+     * @ordered
+     */
+    protected boolean abstract_ = ABSTRACT_EDEFAULT;
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -162,6 +183,29 @@ public class EntityImpl extends NamedElementImpl implements Entity {
      * @generated
      */
     @Override
+    public boolean isAbstract() {
+        return this.abstract_;
+    }
+
+    /**
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     */
+    @Override
+    public void setAbstract(boolean newAbstract) {
+        boolean oldAbstract = this.abstract_;
+        this.abstract_ = newAbstract;
+        if (this.eNotificationRequired())
+            this.eNotify(new ENotificationImpl(this, Notification.SET, DomainPackage.ENTITY__ABSTRACT, oldAbstract, this.abstract_));
+    }
+
+    /**
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     */
+    @Override
     public NotificationChain eInverseRemove(InternalEObject otherEnd, int featureID, NotificationChain msgs) {
         switch (featureID) {
         case DomainPackage.ENTITY__ATTRIBUTES:
@@ -188,6 +232,8 @@ public class EntityImpl extends NamedElementImpl implements Entity {
             if (resolve)
                 return this.getSuperType();
             return this.basicGetSuperType();
+        case DomainPackage.ENTITY__ABSTRACT:
+            return this.isAbstract();
         }
         return super.eGet(featureID, resolve, coreType);
     }
@@ -212,6 +258,9 @@ public class EntityImpl extends NamedElementImpl implements Entity {
         case DomainPackage.ENTITY__SUPER_TYPE:
             this.setSuperType((Entity) newValue);
             return;
+        case DomainPackage.ENTITY__ABSTRACT:
+            this.setAbstract((Boolean) newValue);
+            return;
         }
         super.eSet(featureID, newValue);
     }
@@ -233,6 +282,9 @@ public class EntityImpl extends NamedElementImpl implements Entity {
         case DomainPackage.ENTITY__SUPER_TYPE:
             this.setSuperType((Entity) null);
             return;
+        case DomainPackage.ENTITY__ABSTRACT:
+            this.setAbstract(ABSTRACT_EDEFAULT);
+            return;
         }
         super.eUnset(featureID);
     }
@@ -251,8 +303,27 @@ public class EntityImpl extends NamedElementImpl implements Entity {
             return this.relations != null && !this.relations.isEmpty();
         case DomainPackage.ENTITY__SUPER_TYPE:
             return this.superType != null;
+        case DomainPackage.ENTITY__ABSTRACT:
+            return this.abstract_ != ABSTRACT_EDEFAULT;
         }
         return super.eIsSet(featureID);
+    }
+
+    /**
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     */
+    @Override
+    public String toString() {
+        if (this.eIsProxy())
+            return super.toString();
+
+        StringBuilder result = new StringBuilder(super.toString());
+        result.append(" (abstract: "); //$NON-NLS-1$
+        result.append(this.abstract_);
+        result.append(')');
+        return result.toString();
     }
 
 } // EntityImpl

--- a/backend/sirius-web-domain/src/main/java/org/eclipse/sirius/web/domain/impl/EntityImpl.java
+++ b/backend/sirius-web-domain/src/main/java/org/eclipse/sirius/web/domain/impl/EntityImpl.java
@@ -14,10 +14,12 @@ package org.eclipse.sirius.web.domain.impl;
 
 import java.util.Collection;
 
+import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.notify.NotificationChain;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.InternalEObject;
+import org.eclipse.emf.ecore.impl.ENotificationImpl;
 import org.eclipse.emf.ecore.util.EObjectContainmentEList;
 import org.eclipse.emf.ecore.util.InternalEList;
 import org.eclipse.sirius.web.domain.Attribute;
@@ -33,6 +35,7 @@ import org.eclipse.sirius.web.domain.Relation;
  * <ul>
  * <li>{@link org.eclipse.sirius.web.domain.impl.EntityImpl#getAttributes <em>Attributes</em>}</li>
  * <li>{@link org.eclipse.sirius.web.domain.impl.EntityImpl#getRelations <em>Relations</em>}</li>
+ * <li>{@link org.eclipse.sirius.web.domain.impl.EntityImpl#getSuperType <em>Super Type</em>}</li>
  * </ul>
  *
  * @generated
@@ -57,6 +60,16 @@ public class EntityImpl extends NamedElementImpl implements Entity {
      * @ordered
      */
     protected EList<Relation> relations;
+
+    /**
+     * The cached value of the '{@link #getSuperType() <em>Super Type</em>}' reference. <!-- begin-user-doc --> <!--
+     * end-user-doc -->
+     *
+     * @see #getSuperType()
+     * @generated
+     * @ordered
+     */
+    protected Entity superType;
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -109,6 +122,46 @@ public class EntityImpl extends NamedElementImpl implements Entity {
      * @generated
      */
     @Override
+    public Entity getSuperType() {
+        if (this.superType != null && this.superType.eIsProxy()) {
+            InternalEObject oldSuperType = (InternalEObject) this.superType;
+            this.superType = (Entity) this.eResolveProxy(oldSuperType);
+            if (this.superType != oldSuperType) {
+                if (this.eNotificationRequired())
+                    this.eNotify(new ENotificationImpl(this, Notification.RESOLVE, DomainPackage.ENTITY__SUPER_TYPE, oldSuperType, this.superType));
+            }
+        }
+        return this.superType;
+    }
+
+    /**
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     */
+    public Entity basicGetSuperType() {
+        return this.superType;
+    }
+
+    /**
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     */
+    @Override
+    public void setSuperType(Entity newSuperType) {
+        Entity oldSuperType = this.superType;
+        this.superType = newSuperType;
+        if (this.eNotificationRequired())
+            this.eNotify(new ENotificationImpl(this, Notification.SET, DomainPackage.ENTITY__SUPER_TYPE, oldSuperType, this.superType));
+    }
+
+    /**
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     */
+    @Override
     public NotificationChain eInverseRemove(InternalEObject otherEnd, int featureID, NotificationChain msgs) {
         switch (featureID) {
         case DomainPackage.ENTITY__ATTRIBUTES:
@@ -131,6 +184,10 @@ public class EntityImpl extends NamedElementImpl implements Entity {
             return this.getAttributes();
         case DomainPackage.ENTITY__RELATIONS:
             return this.getRelations();
+        case DomainPackage.ENTITY__SUPER_TYPE:
+            if (resolve)
+                return this.getSuperType();
+            return this.basicGetSuperType();
         }
         return super.eGet(featureID, resolve, coreType);
     }
@@ -152,6 +209,9 @@ public class EntityImpl extends NamedElementImpl implements Entity {
             this.getRelations().clear();
             this.getRelations().addAll((Collection<? extends Relation>) newValue);
             return;
+        case DomainPackage.ENTITY__SUPER_TYPE:
+            this.setSuperType((Entity) newValue);
+            return;
         }
         super.eSet(featureID, newValue);
     }
@@ -170,6 +230,9 @@ public class EntityImpl extends NamedElementImpl implements Entity {
         case DomainPackage.ENTITY__RELATIONS:
             this.getRelations().clear();
             return;
+        case DomainPackage.ENTITY__SUPER_TYPE:
+            this.setSuperType((Entity) null);
+            return;
         }
         super.eUnset(featureID);
     }
@@ -186,6 +249,8 @@ public class EntityImpl extends NamedElementImpl implements Entity {
             return this.attributes != null && !this.attributes.isEmpty();
         case DomainPackage.ENTITY__RELATIONS:
             return this.relations != null && !this.relations.isEmpty();
+        case DomainPackage.ENTITY__SUPER_TYPE:
+            return this.superType != null;
         }
         return super.eIsSet(featureID);
     }

--- a/backend/sirius-web-domain/src/main/resources/model/domain.ecore
+++ b/backend/sirius-web-domain/src/main/resources/model/domain.ecore
@@ -14,6 +14,7 @@
         eType="#//Attribute" containment="true"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="relations" upperBound="-1"
         eType="#//Relation" containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="superType" eType="#//Entity"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="Feature" eSuperTypes="#//NamedElement">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="optional" lowerBound="1"

--- a/backend/sirius-web-domain/src/main/resources/model/domain.ecore
+++ b/backend/sirius-web-domain/src/main/resources/model/domain.ecore
@@ -15,6 +15,8 @@
     <eStructuralFeatures xsi:type="ecore:EReference" name="relations" upperBound="-1"
         eType="#//Relation" containment="true"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="superType" eType="#//Entity"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="abstract" lowerBound="1"
+        eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="Feature" eSuperTypes="#//NamedElement">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="optional" lowerBound="1"

--- a/backend/sirius-web-domain/src/main/resources/model/domain.genmodel
+++ b/backend/sirius-web-domain/src/main/resources/model/domain.genmodel
@@ -29,6 +29,7 @@
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference domain.ecore#//Entity/attributes"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference domain.ecore#//Entity/relations"/>
       <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference domain.ecore#//Entity/superType"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute domain.ecore#//Entity/abstract"/>
     </genClasses>
     <genClasses ecoreClass="domain.ecore#//Feature">
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute domain.ecore#//Feature/optional"/>

--- a/backend/sirius-web-domain/src/main/resources/model/domain.genmodel
+++ b/backend/sirius-web-domain/src/main/resources/model/domain.genmodel
@@ -28,6 +28,7 @@
     <genClasses ecoreClass="domain.ecore#//Entity">
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference domain.ecore#//Entity/attributes"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference domain.ecore#//Entity/relations"/>
+      <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference domain.ecore#//Entity/superType"/>
     </genClasses>
     <genClasses ecoreClass="domain.ecore#//Feature">
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute domain.ecore#//Feature/optional"/>

--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/domain/DomainConverter.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/domain/DomainConverter.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package org.eclipse.sirius.web.emf.domain;
 
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -27,6 +29,7 @@ import org.eclipse.emf.ecore.EcorePackage;
 import org.eclipse.emf.ecore.util.Diagnostician;
 import org.eclipse.sirius.web.domain.Attribute;
 import org.eclipse.sirius.web.domain.Domain;
+import org.eclipse.sirius.web.domain.DomainFactory;
 import org.eclipse.sirius.web.domain.Entity;
 import org.eclipse.sirius.web.domain.Feature;
 import org.eclipse.sirius.web.domain.Relation;
@@ -45,30 +48,56 @@ public class DomainConverter {
         ePackage.setNsURI(domain.getUri());
 
         Map<Entity, EClass> convertedTypes = new HashMap<>();
-        for (Entity entity : domain.getTypes()) {
-            EClass eClass = this.convert(entity);
-            convertedTypes.put(entity, eClass);
-            ePackage.getEClassifiers().add(eClass);
-        }
-        for (Entity entity : domain.getTypes()) {
-            EClass eClass = convertedTypes.get(entity);
-            for (Relation relation : entity.getRelations()) {
-                EReference eReference = this.convert(relation, convertedTypes);
-                eClass.getEStructuralFeatures().add(eReference);
+        // We need to make multiple passes to handle inheritance, as an Entity can only be converted
+        // once all its super types have been. We could use a topological sort to iterate in the correct
+        // order but it seems simpler to simply make multiple passes until all types are converted.
+        Deque<Entity> leftToConvert = new ArrayDeque<>(domain.getTypes());
+        Entity sentinel = DomainFactory.eINSTANCE.createEntity();
+        leftToConvert.addLast(sentinel);
+        // The worst case happens when we can only find and convert a single type on each pass.
+        // If we need more passes than that, it means at least one pass did not find any type that
+        // has all its parents already converted, and thus there is an inheritance loop.
+        int maxPasses = domain.getTypes().size();
+        int nbPasses = 0;
+        while (leftToConvert.size() > 1 && nbPasses <= maxPasses) {
+            Entity candidate = leftToConvert.pop();
+            if (candidate == sentinel) {
+                // We've hit the end of the queue, i.e. finished a single pass
+                nbPasses++;
+                leftToConvert.addLast(sentinel);
+            } else if (Optional.ofNullable(candidate.getSuperType()).stream().allMatch(convertedTypes::containsKey)) {
+                // candidate can be converted if all its super types have already been
+                EClass eClass = this.convert(candidate, convertedTypes);
+                convertedTypes.put(candidate, eClass);
+                ePackage.getEClassifiers().add(eClass);
+            } else {
+                // Try again in the next pass if we have converted all its super-types
+                leftToConvert.addLast(candidate);
             }
         }
-        Diagnostic diagnostic = Diagnostician.INSTANCE.validate(ePackage);
-        if (diagnostic.getSeverity() >= Diagnostic.ERROR) {
-            return Optional.empty();
-        } else {
-            return Optional.of(ePackage);
+        if (leftToConvert.isEmpty()) {
+            for (Entity entity : domain.getTypes()) {
+                EClass eClass = convertedTypes.get(entity);
+                for (Relation relation : entity.getRelations()) {
+                    EReference eReference = this.convert(relation, convertedTypes);
+                    eClass.getEStructuralFeatures().add(eReference);
+                }
+            }
+            Diagnostic diagnostic = Diagnostician.INSTANCE.validate(ePackage);
+            if (diagnostic.getSeverity() < Diagnostic.ERROR) {
+                return Optional.of(ePackage);
+            }
         }
+        return Optional.empty();
     }
 
-    private EClass convert(Entity entity) {
+    private EClass convert(Entity entity, Map<Entity, EClass> convertedTypes) {
         EClass eClass = EcoreFactory.eINSTANCE.createEClass();
         eClass.setName(entity.getName());
         entity.getAttributes().forEach(attribute -> eClass.getEStructuralFeatures().add(this.convert(attribute)));
+        if (entity.getSuperType() != null && convertedTypes.containsKey(entity.getSuperType())) {
+            eClass.getESuperTypes().add(convertedTypes.get(entity.getSuperType()));
+        }
         return eClass;
     }
 

--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/domain/DomainConverter.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/domain/DomainConverter.java
@@ -94,6 +94,7 @@ public class DomainConverter {
     private EClass convert(Entity entity, Map<Entity, EClass> convertedTypes) {
         EClass eClass = EcoreFactory.eINSTANCE.createEClass();
         eClass.setName(entity.getName());
+        eClass.setAbstract(entity.isAbstract());
         entity.getAttributes().forEach(attribute -> eClass.getEStructuralFeatures().add(this.convert(attribute)));
         if (entity.getSuperType() != null && convertedTypes.containsKey(entity.getSuperType())) {
             eClass.getESuperTypes().add(convertedTypes.get(entity.getSuperType()));


### PR DESCRIPTION
The only "tricky" part of the PR is how `DomainConverter` handles inheritance. It might be a little more complex than needed for handling single inheritance, but the code is 99% ready to support mulitple inheritance when we add it.

The rest is trivial changes in the `ecore` and the corresponding regen.