### PR TITLE
[265] Upgrade ANTLR to version 4.8 (the same as AQL)

### DIFF
--- a/backend/sirius-web-interpreter/pom.xml
+++ b/backend/sirius-web-interpreter/pom.xml
@@ -81,7 +81,7 @@
 		<dependency>
 			<groupId>org.antlr</groupId>
 			<artifactId>antlr4-runtime</artifactId>
-			<version>4.7.2</version>
+			<version>4.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.acceleo</groupId>


### PR DESCRIPTION
Before this patch, I get the following message (different from what is mentioned in the issue description):
```
ANTLR Tool version 4.8 used for code generation does not match the current runtime version 4.7.2
```
i.e. it seems that the AQL 7.0.0-SNAPSHOT's parser was generated with ANTLR 4.8 but we forced the use of version 4.7.2 at runtime.