### PR TITLE
[572] Move the object type name in a tooltip for tree items

### DIFF
--- a/frontend/src/tree/TreeItem.tsx
+++ b/frontend/src/tree/TreeItem.tsx
@@ -394,14 +394,21 @@ export const TreeItem = ({
       };
     });
 
+  let itemTitle = null;
   let itemLabel = null;
-  if (item.kind === 'Document' || registry.isRepresentation(item.kind)) {
+  if (item.kind === 'Document') {
     itemLabel = item.label;
+    itemTitle = 'Model';
+  } else if (registry.isRepresentation(item.kind)) {
+    itemLabel = item.label;
+    itemTitle = item.kind;
   } else {
-    itemLabel = item.kind.split('::').pop();
     if (item.label) {
-      itemLabel += ' ' + item.label;
+      itemLabel = item.label;
+    } else {
+      itemLabel = item.kind.split('::').pop();
     }
+    itemTitle = item.kind;
   }
 
   let text;
@@ -679,6 +686,7 @@ export const TreeItem = ({
             className={styles.imageAndLabel}
             onClick={onClick}
             onDoubleClick={() => item.hasChildren && onExpand(item.id, depth)}
+            title={itemTitle}
             data-testid={itemLabel}>
             {image}
             {text}


### PR DESCRIPTION
Make the labels more compact and readable, while still preserving access to the type information when needed.

* Left: before (e.g. "Processor Radar_Capture")
* Right: after ("Radar_Capture" with "Processor" in the tooltip)

![compact-labels](https://user-images.githubusercontent.com/10608/122721283-c3ea1480-d270-11eb-8e23-9362fd876f1d.png)
