### PR TITLE
[532] Improve explorer child creation

### DIFF
--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/services/EditService.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/services/EditService.java
@@ -202,7 +202,10 @@ public class EditService implements IEditService {
         editingDomain.getCommandStack().execute(createChildCommand);
         Collection<?> result = createChildCommand.getResult();
         if (result.size() == 1) {
-            objectOptional = Optional.of(result.iterator().next());
+            Object child = result.iterator().next();
+            if (child instanceof EObject && EcoreUtil.isAncestor(eObject, (EObject) child)) {
+                objectOptional = Optional.of(child);
+            }
         }
         return objectOptional;
     }

--- a/frontend/src/modals/new-object/NewObjectModal.tsx
+++ b/frontend/src/modals/new-object/NewObjectModal.tsx
@@ -27,6 +27,8 @@ import { useMachine } from '@xstate/react';
 import gql from 'graphql-tag';
 import {
   GQLCreateChildMutationData,
+  GQLCreateChildPayload,
+  GQLErrorPayload,
   GQLGetChildCreationDescriptionsQueryData,
   GQLGetChildCreationDescriptionsQueryVariables,
   NewObjectModalProps,
@@ -86,6 +88,9 @@ const useNewObjectModalStyles = makeStyles((theme) => ({
     },
   },
 }));
+
+const isErrorPayload = (payload: GQLCreateChildPayload): payload is GQLErrorPayload =>
+  payload.__typename === 'ErrorPayload';
 
 export const NewObjectModal = ({
   editingContextId,
@@ -150,6 +155,13 @@ export const NewObjectModal = ({
       if (createChildData) {
         const handleResponseEvent: HandleResponseEvent = { type: 'HANDLE_RESPONSE', data: createChildData };
         dispatch(handleResponseEvent);
+
+        const { createChild } = createChildData;
+        if (isErrorPayload(createChild)) {
+          const { message } = createChild;
+          const showToastEvent: ShowToastEvent = { type: 'SHOW_TOAST', message };
+          dispatch(showToastEvent);
+        }
       }
     }
   }, [createChildLoading, createChildData, createChildError, dispatch]);


### PR DESCRIPTION
### Type of this PR 

- [x] Bug fix
- [x] New feature or improvement

### Issue(s)

https://github.com/eclipse-sirius/sirius-components/issues/532

### What does this PR do?

- Makes the CreateChildEventHandler returning an ErrorPayload when the
child that has been created has no owner.
- Handles ErrorPayload in NewObjectModal

### How to test this PR?

- [x] Manual Test:

1. Creates a view model, a diagram description, and a node description
2. Creates a first node style under the node description
3. Tries to create a second node style under the  same node description

The modal used to create the node description child should still be displayed, and the Material-UI Snackbar should appear with an error message.
