### PR TITLE
[fix] Force the use of guava 30

### DIFF
--- a/backend/sirius-web-diagrams-layout/pom.xml
+++ b/backend/sirius-web-diagrams-layout/pom.xml
@@ -38,8 +38,22 @@
 			<url>https://maven.pkg.github.com/eclipse-sirius/sirius-components</url>
 		</repository>
 	</distributionManagement>
+	
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>com.google.guava</groupId>
+				<artifactId>guava</artifactId>
+				<version>30.0-jre</version>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
 
 	<dependencies>
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-context</artifactId>
@@ -67,6 +81,12 @@
 			<groupId>org.eclipse.elk</groupId>
 			<artifactId> org.eclipse.elk.graph</artifactId>
 			<version>${elk.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>com.google.guava</groupId>
+					<artifactId>guava</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.elk</groupId>


### PR DESCRIPTION
### Type of this PR 

- [x] Bug fix
- [x] Build/Releng

### What does this PR do?

In its plug-in dependencies, ELK requires guava [15,19), but, since a
recent version ELK uses guava Streams which have been introduced in
guava 21.
To prevent ClassNotFoundException to occur because of guava Streams we
force the use of guava 30.

We will be able to revert this commit when ELK 0.8.0 will be released
