### PR TITLE
Remove dependencies from the sirius-web-spring-starter project

### DIFF
--- a/backend/sirius-web-emf/pom.xml
+++ b/backend/sirius-web-emf/pom.xml
@@ -94,16 +94,6 @@
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
-			<artifactId>sirius-web-services-api</artifactId>
-			<version>0.3.3</version>
-		</dependency>
-		<dependency>
-			<groupId>org.eclipse.sirius.web</groupId>
-			<artifactId>sirius-web-persistence</artifactId>
-			<version>0.3.3</version>
-		</dependency>
-		<dependency>
-			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-interpreter</artifactId>
 			<version>0.3.3</version>
 		</dependency>

--- a/backend/sirius-web-spring-starter/pom.xml
+++ b/backend/sirius-web-spring-starter/pom.xml
@@ -68,22 +68,12 @@
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
-			<artifactId>sirius-web-services</artifactId>
-			<version>0.3.3</version>
-		</dependency>
-		<dependency>
-			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-emf</artifactId>
 			<version>0.3.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-compatibility</artifactId>
-			<version>0.3.3</version>
-		</dependency>
-		<dependency>
-			<groupId>org.eclipse.sirius.web</groupId>
-			<artifactId>sirius-web-spring</artifactId>
 			<version>0.3.3</version>
 		</dependency>
 	</dependencies>

--- a/backend/sirius-web-spring-starter/src/main/java/org/eclipse/sirius/web/starter/SiriusWebStarterConfiguration.java
+++ b/backend/sirius-web-spring-starter/src/main/java/org/eclipse/sirius/web/starter/SiriusWebStarterConfiguration.java
@@ -38,8 +38,6 @@ import org.springframework.context.annotation.Configuration;
         "org.eclipse.sirius.web.spring.collaborative.diagrams",
         "org.eclipse.sirius.web.spring.collaborative.forms",
         "org.eclipse.sirius.web.spring.collaborative.trees",
-        "org.eclipse.sirius.web.spring",
-        "org.eclipse.sirius.web.services",
     }
 )
 // @formatter:on


### PR DESCRIPTION
In order to prepare for the move of our business code from Sirius Components to Sirius Web, this PR will reduce the dependencies provided by the Sirius Components starter project.