### PR TITLE
[325] Move ViewExtensionDescriptionConverter to sirius-web-compatibility

### DIFF
--- a/backend/sirius-web-compatibility/src/main/java/org/eclipse/sirius/web/compat/forms/ViewExtensionDescriptionConverter.java
+++ b/backend/sirius-web-compatibility/src/main/java/org/eclipse/sirius/web/compat/forms/ViewExtensionDescriptionConverter.java
@@ -10,7 +10,7 @@
  * Contributors:
  *     Obeo - initial API and implementation
  *******************************************************************************/
-package org.eclipse.sirius.web.emf.compatibility.properties;
+package org.eclipse.sirius.web.compat.forms;
 
 import java.util.HashMap;
 import java.util.List;
@@ -22,15 +22,13 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.eclipse.sirius.properties.ViewExtensionDescription;
+import org.eclipse.sirius.web.compat.api.IAQLInterpreterFactory;
 import org.eclipse.sirius.web.compat.api.IIdentifierProvider;
 import org.eclipse.sirius.web.compat.api.IModelOperationHandlerSwitchProvider;
 import org.eclipse.sirius.web.compat.api.ISemanticCandidatesProviderFactory;
-import org.eclipse.sirius.web.compat.forms.GroupDescriptionConverter;
-import org.eclipse.sirius.web.compat.forms.PageDescriptionConverter;
 import org.eclipse.sirius.web.compat.services.forms.api.IViewExtensionDescriptionConverter;
 import org.eclipse.sirius.web.compat.services.representations.IdentifiedElementLabelProvider;
 import org.eclipse.sirius.web.core.api.IObjectService;
-import org.eclipse.sirius.web.emf.compatibility.AQLInterpreterFactory;
 import org.eclipse.sirius.web.forms.description.FormDescription;
 import org.eclipse.sirius.web.forms.description.GroupDescription;
 import org.eclipse.sirius.web.forms.description.PageDescription;
@@ -49,7 +47,7 @@ public class ViewExtensionDescriptionConverter implements IViewExtensionDescript
 
     private final IObjectService objectService;
 
-    private final AQLInterpreterFactory interpreterFactory;
+    private final IAQLInterpreterFactory interpreterFactory;
 
     private final IIdentifierProvider identifierProvider;
 
@@ -59,7 +57,7 @@ public class ViewExtensionDescriptionConverter implements IViewExtensionDescript
 
     private final IdentifiedElementLabelProvider identifiedElementLabelProvider;
 
-    public ViewExtensionDescriptionConverter(IObjectService objectService, AQLInterpreterFactory interpreterFactory, IIdentifierProvider identifierProvider,
+    public ViewExtensionDescriptionConverter(IObjectService objectService, IAQLInterpreterFactory interpreterFactory, IIdentifierProvider identifierProvider,
             ISemanticCandidatesProviderFactory semanticCandidatesProviderFactory, IModelOperationHandlerSwitchProvider modelOperationHandlerSwitchProvider,
             IdentifiedElementLabelProvider identifiedElementLabelProvider) {
         this.objectService = Objects.requireNonNull(objectService);

--- a/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/compatibility/properties/FormRendererTestCases.java
+++ b/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/compatibility/properties/FormRendererTestCases.java
@@ -26,6 +26,7 @@ import org.eclipse.sirius.properties.ViewExtensionDescription;
 import org.eclipse.sirius.web.compat.api.IIdentifierProvider;
 import org.eclipse.sirius.web.compat.api.IModelOperationHandlerSwitchProvider;
 import org.eclipse.sirius.web.compat.api.ISemanticCandidatesProviderFactory;
+import org.eclipse.sirius.web.compat.forms.ViewExtensionDescriptionConverter;
 import org.eclipse.sirius.web.compat.services.representations.IdentifiedElementLabelProvider;
 import org.eclipse.sirius.web.components.Element;
 import org.eclipse.sirius.web.emf.compatibility.AQLInterpreterFactory;


### PR DESCRIPTION
Bug: #325
Signed-off-by: j-barata <jean.barata@thalesgroup.com>

### Type of this PR 

- [ ] Bug fix
- [x] New feature or improvement
- [ ] Documentation
- [ ] Cleanup
- [ ] Test
- [ ] Build/Releng

### Issue(s)

#325

### What does this PR do?

...

### Screenshot/screencast of this PR

...
 

### Potential side effects

...

### How to test this PR?

- [ ] Frontend Unit tests
- [x] Backend Unit tests
- [ ] Cypress : please specify
- [ ] Manual Test : please specify

### Checklist

- [x] I have read CONTRIBUTING carefully.
- [x] I have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All my commits are signed-off (`-s`) with my mail address of my Eclipse Account.
- [ ] I have covered my changes by unit tests or integration tests or manual tests.
- [x] All tests pass.
- [ ] I have updated the documentation accordingly
- [ ] New React components are availables in storybook
