### PR TITLE
Add a basic support for validation in the properties view

### DIFF
--- a/backend/sirius-web-compatibility/src/main/java/org/eclipse/sirius/web/compat/forms/WidgetDescriptionConverter.java
+++ b/backend/sirius-web-compatibility/src/main/java/org/eclipse/sirius/web/compat/forms/WidgetDescriptionConverter.java
@@ -105,6 +105,9 @@ public class WidgetDescriptionConverter {
                 .labelProvider(labelProvider)
                 .valueProvider(valueProvider)
                 .newValueHandler(newValueHandler)
+                .diagnosticsProvider((variableManager) -> List.of())
+                .kindProvider((object) -> "") //$NON-NLS-1$
+                .messageProvider((object) -> "") //$NON-NLS-1$
                 .build();
         // @formatter:on
 
@@ -125,6 +128,9 @@ public class WidgetDescriptionConverter {
                 .labelProvider(labelProvider)
                 .valueProvider(valueProvider)
                 .newValueHandler(newValueHandler)
+                .diagnosticsProvider((variableManager) -> List.of())
+                .kindProvider((object) -> "") //$NON-NLS-1$
+                .messageProvider((object) -> "") //$NON-NLS-1$
                 .build();
         // @formatter:on
 
@@ -200,6 +206,9 @@ public class WidgetDescriptionConverter {
                 .optionSelectedProvider(optionSelectedProvider)
                 .optionsProvider(optionsProvider)
                 .newValueHandler(newValueHandler)
+                .diagnosticsProvider((variableManager) -> List.of())
+                .kindProvider((object) -> "") //$NON-NLS-1$
+                .messageProvider((object) -> "") //$NON-NLS-1$
                 .build();
         // @formatter:on
 
@@ -250,6 +259,9 @@ public class WidgetDescriptionConverter {
                 .optionIdProvider(optionIdProvider)
                 .optionLabelProvider(optionLabelProvider)
                 .newValueHandler(newValueHandler)
+                .diagnosticsProvider((variableManager) -> List.of())
+                .kindProvider((object) -> "") //$NON-NLS-1$
+                .messageProvider((object) -> "") //$NON-NLS-1$
                 .build();
         // @formatter:on
 
@@ -281,6 +293,9 @@ public class WidgetDescriptionConverter {
                 .labelProvider(labelProvider)
                 .valueProvider(valueProvider)
                 .newValueHandler(newValueHandler)
+                .diagnosticsProvider((variableManager) -> List.of())
+                .kindProvider((object) -> "") //$NON-NLS-1$
+                .messageProvider((object) -> "") //$NON-NLS-1$
                 .build();
         // @formatter:on
     }

--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/properties/EBooleanIfDescriptionProvider.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/properties/EBooleanIfDescriptionProvider.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.sirius.web.emf.compatibility.properties;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -66,6 +67,9 @@ public class EBooleanIfDescriptionProvider {
                 .labelProvider(this.getLabelProvider())
                 .valueProvider(this.getValueProvider())
                 .newValueHandler(this.getNewValueHandler())
+                .diagnosticsProvider((variableManager) -> List.of())
+                .kindProvider((object) -> "") //$NON-NLS-1$
+                .messageProvider((object) -> "") //$NON-NLS-1$
                 .build();
         // @formatter:on
     }

--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/properties/EEnumIfDescriptionProvider.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/properties/EEnumIfDescriptionProvider.java
@@ -87,6 +87,9 @@ public class EEnumIfDescriptionProvider {
                 .optionIdProvider(this.getOptionIdProvider())
                 .optionLabelProvider(this.getOptionLabelProvider())
                 .newValueHandler(this.getNewValueHandler())
+                .diagnosticsProvider((variableManager) -> List.of())
+                .kindProvider((object) -> "") //$NON-NLS-1$
+                .messageProvider((object) -> "") //$NON-NLS-1$
                 .build();
         // @formatter:on
     }

--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/properties/EStringIfDescriptionProvider.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/properties/EStringIfDescriptionProvider.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.sirius.web.emf.compatibility.properties;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -70,6 +71,9 @@ public class EStringIfDescriptionProvider {
                 .labelProvider(this.getLabelProvider())
                 .valueProvider(this.getValueProvider())
                 .newValueHandler(this.getNewValueHandler())
+                .diagnosticsProvider((variableManager) -> List.of())
+                .kindProvider((object) -> "") //$NON-NLS-1$
+                .messageProvider((object) -> "") //$NON-NLS-1$
                 .build();
         // @formatter:on
     }

--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/properties/MonoValuedNonContainmentReferenceIfDescriptionProvider.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/properties/MonoValuedNonContainmentReferenceIfDescriptionProvider.java
@@ -84,6 +84,9 @@ public class MonoValuedNonContainmentReferenceIfDescriptionProvider {
                 .optionIdProvider(this.getOptionIdProvider())
                 .optionLabelProvider(this.getOptionLabelProvider())
                 .newValueHandler(this.getNewValueHandler())
+                .diagnosticsProvider((variableManager) -> List.of())
+                .kindProvider((object) -> "") //$NON-NLS-1$
+                .messageProvider((object) -> "") //$NON-NLS-1$
                 .build();
         // @formatter:on
     }

--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/properties/MultiValuedNonContainmentReferenceIfDescriptionProvider.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/properties/MultiValuedNonContainmentReferenceIfDescriptionProvider.java
@@ -79,6 +79,9 @@ public class MultiValuedNonContainmentReferenceIfDescriptionProvider {
                 .itemIdProvider(this.getItemIdProvider())
                 .itemLabelProvider(this.getItemLabelProvider())
                 .itemImageURLProvider(this.getImageURLProvider())
+                .diagnosticsProvider((variableManager) -> List.of())
+                .kindProvider((object) -> "") //$NON-NLS-1$
+                .messageProvider((object) -> "") //$NON-NLS-1$
                 .build();
         // @formatter:on
     }

--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/properties/NumberIfDescriptionProvider.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/properties/NumberIfDescriptionProvider.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.sirius.web.emf.compatibility.properties;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.BiFunction;
@@ -68,6 +69,9 @@ public class NumberIfDescriptionProvider {
                 .labelProvider(this.getLabelProvider())
                 .valueProvider(this.getValueProvider())
                 .newValueHandler(this.getNewValueHandler())
+                .diagnosticsProvider((variableManager) -> List.of())
+                .kindProvider((object) -> "") //$NON-NLS-1$
+                .messageProvider((object) -> "") //$NON-NLS-1$
                 .build();
         // @formatter:on
     }

--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/domain/DomainValidator.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/domain/DomainValidator.java
@@ -23,6 +23,7 @@ import org.eclipse.emf.ecore.EDataType;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EValidator;
 import org.eclipse.sirius.web.domain.Domain;
+import org.eclipse.sirius.web.domain.DomainPackage;
 
 /**
  * The validator for Domain.
@@ -63,7 +64,10 @@ public class DomainValidator implements EValidator {
                     SIRIUS_WEB_EMF_PACKAGE,
                     0,
                     String.format(DOMAIN_URI_SCHEME_ERROR_MESSAGE, domain.getName()),
-                    null);
+                    new Object [] {
+                            domain,
+                            DomainPackage.Literals.DOMAIN__URI,
+                    });
             // @formatter:on
 
             diagnostics.add(basicDiagnostic);
@@ -80,7 +84,10 @@ public class DomainValidator implements EValidator {
                     SIRIUS_WEB_EMF_PACKAGE,
                     0,
                     DOMAIN_NAME_ERROR_MESSAGE,
-                    null);
+                    new Object [] {
+                            domain,
+                            DomainPackage.Literals.NAMED_ELEMENT__NAME,
+                    });
             // @formatter:on
 
             diagnostics.add(basicDiagnostic);

--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/view/ViewPropertiesConfigurer.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/view/ViewPropertiesConfigurer.java
@@ -23,9 +23,12 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import org.eclipse.emf.common.util.Diagnostic;
+import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.sirius.web.api.configuration.IPropertiesDescriptionRegistry;
 import org.eclipse.sirius.web.api.configuration.IPropertiesDescriptionRegistryConfigurer;
+import org.eclipse.sirius.web.collaborative.validation.api.IValidationService;
 import org.eclipse.sirius.web.forms.components.SelectComponent;
 import org.eclipse.sirius.web.forms.description.AbstractControlDescription;
 import org.eclipse.sirius.web.forms.description.CheckboxDescription;
@@ -40,6 +43,7 @@ import org.eclipse.sirius.web.representations.Status;
 import org.eclipse.sirius.web.representations.VariableManager;
 import org.eclipse.sirius.web.view.ConditionalNodeStyle;
 import org.eclipse.sirius.web.view.NodeStyle;
+import org.eclipse.sirius.web.view.ViewPackage;
 import org.springframework.stereotype.Component;
 
 /**
@@ -58,7 +62,10 @@ public class ViewPropertiesConfigurer implements IPropertiesDescriptionRegistryC
 
     private final ICustomImagesService customImagesService;
 
-    public ViewPropertiesConfigurer(ICustomImagesService customImagesService) {
+    private final IValidationService validationService;
+
+    public ViewPropertiesConfigurer(ICustomImagesService customImagesService, IValidationService validationService) {
+        this.validationService = Objects.requireNonNull(validationService);
         this.customImagesService = Objects.requireNonNull(customImagesService);
     }
 
@@ -79,13 +86,16 @@ public class ViewPropertiesConfigurer implements IPropertiesDescriptionRegistryC
         List<AbstractControlDescription> controls = List.of(
                 this.createTextField("conditionalnodestyle.condition", "Condition", //$NON-NLS-1$ //$NON-NLS-2$
                         style -> ((ConditionalNodeStyle) style).getCondition(),
-                        (style, newCondition) -> ((ConditionalNodeStyle) style).setCondition(newCondition)),
+                        (style, newCondition) -> ((ConditionalNodeStyle) style).setCondition(newCondition),
+                        ViewPackage.Literals.CONDITIONAL__CONDITION),
                 this.createTextField("conditionalnodestyle.color", "Color", //$NON-NLS-1$ //$NON-NLS-2$
                         style -> ((NodeStyle) style).getColor(),
-                        (style, newColor) -> ((NodeStyle) style).setColor(newColor)),
+                        (style, newColor) -> ((NodeStyle) style).setColor(newColor),
+                        ViewPackage.Literals.STYLE__COLOR),
                 this.createTextField("conditionalnodestyle.borderColor", "Border Color", //$NON-NLS-1$ //$NON-NLS-2$
                         style -> ((NodeStyle) style).getBorderColor(),
-                        (style, newColor) -> ((NodeStyle) style).setBorderColor(newColor)),
+                        (style, newColor) -> ((NodeStyle) style).setBorderColor(newColor),
+                        ViewPackage.Literals.STYLE__BORDER_COLOR),
                 this.createTextField("conditionalnodestyle.borderRadius", "Border Radius", //$NON-NLS-1$ //$NON-NLS-2$
                         style -> String.valueOf(((NodeStyle) style).getBorderRadius()),
                         (style, newBorderRadius) -> {
@@ -94,10 +104,12 @@ public class ViewPropertiesConfigurer implements IPropertiesDescriptionRegistryC
                             } catch (NumberFormatException nfe) {
                                 // Ignore.
                             }
-                        }),
+                        },
+                        ViewPackage.Literals.NODE_STYLE__BORDER_RADIUS),
                 this.createCheckbox("conditionalnodestyle.listMost", "List Mode", //$NON-NLS-1$ //$NON-NLS-2$
                         style -> ((NodeStyle) style).isListMode(),
-                        (style, newListMode) -> ((NodeStyle) style).setListMode(newListMode)),
+                        (style, newListMode) -> ((NodeStyle) style).setListMode(newListMode),
+                        ViewPackage.Literals.NODE_STYLE__LIST_MODE),
                 this.createTextField("conditionalnodestyle.fontSize", "Font Size", //$NON-NLS-1$ //$NON-NLS-2$
                         style -> String.valueOf(((NodeStyle) style).getFontSize()),
                         (style, newColor) -> {
@@ -106,8 +118,9 @@ public class ViewPropertiesConfigurer implements IPropertiesDescriptionRegistryC
                             } catch (NumberFormatException nfe) {
                                 // Ignore.
                             }
-                        }),
-                this.createShapeSelectionField());
+                        },
+                        ViewPackage.Literals.STYLE__FONT_SIZE),
+                this.createShapeSelectionField(ViewPackage.Literals.NODE_STYLE__SHAPE));
 
         GroupDescription groupDescription = this.createSimpleGroupDescription(controls);
         return FormDescription.newFormDescription(formDescriptionId)
@@ -139,10 +152,12 @@ public class ViewPropertiesConfigurer implements IPropertiesDescriptionRegistryC
         List<AbstractControlDescription> controls = List.of(
                 this.createTextField("nodestyle.color", "Color", //$NON-NLS-1$ //$NON-NLS-2$
                                      style -> ((NodeStyle) style).getColor(),
-                                     (style, newColor) -> ((NodeStyle) style).setColor(newColor)),
+                                     (style, newColor) -> ((NodeStyle) style).setColor(newColor),
+                                     ViewPackage.Literals.STYLE__COLOR),
                 this.createTextField("nodestyle.borderColor", "Border Color", //$NON-NLS-1$ //$NON-NLS-2$
                         style -> ((NodeStyle) style).getBorderColor(),
-                        (style, newColor) -> ((NodeStyle) style).setBorderColor(newColor)),
+                        (style, newColor) -> ((NodeStyle) style).setBorderColor(newColor),
+                        ViewPackage.Literals.STYLE__BORDER_COLOR),
                 this.createTextField("nodestyle.borderRadius", "Border Radius", //$NON-NLS-1$ //$NON-NLS-2$
                         style -> String.valueOf(((NodeStyle) style).getBorderRadius()),
                         (style, newBorderRadius) -> {
@@ -151,10 +166,12 @@ public class ViewPropertiesConfigurer implements IPropertiesDescriptionRegistryC
                             } catch (NumberFormatException nfe) {
                                 // Ignore.
                             }
-                        }),
+                        },
+                        ViewPackage.Literals.NODE_STYLE__BORDER_RADIUS),
                 this.createCheckbox("nodestyle.listMost", "List Mode", //$NON-NLS-1$ //$NON-NLS-2$
                         style -> ((NodeStyle) style).isListMode(),
-                        (style, newListMode) -> ((NodeStyle) style).setListMode(newListMode)),
+                        (style, newListMode) -> ((NodeStyle) style).setListMode(newListMode),
+                        ViewPackage.Literals.NODE_STYLE__LIST_MODE),
                 this.createTextField("nodestyle.fontSize", "Font Size", //$NON-NLS-1$ //$NON-NLS-2$
                         style -> String.valueOf(((NodeStyle) style).getFontSize()),
                         (style, newColor) -> {
@@ -163,8 +180,9 @@ public class ViewPropertiesConfigurer implements IPropertiesDescriptionRegistryC
                             } catch (NumberFormatException nfe) {
                                 // Ignore.
                             }
-                        }),
-                this.createShapeSelectionField());
+                        },
+                        ViewPackage.Literals.STYLE__FONT_SIZE),
+                this.createShapeSelectionField(ViewPackage.Literals.NODE_STYLE__SHAPE));
 
         GroupDescription groupDescription = this.createSimpleGroupDescription(controls);
         return FormDescription.newFormDescription(formDescriptionId)
@@ -208,7 +226,7 @@ public class ViewPropertiesConfigurer implements IPropertiesDescriptionRegistryC
         // @formatter:on
     }
 
-    private TextfieldDescription createTextField(String id, String title, Function<Object, String> reader, BiConsumer<Object, String> writer) {
+    private TextfieldDescription createTextField(String id, String title, Function<Object, String> reader, BiConsumer<Object, String> writer, Object feature) {
         Function<VariableManager, String> valueProvider = variableManager -> variableManager.get(VariableManager.SELF, Object.class).map(reader).orElse(EMPTY);
         BiFunction<VariableManager, String, Status> newValueHandler = (variableManager, newValue) -> {
             var optionalDiagramMapping = variableManager.get(VariableManager.SELF, Object.class);
@@ -219,17 +237,21 @@ public class ViewPropertiesConfigurer implements IPropertiesDescriptionRegistryC
                 return Status.ERROR;
             }
         };
+
         // @formatter:off
         return TextfieldDescription.newTextfieldDescription(id)
                                    .idProvider(variableManager -> id)
                                    .labelProvider(variableManager -> title)
                                    .valueProvider(valueProvider)
                                    .newValueHandler(newValueHandler)
+                                   .diagnosticsProvider(this.getDiagnosticsProvider(feature))
+                                   .kindProvider(this::kindProvider)
+                                   .messageProvider(this::messageProvider)
                                    .build();
         // @formatter:on
     }
 
-    private CheckboxDescription createCheckbox(String id, String title, Function<Object, Boolean> reader, BiConsumer<Object, Boolean> writer) {
+    private CheckboxDescription createCheckbox(String id, String title, Function<Object, Boolean> reader, BiConsumer<Object, Boolean> writer, Object feature) {
         Function<VariableManager, Boolean> valueProvider = variableManager -> variableManager.get(VariableManager.SELF, Object.class).map(reader).orElse(Boolean.FALSE);
         BiFunction<VariableManager, Boolean, Status> newValueHandler = (variableManager, newValue) -> {
             var optionalDiagramMapping = variableManager.get(VariableManager.SELF, Object.class);
@@ -246,11 +268,14 @@ public class ViewPropertiesConfigurer implements IPropertiesDescriptionRegistryC
                                    .labelProvider(variableManager -> title)
                                    .valueProvider(valueProvider)
                                    .newValueHandler(newValueHandler)
+                                   .diagnosticsProvider(this.getDiagnosticsProvider(feature))
+                                   .kindProvider(this::kindProvider)
+                                   .messageProvider(this::messageProvider)
                                    .build();
         // @formatter:on
     }
 
-    private SelectDescription createShapeSelectionField() {
+    private SelectDescription createShapeSelectionField(Object feature) {
         // @formatter:off
         return SelectDescription.newSelectDescription("nodestyle.shapeSelector") //$NON-NLS-1$
                                 .idProvider(variableManager -> "nodestyle.shapeSelector") //$NON-NLS-1$
@@ -260,6 +285,9 @@ public class ViewPropertiesConfigurer implements IPropertiesDescriptionRegistryC
                                 .optionIdProvider(variableManager -> variableManager.get(SelectComponent.CANDIDATE_VARIABLE, CustomImage.class).map(CustomImage::getId).map(UUID::toString).orElse(EMPTY))
                                 .optionLabelProvider(variableManager -> variableManager.get(SelectComponent.CANDIDATE_VARIABLE, CustomImage.class).map(CustomImage::getLabel).orElse(EMPTY))
                                 .newValueHandler(this.getNewShapeValueHandler())
+                                .diagnosticsProvider(this.getDiagnosticsProvider(feature))
+                                .kindProvider(this::kindProvider)
+                                .messageProvider(this::messageProvider)
                                 .build();
         // @formatter:on
     }
@@ -276,6 +304,50 @@ public class ViewPropertiesConfigurer implements IPropertiesDescriptionRegistryC
             }
             return Status.ERROR;
         };
+    }
+
+    private Function<VariableManager, List<Object>> getDiagnosticsProvider(Object feature) {
+        return variableManager -> {
+            var optionalSelf = variableManager.get(VariableManager.SELF, EObject.class);
+
+            if (optionalSelf.isPresent()) {
+                EObject self = optionalSelf.get();
+                List<Object> diagnostics = this.validationService.validate(self, feature);
+                return diagnostics;
+            }
+
+            return List.of();
+        };
+    }
+
+    private String kindProvider(Object object) {
+        String kind = "Unknown"; //$NON-NLS-1$
+        if (object instanceof Diagnostic) {
+            Diagnostic diagnostic = (Diagnostic) object;
+            switch (diagnostic.getSeverity()) {
+            case org.eclipse.emf.common.util.Diagnostic.ERROR:
+                kind = "Error"; //$NON-NLS-1$
+                break;
+            case org.eclipse.emf.common.util.Diagnostic.WARNING:
+                kind = "Warning"; //$NON-NLS-1$
+                break;
+            case org.eclipse.emf.common.util.Diagnostic.INFO:
+                kind = "Info"; //$NON-NLS-1$
+                break;
+            default:
+                kind = "Unknown"; //$NON-NLS-1$
+                break;
+            }
+        }
+        return kind;
+    }
+
+    private String messageProvider(Object object) {
+        if (object instanceof Diagnostic) {
+            Diagnostic diagnostic = (Diagnostic) object;
+            return diagnostic.getMessage();
+        }
+        return ""; //$NON-NLS-1$
     }
 
 }

--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/view/ViewValidator.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/view/ViewValidator.java
@@ -33,7 +33,10 @@ import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.sirius.web.domain.Domain;
 import org.eclipse.sirius.web.domain.DomainPackage;
 import org.eclipse.sirius.web.domain.Entity;
+import org.eclipse.sirius.web.view.Conditional;
 import org.eclipse.sirius.web.view.NodeDescription;
+import org.eclipse.sirius.web.view.NodeStyle;
+import org.eclipse.sirius.web.view.ViewPackage;
 
 /**
  * The validator for View.
@@ -60,12 +63,62 @@ public class ViewValidator implements EValidator {
             NodeDescription nodeDescription = (NodeDescription) eObject;
             isValid = this.hasProperDomainType(nodeDescription, diagnostics) && isValid;
         }
+        if (eObject instanceof NodeStyle) {
+            NodeStyle nodeStyle = (NodeStyle) eObject;
+            isValid = this.hasProperColor(nodeStyle, diagnostics) && isValid;
+        }
+        if (eObject instanceof Conditional) {
+            Conditional conditional = (Conditional) eObject;
+            isValid = this.conditionIsPresent(conditional, diagnostics) && isValid;
+        }
         return isValid;
     }
 
     @Override
     public boolean validate(EDataType eDataType, Object value, DiagnosticChain diagnostics, Map<Object, Object> context) {
         return true;
+    }
+
+    private boolean conditionIsPresent(Conditional conditional, DiagnosticChain diagnostics) {
+        boolean isValid = !conditional.getCondition().isBlank();
+
+        if (!isValid && diagnostics != null) {
+            // @formatter:off
+            BasicDiagnostic basicDiagnostic = new BasicDiagnostic(Diagnostic.ERROR,
+                    SIRIUS_WEB_EMF_PACKAGE,
+                    0,
+                    "The condition should not be empty", //$NON-NLS-1$
+                    new Object [] {
+                            conditional,
+                            ViewPackage.Literals.CONDITIONAL__CONDITION,
+                    });
+            // @formatter:on
+
+            diagnostics.add(basicDiagnostic);
+        }
+
+        return isValid;
+    }
+
+    private boolean hasProperColor(NodeStyle nodeStyle, DiagnosticChain diagnostics) {
+        boolean isValid = !nodeStyle.getColor().isBlank();
+
+        if (!isValid && diagnostics != null) {
+            // @formatter:off
+            BasicDiagnostic basicDiagnostic = new BasicDiagnostic(Diagnostic.ERROR,
+                    SIRIUS_WEB_EMF_PACKAGE,
+                    0,
+                    "The color should not be empty", //$NON-NLS-1$
+                    new Object [] {
+                            nodeStyle,
+                            ViewPackage.Literals.STYLE__COLOR,
+                    });
+            // @formatter:on
+
+            diagnostics.add(basicDiagnostic);
+        }
+
+        return isValid;
     }
 
     private boolean hasProperDomainType(NodeDescription nodeDescription, DiagnosticChain diagnostics) {
@@ -95,7 +148,10 @@ public class ViewValidator implements EValidator {
                     SIRIUS_WEB_EMF_PACKAGE,
                     0,
                     String.format(NODE_DESCRIPTION_INVALID_DOMAIN_TYPE_ERROR_MESSAGE, nodeDescription.getDomainType()),
-                    null);
+                    new Object [] {
+                            nodeDescription,
+                            ViewPackage.Literals.DIAGRAM_ELEMENT_DESCRIPTION__DOMAIN_TYPE,
+                    });
             // @formatter:on
 
             diagnostics.add(basicDiagnostic);

--- a/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/services/validation/DiagnosticAssert.java
+++ b/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/services/validation/DiagnosticAssert.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.emf.services.validation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.sirius.web.emf.services.validation.DiagnosticAssertions.assertThat;
+
+import org.assertj.core.api.AbstractAssert;
+import org.eclipse.emf.common.util.Diagnostic;
+
+/**
+ * Custom assertion class used to perform tests on diagnostics.
+ *
+ * @author sbegaudeau
+ */
+public class DiagnosticAssert extends AbstractAssert<DiagnosticAssert, Diagnostic> {
+
+    public DiagnosticAssert(Diagnostic diagnostic) {
+        super(diagnostic, DiagnosticAssert.class);
+    }
+
+    @Override
+    public DiagnosticAssert isEqualTo(Object expected) {
+        if (expected instanceof Diagnostic) {
+            Diagnostic expectedDiagnostic = (Diagnostic) expected;
+
+            assertThat(this.actual.getSeverity()).isEqualTo(expectedDiagnostic.getSeverity());
+            assertThat(this.actual.getCode()).isEqualTo(expectedDiagnostic.getCode());
+            assertThat(this.actual.getMessage()).isEqualTo(expectedDiagnostic.getMessage());
+            if (this.actual.getChildren() != null) {
+                assertThat(this.actual.getChildren()).hasSameSizeAs(expectedDiagnostic.getChildren());
+                for (int i = 0; i < this.actual.getChildren().size(); ++i) {
+                    assertThat(this.actual.getChildren().get(i)).isEqualTo(expectedDiagnostic.getChildren().get(i));
+                }
+
+            } else {
+                assertThat(this.actual.getChildren()).isEqualTo(expectedDiagnostic.getChildren());
+            }
+            if (this.actual.getData() != null) {
+                assertThat(this.actual.getData()).hasSameSizeAs(expectedDiagnostic.getData());
+                for (int i = 0; i < this.actual.getData().size(); ++i) {
+                    assertThat(this.actual.getData().get(i)).isEqualTo(expectedDiagnostic.getData().get(i));
+                }
+            } else {
+                assertThat(this.actual.getData()).isEqualTo(expectedDiagnostic.getData());
+            }
+        }
+        return this;
+    }
+}

--- a/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/services/validation/DiagnosticAssertions.java
+++ b/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/services/validation/DiagnosticAssertions.java
@@ -10,21 +10,18 @@
  * Contributors:
  *     Obeo - initial API and implementation
  *******************************************************************************/
-package org.eclipse.sirius.web.collaborative.validation.api;
+package org.eclipse.sirius.web.emf.services.validation;
 
-import java.util.List;
-
-import org.eclipse.sirius.web.core.api.IEditingContext;
+import org.assertj.core.api.Assertions;
+import org.eclipse.emf.common.util.Diagnostic;
 
 /**
- * Interface used to validate elements.
+ * Entry point of all the AssertJ assertions for diagnostics.
  *
- * @author gcoutable
+ * @author sbegaudeau
  */
-public interface IValidationService {
-
-    List<Object> validate(IEditingContext editingContext);
-
-    List<Object> validate(Object object, Object feature);
-
+public class DiagnosticAssertions extends Assertions {
+    public static DiagnosticAssert assertThat(Diagnostic diagnostic) {
+        return new DiagnosticAssert(diagnostic);
+    }
 }

--- a/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/services/validation/DomainValidatorTests.java
+++ b/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/services/validation/DomainValidatorTests.java
@@ -1,0 +1,106 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.emf.services.validation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.sirius.web.emf.services.validation.DiagnosticAssertions.assertThat;
+
+import java.util.Map;
+
+import org.eclipse.emf.common.util.BasicDiagnostic;
+import org.eclipse.emf.common.util.Diagnostic;
+import org.eclipse.emf.ecore.util.Diagnostician;
+import org.eclipse.sirius.web.domain.Domain;
+import org.eclipse.sirius.web.domain.DomainFactory;
+import org.eclipse.sirius.web.domain.DomainPackage;
+import org.eclipse.sirius.web.emf.domain.DomainValidator;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for the {@link DomainValidator}.
+ *
+ * @author gcoutable
+ */
+public class DomainValidatorTests {
+
+    @Test
+    public void testDomainShouldBeValid() {
+        Map<Object, Object> defaultContext = Diagnostician.INSTANCE.createDefaultContext();
+        Domain domain = DomainFactory.eINSTANCE.createDomain();
+        domain.setName("Family"); //$NON-NLS-1$
+        domain.setUri("domain://Family"); //$NON-NLS-1$
+
+        BasicDiagnostic diagnosticChain = new BasicDiagnostic(Diagnostic.OK, null, 0, null, null);
+
+        boolean validationResult = new DomainValidator().validate(domain.eClass(), domain, diagnosticChain, defaultContext);
+        assertThat(validationResult).isTrue();
+
+        assertThat(diagnosticChain).isEqualTo(new BasicDiagnostic(Diagnostic.OK, null, 0, null, null));
+    }
+
+    @Test
+    public void testDomainInvalidURI() {
+        Map<Object, Object> defaultContext = Diagnostician.INSTANCE.createDefaultContext();
+        Domain domain = DomainFactory.eINSTANCE.createDomain();
+        domain.setName("Family"); //$NON-NLS-1$
+        domain.setUri(""); //$NON-NLS-1$
+
+        BasicDiagnostic diagnosticChain = new BasicDiagnostic(Diagnostic.OK, null, 0, null, null);
+
+        boolean validationResult = new DomainValidator().validate(domain.eClass(), domain, diagnosticChain, defaultContext);
+        assertThat(validationResult).isFalse();
+
+        BasicDiagnostic expected = new BasicDiagnostic(Diagnostic.ERROR, null, 0, null, null);
+        // @formatter:off
+        expected.add(new BasicDiagnostic(Diagnostic.ERROR,
+                "org.eclipse.sirius.web.emf", //$NON-NLS-1$
+                0,
+                String.format("The domain %1$s uri's does not start with \"domain://\".", domain.getName()), //$NON-NLS-1$
+                new Object [] {
+                        domain,
+                        DomainPackage.Literals.DOMAIN__URI,
+
+        }));
+        // @formatter:on
+
+        assertThat(diagnosticChain).isEqualTo(expected);
+    }
+
+    @Test
+    public void testDomainInvalidName() {
+        Map<Object, Object> defaultContext = Diagnostician.INSTANCE.createDefaultContext();
+        Domain domain = DomainFactory.eINSTANCE.createDomain();
+        domain.setName(""); //$NON-NLS-1$
+        domain.setUri("domain://Family"); //$NON-NLS-1$
+
+        BasicDiagnostic diagnosticChain = new BasicDiagnostic(Diagnostic.OK, null, 0, null, null);
+
+        boolean validationResult = new DomainValidator().validate(domain.eClass(), domain, diagnosticChain, defaultContext);
+        assertThat(validationResult).isFalse();
+
+        BasicDiagnostic expected = new BasicDiagnostic(Diagnostic.WARNING, null, 0, null, null);
+        // @formatter:off
+        expected.add(new BasicDiagnostic(Diagnostic.WARNING,
+                "org.eclipse.sirius.web.emf", //$NON-NLS-1$
+                0,
+                "The domain name should not be empty.", //$NON-NLS-1$
+                new Object [] {
+                        domain,
+                        DomainPackage.Literals.NAMED_ELEMENT__NAME,
+        }));
+        // @formatter:on
+
+        assertThat(diagnosticChain).isEqualTo(expected);
+    }
+
+}

--- a/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/services/validation/ViewValidatorTests.java
+++ b/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/services/validation/ViewValidatorTests.java
@@ -1,0 +1,214 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.emf.services.validation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.sirius.web.emf.services.validation.DiagnosticAssertions.assertThat;
+
+import java.util.Map;
+
+import org.eclipse.emf.common.util.BasicDiagnostic;
+import org.eclipse.emf.common.util.Diagnostic;
+import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.EPackage;
+import org.eclipse.emf.ecore.EcoreFactory;
+import org.eclipse.emf.ecore.impl.EPackageRegistryImpl;
+import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
+import org.eclipse.emf.ecore.util.Diagnostician;
+import org.eclipse.emf.ecore.xmi.impl.XMIResourceImpl;
+import org.eclipse.sirius.web.domain.Domain;
+import org.eclipse.sirius.web.domain.DomainFactory;
+import org.eclipse.sirius.web.domain.Entity;
+import org.eclipse.sirius.web.emf.view.ViewValidator;
+import org.eclipse.sirius.web.view.ConditionalNodeStyle;
+import org.eclipse.sirius.web.view.NodeDescription;
+import org.eclipse.sirius.web.view.NodeStyle;
+import org.eclipse.sirius.web.view.ViewFactory;
+import org.eclipse.sirius.web.view.ViewPackage;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for the {@link ViewValidator}.
+ *
+ * @author gcoutable
+ */
+public class ViewValidatorTests {
+
+    private static final String SAMPLE_DOMAIN_NAME = "sample"; //$NON-NLS-1$
+
+    private static final String SAMPLE_ENTITY_NAME = "SampleEntity"; //$NON-NLS-1$
+
+    private static final String SIRIUS_WEB_EMF_PACKAGE = "org.eclipse.sirius.web.emf"; //$NON-NLS-1$
+
+    @Test
+    public void testNodeStyleDefaultValuesAreValid() {
+        Map<Object, Object> defaultContext = Diagnostician.INSTANCE.createDefaultContext();
+        NodeStyle nodeStyle = ViewFactory.eINSTANCE.createNodeStyle();
+
+        BasicDiagnostic diagnosticChain = new BasicDiagnostic(Diagnostic.OK, null, 0, null, null);
+        boolean validationResult = new ViewValidator().validate(nodeStyle.eClass(), nodeStyle, diagnosticChain, defaultContext);
+        assertThat(validationResult).isTrue();
+
+        assertThat(diagnosticChain).isEqualTo(new BasicDiagnostic(Diagnostic.OK, null, 0, null, null));
+    }
+
+    @Test
+    public void testConditionalNodeStyleDefaultValuesAreValid() {
+        Map<Object, Object> defaultContext = Diagnostician.INSTANCE.createDefaultContext();
+        NodeStyle conditionalNodeStyle = ViewFactory.eINSTANCE.createConditionalNodeStyle();
+
+        BasicDiagnostic diagnosticChain = new BasicDiagnostic(Diagnostic.OK, null, 0, null, null);
+        boolean validationResult = new ViewValidator().validate(conditionalNodeStyle.eClass(), conditionalNodeStyle, diagnosticChain, defaultContext);
+        assertThat(validationResult).isTrue();
+
+        assertThat(diagnosticChain).isEqualTo(new BasicDiagnostic(Diagnostic.OK, null, 0, null, null));
+    }
+
+    @Test
+    public void testConditionalConditionIsAbsent() {
+        Map<Object, Object> defaultContext = Diagnostician.INSTANCE.createDefaultContext();
+        ConditionalNodeStyle conditionalNodeStyle = ViewFactory.eINSTANCE.createConditionalNodeStyle();
+        conditionalNodeStyle.setColor("black"); //$NON-NLS-1$
+        conditionalNodeStyle.setCondition(""); //$NON-NLS-1$
+
+        BasicDiagnostic expected = new BasicDiagnostic(Diagnostic.OK, null, 0, null, null);
+        // @formatter:off
+        expected.add(new BasicDiagnostic(Diagnostic.ERROR,
+                SIRIUS_WEB_EMF_PACKAGE,
+                0,
+                "The condition should not be empty", //$NON-NLS-1$
+                new Object [] {
+                        conditionalNodeStyle,
+                        ViewPackage.Literals.CONDITIONAL__CONDITION,
+                })
+            );
+        // @formatter:on
+
+        BasicDiagnostic diagnosticChain = new BasicDiagnostic(Diagnostic.OK, null, 0, null, null);
+        boolean validationResult = new ViewValidator().validate(conditionalNodeStyle.eClass(), conditionalNodeStyle, diagnosticChain, defaultContext);
+        assertThat(validationResult).isFalse();
+        assertThat(diagnosticChain).isEqualTo(expected);
+    }
+
+    @Test
+    public void testNodeStyleColorIsAbsent() {
+        Map<Object, Object> defaultContext = Diagnostician.INSTANCE.createDefaultContext();
+        ConditionalNodeStyle conditionalNodeStyle = ViewFactory.eINSTANCE.createConditionalNodeStyle();
+        conditionalNodeStyle.setColor(""); //$NON-NLS-1$
+
+        BasicDiagnostic expected = new BasicDiagnostic(Diagnostic.ERROR, null, 0, null, null);
+        // @formatter:off
+        expected.add(new BasicDiagnostic(Diagnostic.ERROR,
+                SIRIUS_WEB_EMF_PACKAGE,
+                0,
+                "The color should not be empty", //$NON-NLS-1$
+                new Object [] {
+                        conditionalNodeStyle,
+                        ViewPackage.Literals.STYLE__COLOR,
+                })
+            );
+        // @formatter:on
+
+        BasicDiagnostic diagnosticChain = new BasicDiagnostic(Diagnostic.OK, null, 0, null, null);
+        boolean validationResult = new ViewValidator().validate(conditionalNodeStyle.eClass(), conditionalNodeStyle, diagnosticChain, defaultContext);
+        assertThat(validationResult).isFalse();
+        assertThat(diagnosticChain).isEqualTo(expected);
+    }
+
+    @Test
+    public void testNodeDescriptionInvalidDomain() {
+        Map<Object, Object> defaultContext = Diagnostician.INSTANCE.createDefaultContext();
+        NodeDescription nodeDescription = ViewFactory.eINSTANCE.createNodeDescription();
+
+        ResourceSetImpl resourceSet = new ResourceSetImpl();
+        XMIResourceImpl xmiResource = new XMIResourceImpl();
+        xmiResource.getContents().add(nodeDescription);
+        resourceSet.getResources().add(xmiResource);
+
+        BasicDiagnostic expected = new BasicDiagnostic(Diagnostic.ERROR, null, 0, null, null);
+        // @formatter:off
+        expected.add(new BasicDiagnostic(Diagnostic.ERROR,
+                SIRIUS_WEB_EMF_PACKAGE,
+                0,
+                String.format("The node description \"%1$s\" does not have a valid domain class", nodeDescription.getDomainType()), //$NON-NLS-1$
+                new Object [] {
+                        nodeDescription,
+                        ViewPackage.Literals.DIAGRAM_ELEMENT_DESCRIPTION__DOMAIN_TYPE,
+                })
+            );
+
+        // @formatter:on
+
+        BasicDiagnostic diagnosticChain = new BasicDiagnostic(Diagnostic.OK, null, 0, null, null);
+        boolean validationResult = new ViewValidator().validate(nodeDescription.eClass(), nodeDescription, diagnosticChain, defaultContext);
+        assertThat(validationResult).isFalse();
+        assertThat(diagnosticChain).isEqualTo(expected);
+    }
+
+    @Test
+    public void testNodeStyleDescriptionValidDomainInResourceSet() {
+        Map<Object, Object> defaultContext = Diagnostician.INSTANCE.createDefaultContext();
+        NodeDescription nodeDescription = ViewFactory.eINSTANCE.createNodeDescription();
+        nodeDescription.setDomainType(SAMPLE_ENTITY_NAME);
+
+        ResourceSetImpl resourceSet = new ResourceSetImpl();
+        XMIResourceImpl viewResource = new XMIResourceImpl();
+        viewResource.getContents().add(nodeDescription);
+        XMIResourceImpl domainResource = new XMIResourceImpl();
+        Domain domain = DomainFactory.eINSTANCE.createDomain();
+        domain.setName(SAMPLE_DOMAIN_NAME);
+        domainResource.getContents().add(domain);
+        Entity entity = DomainFactory.eINSTANCE.createEntity();
+        entity.setName(SAMPLE_ENTITY_NAME);
+        domain.getTypes().add(entity);
+
+        resourceSet.getResources().add(viewResource);
+        resourceSet.getResources().add(domainResource);
+
+        BasicDiagnostic diagnosticChain = new BasicDiagnostic(Diagnostic.OK, null, 0, null, null);
+        boolean validationResult = new ViewValidator().validate(nodeDescription.eClass(), nodeDescription, diagnosticChain, defaultContext);
+        assertThat(validationResult).isTrue();
+        assertThat(diagnosticChain).isEqualTo(new BasicDiagnostic(Diagnostic.OK, null, 0, null, null));
+    }
+
+    @Test
+    public void testNodeStyleDescriptionValidDomainInPackageRegistry() {
+        Map<Object, Object> defaultContext = Diagnostician.INSTANCE.createDefaultContext();
+        NodeDescription nodeDescription = ViewFactory.eINSTANCE.createNodeDescription();
+        nodeDescription.setDomainType(SAMPLE_ENTITY_NAME);
+
+        ResourceSetImpl resourceSet = new ResourceSetImpl();
+        XMIResourceImpl viewResource = new XMIResourceImpl();
+        viewResource.getContents().add(nodeDescription);
+        resourceSet.getResources().add(viewResource);
+
+        EPackageRegistryImpl packageRegistryImpl = new EPackageRegistryImpl();
+        EPackage ePackage = EcoreFactory.eINSTANCE.createEPackage();
+        ePackage.setName(SAMPLE_DOMAIN_NAME);
+        ePackage.setNsPrefix(SAMPLE_DOMAIN_NAME);
+        ePackage.setNsURI("domain://sample"); //$NON-NLS-1$
+
+        EClass sampleClass = EcoreFactory.eINSTANCE.createEClass();
+        sampleClass.setName(SAMPLE_ENTITY_NAME);
+        ePackage.getEClassifiers().add(sampleClass);
+        packageRegistryImpl.put(ePackage.getNsURI(), ePackage);
+        resourceSet.setPackageRegistry(packageRegistryImpl);
+
+        BasicDiagnostic diagnosticChain = new BasicDiagnostic(Diagnostic.OK, null, 0, null, null);
+        boolean validationResult = new ViewValidator().validate(nodeDescription.eClass(), nodeDescription, diagnosticChain, defaultContext);
+        assertThat(validationResult).isTrue();
+
+        assertThat(diagnosticChain).isEqualTo(new BasicDiagnostic(Diagnostic.OK, null, 0, null, null));
+    }
+
+}

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/AbstractWidget.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/AbstractWidget.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Obeo.
+ * Copyright (c) 2019, 2021 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -12,10 +12,13 @@
  *******************************************************************************/
 package org.eclipse.sirius.web.forms;
 
+import java.util.List;
+
 import org.eclipse.sirius.web.annotations.graphql.GraphQLField;
 import org.eclipse.sirius.web.annotations.graphql.GraphQLID;
 import org.eclipse.sirius.web.annotations.graphql.GraphQLInterfaceType;
 import org.eclipse.sirius.web.annotations.graphql.GraphQLNonNull;
+import org.eclipse.sirius.web.forms.validation.Diagnostic;
 
 /**
  * Abstract class to be extended by all the widgets of the form-based representation.
@@ -26,10 +29,18 @@ import org.eclipse.sirius.web.annotations.graphql.GraphQLNonNull;
 public abstract class AbstractWidget {
     protected String id;
 
+    protected List<Diagnostic> diagnostics;
+
     @GraphQLID
     @GraphQLField
     @GraphQLNonNull
     public String getId() {
         return this.id;
+    }
+
+    @GraphQLField
+    @GraphQLNonNull
+    public List<@GraphQLNonNull Diagnostic> getDiagnostics() {
+        return this.diagnostics;
     }
 }

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/Checkbox.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/Checkbox.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Obeo.
+ * Copyright (c) 2019, 2021 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -13,6 +13,7 @@
 package org.eclipse.sirius.web.forms;
 
 import java.text.MessageFormat;
+import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
 
@@ -20,6 +21,7 @@ import org.eclipse.sirius.web.annotations.Immutable;
 import org.eclipse.sirius.web.annotations.graphql.GraphQLField;
 import org.eclipse.sirius.web.annotations.graphql.GraphQLNonNull;
 import org.eclipse.sirius.web.annotations.graphql.GraphQLObjectType;
+import org.eclipse.sirius.web.forms.validation.Diagnostic;
 import org.eclipse.sirius.web.representations.Status;
 
 /**
@@ -81,6 +83,8 @@ public final class Checkbox extends AbstractWidget {
 
         private Function<Boolean, Status> newValueHandler;
 
+        private List<Diagnostic> diagnostics;
+
         private Builder(String id) {
             this.id = Objects.requireNonNull(id);
         }
@@ -100,12 +104,18 @@ public final class Checkbox extends AbstractWidget {
             return this;
         }
 
+        public Builder diagnostics(List<Diagnostic> diagnostics) {
+            this.diagnostics = Objects.requireNonNull(diagnostics);
+            return this;
+        }
+
         public Checkbox build() {
             Checkbox checkbox = new Checkbox();
             checkbox.id = Objects.requireNonNull(this.id);
             checkbox.label = Objects.requireNonNull(this.label);
             checkbox.value = Objects.requireNonNull(this.value);
             checkbox.newValueHandler = Objects.requireNonNull(this.newValueHandler);
+            checkbox.diagnostics = Objects.requireNonNull(this.diagnostics);
             return checkbox;
         }
     }

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/List.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/List.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Obeo.
+ * Copyright (c) 2019, 2021 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -19,6 +19,7 @@ import org.eclipse.sirius.web.annotations.Immutable;
 import org.eclipse.sirius.web.annotations.graphql.GraphQLField;
 import org.eclipse.sirius.web.annotations.graphql.GraphQLNonNull;
 import org.eclipse.sirius.web.annotations.graphql.GraphQLObjectType;
+import org.eclipse.sirius.web.forms.validation.Diagnostic;
 
 /**
  * The list widget.
@@ -71,6 +72,8 @@ public final class List extends AbstractWidget {
 
         private java.util.List<ListItem> items;
 
+        private java.util.List<Diagnostic> diagnostics;
+
         private Builder(String id) {
             this.id = Objects.requireNonNull(id);
         }
@@ -85,11 +88,17 @@ public final class List extends AbstractWidget {
             return this;
         }
 
+        public Builder diagnostics(java.util.List<Diagnostic> diagnostics) {
+            this.diagnostics = Objects.requireNonNull(diagnostics);
+            return this;
+        }
+
         public List build() {
             List list = new List();
             list.id = Objects.requireNonNull(this.id);
             list.label = Objects.requireNonNull(this.label);
             list.items = Objects.requireNonNull(this.items);
+            list.diagnostics = Objects.requireNonNull(this.diagnostics);
             return list;
         }
     }

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/Radio.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/Radio.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Obeo.
+ * Copyright (c) 2019, 2021 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -21,6 +21,7 @@ import org.eclipse.sirius.web.annotations.Immutable;
 import org.eclipse.sirius.web.annotations.graphql.GraphQLField;
 import org.eclipse.sirius.web.annotations.graphql.GraphQLNonNull;
 import org.eclipse.sirius.web.annotations.graphql.GraphQLObjectType;
+import org.eclipse.sirius.web.forms.validation.Diagnostic;
 import org.eclipse.sirius.web.representations.Status;
 
 /**
@@ -82,6 +83,8 @@ public final class Radio extends AbstractWidget {
 
         private Function<String, Status> newValueHandler;
 
+        private List<Diagnostic> diagnostics;
+
         private Builder(String id) {
             this.id = Objects.requireNonNull(id);
         }
@@ -101,12 +104,18 @@ public final class Radio extends AbstractWidget {
             return this;
         }
 
+        public Builder diagnostics(List<Diagnostic> diagnostics) {
+            this.diagnostics = Objects.requireNonNull(diagnostics);
+            return this;
+        }
+
         public Radio build() {
             Radio radio = new Radio();
             radio.id = Objects.requireNonNull(this.id);
             radio.label = Objects.requireNonNull(this.label);
             radio.options = Objects.requireNonNull(this.options);
             radio.newValueHandler = Objects.requireNonNull(this.newValueHandler);
+            radio.diagnostics = Objects.requireNonNull(this.diagnostics);
             return radio;
         }
     }

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/Select.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/Select.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Obeo.
+ * Copyright (c) 2019, 2021 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -21,6 +21,7 @@ import org.eclipse.sirius.web.annotations.Immutable;
 import org.eclipse.sirius.web.annotations.graphql.GraphQLField;
 import org.eclipse.sirius.web.annotations.graphql.GraphQLNonNull;
 import org.eclipse.sirius.web.annotations.graphql.GraphQLObjectType;
+import org.eclipse.sirius.web.forms.validation.Diagnostic;
 import org.eclipse.sirius.web.representations.Status;
 
 /**
@@ -91,6 +92,8 @@ public final class Select extends AbstractWidget {
 
         private Function<String, Status> newValueHandler;
 
+        private List<Diagnostic> diagnostics;
+
         private Builder(String id) {
             this.id = Objects.requireNonNull(id);
         }
@@ -115,6 +118,11 @@ public final class Select extends AbstractWidget {
             return this;
         }
 
+        public Builder diagnostics(List<Diagnostic> diagnostics) {
+            this.diagnostics = Objects.requireNonNull(diagnostics);
+            return this;
+        }
+
         public Select build() {
             Select select = new Select();
             select.id = Objects.requireNonNull(this.id);
@@ -122,6 +130,7 @@ public final class Select extends AbstractWidget {
             select.options = Objects.requireNonNull(this.options);
             select.value = this.value;
             select.newValueHandler = Objects.requireNonNull(this.newValueHandler);
+            select.diagnostics = Objects.requireNonNull(this.diagnostics);
             return select;
         }
     }

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/Textarea.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/Textarea.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Obeo.
+ * Copyright (c) 2019, 2021 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -13,12 +13,14 @@
 package org.eclipse.sirius.web.forms;
 
 import java.text.MessageFormat;
+import java.util.List;
 import java.util.Objects;
 
 import org.eclipse.sirius.web.annotations.Immutable;
 import org.eclipse.sirius.web.annotations.graphql.GraphQLField;
 import org.eclipse.sirius.web.annotations.graphql.GraphQLNonNull;
 import org.eclipse.sirius.web.annotations.graphql.GraphQLObjectType;
+import org.eclipse.sirius.web.forms.validation.Diagnostic;
 
 /**
  * The text area widget.
@@ -72,6 +74,8 @@ public final class Textarea extends AbstractWidget {
 
         private String value;
 
+        private List<Diagnostic> diagnostics;
+
         private Builder(String id) {
             this.id = Objects.requireNonNull(id);
         }
@@ -86,11 +90,17 @@ public final class Textarea extends AbstractWidget {
             return this;
         }
 
+        public Builder diagnostics(List<Diagnostic> diagnostics) {
+            this.diagnostics = Objects.requireNonNull(diagnostics);
+            return this;
+        }
+
         public Textarea build() {
             Textarea textarea = new Textarea();
             textarea.id = Objects.requireNonNull(this.id);
             textarea.label = Objects.requireNonNull(this.label);
             textarea.value = Objects.requireNonNull(this.value);
+            textarea.diagnostics = Objects.requireNonNull(this.diagnostics);
             return textarea;
         }
     }

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/Textfield.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/Textfield.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Obeo.
+ * Copyright (c) 2019, 2021 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -13,6 +13,7 @@
 package org.eclipse.sirius.web.forms;
 
 import java.text.MessageFormat;
+import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
 
@@ -20,6 +21,7 @@ import org.eclipse.sirius.web.annotations.Immutable;
 import org.eclipse.sirius.web.annotations.graphql.GraphQLField;
 import org.eclipse.sirius.web.annotations.graphql.GraphQLNonNull;
 import org.eclipse.sirius.web.annotations.graphql.GraphQLObjectType;
+import org.eclipse.sirius.web.forms.validation.Diagnostic;
 import org.eclipse.sirius.web.representations.Status;
 
 /**
@@ -81,6 +83,8 @@ public final class Textfield extends AbstractWidget {
 
         private Function<String, Status> newValueHandler;
 
+        private List<Diagnostic> diagnostics;
+
         private Builder(String id) {
             this.id = Objects.requireNonNull(id);
         }
@@ -100,12 +104,18 @@ public final class Textfield extends AbstractWidget {
             return this;
         }
 
+        public Builder diagnostics(List<Diagnostic> diagnostics) {
+            this.diagnostics = Objects.requireNonNull(diagnostics);
+            return this;
+        }
+
         public Textfield build() {
             Textfield textfield = new Textfield();
             textfield.id = Objects.requireNonNull(this.id);
             textfield.label = Objects.requireNonNull(this.label);
             textfield.value = Objects.requireNonNull(this.value);
             textfield.newValueHandler = Objects.requireNonNull(this.newValueHandler);
+            textfield.diagnostics = Objects.requireNonNull(this.diagnostics);
             return textfield;
         }
     }

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/components/CheckboxComponent.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/components/CheckboxComponent.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Obeo.
+ * Copyright (c) 2019, 2021 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.sirius.web.forms.components;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -20,6 +21,8 @@ import org.eclipse.sirius.web.components.Element;
 import org.eclipse.sirius.web.components.IComponent;
 import org.eclipse.sirius.web.forms.description.CheckboxDescription;
 import org.eclipse.sirius.web.forms.elements.CheckboxElementProps;
+import org.eclipse.sirius.web.forms.validation.DiagnosticComponent;
+import org.eclipse.sirius.web.forms.validation.DiagnosticComponentProps;
 import org.eclipse.sirius.web.representations.Status;
 import org.eclipse.sirius.web.representations.VariableManager;
 
@@ -47,11 +50,14 @@ public class CheckboxComponent implements IComponent {
         BiFunction<VariableManager, Boolean, Status> genericHandler = checkboxDescription.getNewValueHandler();
         Function<Boolean, Status> specializedHandler = newValue -> genericHandler.apply(variableManager, newValue);
 
+        List<Element> children = List.of(new Element(DiagnosticComponent.class, new DiagnosticComponentProps(checkboxDescription, variableManager)));
+
         // @formatter:off
         CheckboxElementProps checkboxElementProps = CheckboxElementProps.newCheckboxElementProps(id)
                 .label(label)
                 .value(value.booleanValue())
                 .newValueHandler(specializedHandler)
+                .children(children)
                 .build();
         return new Element(CheckboxElementProps.TYPE, checkboxElementProps);
         // @formatter:on

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/components/ListComponent.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/components/ListComponent.java
@@ -21,6 +21,8 @@ import org.eclipse.sirius.web.components.IComponent;
 import org.eclipse.sirius.web.forms.ListItem;
 import org.eclipse.sirius.web.forms.description.ListDescription;
 import org.eclipse.sirius.web.forms.elements.ListElementProps;
+import org.eclipse.sirius.web.forms.validation.DiagnosticComponent;
+import org.eclipse.sirius.web.forms.validation.DiagnosticComponentProps;
 import org.eclipse.sirius.web.representations.VariableManager;
 
 /**
@@ -47,6 +49,8 @@ public class ListComponent implements IComponent {
         String label = listDescription.getLabelProvider().apply(variableManager);
         List<Object> itemCandidates = listDescription.getItemsProvider().apply(variableManager);
 
+        List<Element> children = List.of(new Element(DiagnosticComponent.class, new DiagnosticComponentProps(listDescription, variableManager)));
+
         List<ListItem> items = new ArrayList<>();
         for (Object itemCandidate : itemCandidates) {
             VariableManager itemVariableManager = variableManager.createChild();
@@ -70,6 +74,7 @@ public class ListComponent implements IComponent {
         ListElementProps listElementProps = ListElementProps.newListElementProps(id)
                 .label(label)
                 .items(items)
+                .children(children)
                 .build();
         // @formatter:on
 

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/components/RadioComponent.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/components/RadioComponent.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Obeo.
+ * Copyright (c) 2019, 2021 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -23,6 +23,8 @@ import org.eclipse.sirius.web.components.IComponent;
 import org.eclipse.sirius.web.forms.RadioOption;
 import org.eclipse.sirius.web.forms.description.RadioDescription;
 import org.eclipse.sirius.web.forms.elements.RadioElementProps;
+import org.eclipse.sirius.web.forms.validation.DiagnosticComponent;
+import org.eclipse.sirius.web.forms.validation.DiagnosticComponentProps;
 import org.eclipse.sirius.web.representations.Status;
 import org.eclipse.sirius.web.representations.VariableManager;
 
@@ -49,6 +51,8 @@ public class RadioComponent implements IComponent {
         String id = radioDescription.getIdProvider().apply(variableManager);
         String label = radioDescription.getLabelProvider().apply(variableManager);
         List<Object> optionCandidates = radioDescription.getOptionsProvider().apply(variableManager);
+
+        List<Element> children = List.of(new Element(DiagnosticComponent.class, new DiagnosticComponentProps(radioDescription, variableManager)));
 
         List<RadioOption> options = new ArrayList<>();
         for (Object candidate : optionCandidates) {
@@ -79,6 +83,7 @@ public class RadioComponent implements IComponent {
                 .label(label)
                 .options(options)
                 .newValueHandler(specializedHandler)
+                .children(children)
                 .build();
         return new Element(RadioElementProps.TYPE, radioElementProps);
         // @formatter:on

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/components/SelectComponent.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/components/SelectComponent.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Obeo.
+ * Copyright (c) 2019, 2021 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -22,6 +22,8 @@ import org.eclipse.sirius.web.components.IComponent;
 import org.eclipse.sirius.web.forms.SelectOption;
 import org.eclipse.sirius.web.forms.description.SelectDescription;
 import org.eclipse.sirius.web.forms.elements.SelectElementProps;
+import org.eclipse.sirius.web.forms.validation.DiagnosticComponent;
+import org.eclipse.sirius.web.forms.validation.DiagnosticComponentProps;
 import org.eclipse.sirius.web.representations.Status;
 import org.eclipse.sirius.web.representations.VariableManager;
 
@@ -50,6 +52,8 @@ public class SelectComponent implements IComponent {
         List<Object> optionCandidates = selectDescription.getOptionsProvider().apply(variableManager);
         String value = selectDescription.getValueProvider().apply(variableManager);
 
+        List<Element> children = List.of(new Element(DiagnosticComponent.class, new DiagnosticComponentProps(selectDescription, variableManager)));
+
         List<SelectOption> options = new ArrayList<>();
         for (Object candidate : optionCandidates) {
             VariableManager optionVariableManager = variableManager.createChild();
@@ -76,6 +80,7 @@ public class SelectComponent implements IComponent {
                 .options(options)
                 .value(value)
                 .newValueHandler(specializedHandler)
+                .children(children)
                 .build();
         return new Element(SelectElementProps.TYPE, selectElementProps);
         // @formatter:on

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/components/TextareaComponent.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/components/TextareaComponent.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Obeo.
+ * Copyright (c) 2019, 2021 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.sirius.web.forms.components;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
 
@@ -19,6 +20,8 @@ import org.eclipse.sirius.web.components.Element;
 import org.eclipse.sirius.web.components.IComponent;
 import org.eclipse.sirius.web.forms.description.TextareaDescription;
 import org.eclipse.sirius.web.forms.elements.TextareaElementProps;
+import org.eclipse.sirius.web.forms.validation.DiagnosticComponent;
+import org.eclipse.sirius.web.forms.validation.DiagnosticComponentProps;
 import org.eclipse.sirius.web.representations.Status;
 import org.eclipse.sirius.web.representations.VariableManager;
 
@@ -47,11 +50,14 @@ public class TextareaComponent implements IComponent {
             return textareaDescription.getNewValueHandler().apply(variableManager, newValue);
         };
 
+        List<Element> children = List.of(new Element(DiagnosticComponent.class, new DiagnosticComponentProps(textareaDescription, variableManager)));
+
         // @formatter:off
         TextareaElementProps textareaElementProps = TextareaElementProps.newTextareaElementProps(id)
                 .label(label)
                 .value(value)
                 .newValueHandler(specializedHandler)
+                .children(children)
                 .build();
         return new Element(TextareaElementProps.TYPE, textareaElementProps);
         // @formatter:on

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/components/TextfieldComponent.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/components/TextfieldComponent.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Obeo.
+ * Copyright (c) 2019, 2021 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.sirius.web.forms.components;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -20,6 +21,8 @@ import org.eclipse.sirius.web.components.Element;
 import org.eclipse.sirius.web.components.IComponent;
 import org.eclipse.sirius.web.forms.description.TextfieldDescription;
 import org.eclipse.sirius.web.forms.elements.TextfieldElementProps;
+import org.eclipse.sirius.web.forms.validation.DiagnosticComponent;
+import org.eclipse.sirius.web.forms.validation.DiagnosticComponentProps;
 import org.eclipse.sirius.web.representations.Status;
 import org.eclipse.sirius.web.representations.VariableManager;
 
@@ -48,12 +51,14 @@ public class TextfieldComponent implements IComponent {
         Function<String, Status> specializedHandler = newValue -> {
             return genericHandler.apply(variableManager, newValue);
         };
+        List<Element> children = List.of(new Element(DiagnosticComponent.class, new DiagnosticComponentProps(textfieldDescription, variableManager)));
 
         // @formatter:off
         TextfieldElementProps textfieldElementProps = TextfieldElementProps.newTextfieldElementProps(id)
                 .label(label)
                 .value(value)
                 .newValueHandler(specializedHandler)
+                .children(children)
                 .build();
         return new Element(TextfieldElementProps.TYPE, textfieldElementProps);
         // @formatter:on

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/description/AbstractWidgetDescription.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/description/AbstractWidgetDescription.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Obeo.
+ * Copyright (c) 2019, 2021 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -12,11 +12,33 @@
  *******************************************************************************/
 package org.eclipse.sirius.web.forms.description;
 
+import java.util.List;
+import java.util.function.Function;
+
+import org.eclipse.sirius.web.representations.VariableManager;
+
 /**
  * The common superclass of all the widget descriptions.
  *
  * @author sbegaudeau
  */
 public abstract class AbstractWidgetDescription extends AbstractControlDescription {
-    // Nothing for now
+
+    protected Function<VariableManager, List<Object>> diagnosticsProvider;
+
+    protected Function<Object, String> kindProvider;
+
+    protected Function<Object, String> messageProvider;
+
+    public Function<VariableManager, List<Object>> getDiagnosticsProvider() {
+        return this.diagnosticsProvider;
+    }
+
+    public Function<Object, String> getKindProvider() {
+        return this.kindProvider;
+    }
+
+    public Function<Object, String> getMessageProvider() {
+        return this.messageProvider;
+    }
 }

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/description/CheckboxDescription.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/description/CheckboxDescription.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Obeo.
+ * Copyright (c) 2019, 2021 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -13,6 +13,7 @@
 package org.eclipse.sirius.web.forms.description;
 
 import java.text.MessageFormat;
+import java.util.List;
 import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -84,6 +85,12 @@ public final class CheckboxDescription extends AbstractWidgetDescription {
 
         private BiFunction<VariableManager, Boolean, Status> newValueHandler;
 
+        private Function<VariableManager, List<Object>> diagnosticsProvider;
+
+        private Function<Object, String> kindProvider;
+
+        private Function<Object, String> messageProvider;
+
         private Builder(String id) {
             this.id = Objects.requireNonNull(id);
         }
@@ -108,6 +115,21 @@ public final class CheckboxDescription extends AbstractWidgetDescription {
             return this;
         }
 
+        public Builder diagnosticsProvider(Function<VariableManager, List<Object>> diagnosticsProvider) {
+            this.diagnosticsProvider = Objects.requireNonNull(diagnosticsProvider);
+            return this;
+        }
+
+        public Builder kindProvider(Function<Object, String> kindProvider) {
+            this.kindProvider = Objects.requireNonNull(kindProvider);
+            return this;
+        }
+
+        public Builder messageProvider(Function<Object, String> messageProvider) {
+            this.messageProvider = Objects.requireNonNull(messageProvider);
+            return this;
+        }
+
         public CheckboxDescription build() {
             CheckboxDescription checkboxDescription = new CheckboxDescription();
             checkboxDescription.id = Objects.requireNonNull(this.id);
@@ -115,6 +137,9 @@ public final class CheckboxDescription extends AbstractWidgetDescription {
             checkboxDescription.labelProvider = Objects.requireNonNull(this.labelProvider);
             checkboxDescription.valueProvider = Objects.requireNonNull(this.valueProvider);
             checkboxDescription.newValueHandler = Objects.requireNonNull(this.newValueHandler);
+            checkboxDescription.diagnosticsProvider = Objects.requireNonNull(this.diagnosticsProvider);
+            checkboxDescription.kindProvider = Objects.requireNonNull(this.kindProvider);
+            checkboxDescription.messageProvider = Objects.requireNonNull(this.messageProvider);
             return checkboxDescription;
         }
     }

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/description/ListDescription.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/description/ListDescription.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Obeo.
+ * Copyright (c) 2019, 2021 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -99,6 +99,12 @@ public final class ListDescription extends AbstractWidgetDescription {
 
         private Function<VariableManager, String> itemImageURLProvider;
 
+        private Function<VariableManager, List<Object>> diagnosticsProvider;
+
+        private Function<Object, String> kindProvider;
+
+        private Function<Object, String> messageProvider;
+
         private Builder(String id) {
             this.id = Objects.requireNonNull(id);
         }
@@ -133,6 +139,21 @@ public final class ListDescription extends AbstractWidgetDescription {
             return this;
         }
 
+        public Builder diagnosticsProvider(Function<VariableManager, List<Object>> diagnosticsProvider) {
+            this.diagnosticsProvider = Objects.requireNonNull(diagnosticsProvider);
+            return this;
+        }
+
+        public Builder kindProvider(Function<Object, String> kindProvider) {
+            this.kindProvider = Objects.requireNonNull(kindProvider);
+            return this;
+        }
+
+        public Builder messageProvider(Function<Object, String> messageProvider) {
+            this.messageProvider = Objects.requireNonNull(messageProvider);
+            return this;
+        }
+
         public ListDescription build() {
             ListDescription listDescription = new ListDescription();
             listDescription.id = Objects.requireNonNull(this.id);
@@ -142,6 +163,9 @@ public final class ListDescription extends AbstractWidgetDescription {
             listDescription.itemIdProvider = Objects.requireNonNull(this.itemIdProvider);
             listDescription.itemLabelProvider = Objects.requireNonNull(this.itemLabelProvider);
             listDescription.itemImageURLProvider = Objects.requireNonNull(this.itemImageURLProvider);
+            listDescription.diagnosticsProvider = Objects.requireNonNull(this.diagnosticsProvider);
+            listDescription.kindProvider = Objects.requireNonNull(this.kindProvider);
+            listDescription.messageProvider = Objects.requireNonNull(this.messageProvider);
             return listDescription;
         }
     }

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/description/OptionDescription.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/description/OptionDescription.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Obeo.
+ * Copyright (c) 2019, 2021 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -13,6 +13,7 @@
 package org.eclipse.sirius.web.forms.description;
 
 import java.text.MessageFormat;
+import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
 
@@ -71,6 +72,12 @@ public final class OptionDescription extends AbstractWidgetDescription {
 
         private Function<VariableManager, Boolean> selectedProvider;
 
+        private Function<VariableManager, List<Object>> diagnosticsProvider;
+
+        private Function<Object, String> kindProvider;
+
+        private Function<Object, String> messageProvider;
+
         private Builder(String id) {
             this.id = Objects.requireNonNull(id);
         }
@@ -85,12 +92,30 @@ public final class OptionDescription extends AbstractWidgetDescription {
             return this;
         }
 
+        public Builder diagnosticsProvider(Function<VariableManager, List<Object>> diagnosticsProvider) {
+            this.diagnosticsProvider = Objects.requireNonNull(diagnosticsProvider);
+            return this;
+        }
+
+        public Builder kindProvider(Function<Object, String> kindProvider) {
+            this.kindProvider = Objects.requireNonNull(kindProvider);
+            return this;
+        }
+
+        public Builder messageProvider(Function<Object, String> messageProvider) {
+            this.messageProvider = Objects.requireNonNull(messageProvider);
+            return this;
+        }
+
         public OptionDescription build() {
-            OptionDescription textfieldDescription = new OptionDescription();
-            textfieldDescription.id = Objects.requireNonNull(this.id);
-            textfieldDescription.labelProvider = Objects.requireNonNull(this.labelProvider);
-            textfieldDescription.selectedProvider = Objects.requireNonNull(this.selectedProvider);
-            return textfieldDescription;
+            OptionDescription optionDescription = new OptionDescription();
+            optionDescription.id = Objects.requireNonNull(this.id);
+            optionDescription.labelProvider = Objects.requireNonNull(this.labelProvider);
+            optionDescription.selectedProvider = Objects.requireNonNull(this.selectedProvider);
+            optionDescription.diagnosticsProvider = Objects.requireNonNull(this.diagnosticsProvider);
+            optionDescription.kindProvider = Objects.requireNonNull(this.kindProvider);
+            optionDescription.messageProvider = Objects.requireNonNull(this.messageProvider);
+            return optionDescription;
         }
     }
 }

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/description/RadioDescription.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/description/RadioDescription.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Obeo.
+ * Copyright (c) 2019, 2021 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -109,6 +109,12 @@ public final class RadioDescription extends AbstractWidgetDescription {
 
         private BiFunction<VariableManager, String, Status> newValueHandler;
 
+        private Function<VariableManager, List<Object>> diagnosticsProvider;
+
+        private Function<Object, String> kindProvider;
+
+        private Function<Object, String> messageProvider;
+
         private Builder(String id) {
             this.id = Objects.requireNonNull(id);
         }
@@ -148,6 +154,21 @@ public final class RadioDescription extends AbstractWidgetDescription {
             return this;
         }
 
+        public Builder diagnosticsProvider(Function<VariableManager, List<Object>> diagnosticsProvider) {
+            this.diagnosticsProvider = Objects.requireNonNull(diagnosticsProvider);
+            return this;
+        }
+
+        public Builder kindProvider(Function<Object, String> kindProvider) {
+            this.kindProvider = Objects.requireNonNull(kindProvider);
+            return this;
+        }
+
+        public Builder messageProvider(Function<Object, String> messageProvider) {
+            this.messageProvider = Objects.requireNonNull(messageProvider);
+            return this;
+        }
+
         public RadioDescription build() {
             RadioDescription radioDescription = new RadioDescription();
             radioDescription.id = Objects.requireNonNull(this.id);
@@ -158,6 +179,9 @@ public final class RadioDescription extends AbstractWidgetDescription {
             radioDescription.optionLabelProvider = Objects.requireNonNull(this.optionLabelProvider);
             radioDescription.optionSelectedProvider = Objects.requireNonNull(this.optionSelectedProvider);
             radioDescription.newValueHandler = Objects.requireNonNull(this.newValueHandler);
+            radioDescription.diagnosticsProvider = Objects.requireNonNull(this.diagnosticsProvider);
+            radioDescription.kindProvider = Objects.requireNonNull(this.kindProvider);
+            radioDescription.messageProvider = Objects.requireNonNull(this.messageProvider);
             return radioDescription;
         }
 

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/description/SelectDescription.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/description/SelectDescription.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Obeo.
+ * Copyright (c) 2019, 2021 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -109,6 +109,12 @@ public final class SelectDescription extends AbstractWidgetDescription {
 
         private BiFunction<VariableManager, String, Status> newValueHandler;
 
+        private Function<VariableManager, List<Object>> diagnosticsProvider;
+
+        private Function<Object, String> kindProvider;
+
+        private Function<Object, String> messageProvider;
+
         private Builder(String id) {
             this.id = Objects.requireNonNull(id);
         }
@@ -148,6 +154,21 @@ public final class SelectDescription extends AbstractWidgetDescription {
             return this;
         }
 
+        public Builder diagnosticsProvider(Function<VariableManager, List<Object>> diagnosticsProvider) {
+            this.diagnosticsProvider = Objects.requireNonNull(diagnosticsProvider);
+            return this;
+        }
+
+        public Builder kindProvider(Function<Object, String> kindProvider) {
+            this.kindProvider = Objects.requireNonNull(kindProvider);
+            return this;
+        }
+
+        public Builder messageProvider(Function<Object, String> messageProvider) {
+            this.messageProvider = Objects.requireNonNull(messageProvider);
+            return this;
+        }
+
         public SelectDescription build() {
             SelectDescription selectDescription = new SelectDescription();
             selectDescription.id = Objects.requireNonNull(this.id);
@@ -158,6 +179,9 @@ public final class SelectDescription extends AbstractWidgetDescription {
             selectDescription.optionLabelProvider = Objects.requireNonNull(this.optionLabelProvider);
             selectDescription.valueProvider = Objects.requireNonNull(this.valueProvider);
             selectDescription.newValueHandler = Objects.requireNonNull(this.newValueHandler);
+            selectDescription.diagnosticsProvider = Objects.requireNonNull(this.diagnosticsProvider);
+            selectDescription.kindProvider = Objects.requireNonNull(this.kindProvider);
+            selectDescription.messageProvider = Objects.requireNonNull(this.messageProvider);
             return selectDescription;
         }
 

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/description/TextareaDescription.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/description/TextareaDescription.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Obeo.
+ * Copyright (c) 2019, 2021 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -13,6 +13,7 @@
 package org.eclipse.sirius.web.forms.description;
 
 import java.text.MessageFormat;
+import java.util.List;
 import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -84,6 +85,12 @@ public final class TextareaDescription extends AbstractWidgetDescription {
 
         private BiFunction<VariableManager, String, Status> newValueHandler;
 
+        private Function<VariableManager, List<Object>> diagnosticsProvider;
+
+        private Function<Object, String> kindProvider;
+
+        private Function<Object, String> messageProvider;
+
         private Builder(String id) {
             this.id = Objects.requireNonNull(id);
         }
@@ -108,6 +115,21 @@ public final class TextareaDescription extends AbstractWidgetDescription {
             return this;
         }
 
+        public Builder diagnosticsProvider(Function<VariableManager, List<Object>> diagnosticsProvider) {
+            this.diagnosticsProvider = Objects.requireNonNull(diagnosticsProvider);
+            return this;
+        }
+
+        public Builder kindProvider(Function<Object, String> kindProvider) {
+            this.kindProvider = Objects.requireNonNull(kindProvider);
+            return this;
+        }
+
+        public Builder messageProvider(Function<Object, String> messageProvider) {
+            this.messageProvider = Objects.requireNonNull(messageProvider);
+            return this;
+        }
+
         public TextareaDescription build() {
             TextareaDescription textareaDescription = new TextareaDescription();
             textareaDescription.id = Objects.requireNonNull(this.id);
@@ -115,6 +137,9 @@ public final class TextareaDescription extends AbstractWidgetDescription {
             textareaDescription.labelProvider = Objects.requireNonNull(this.labelProvider);
             textareaDescription.valueProvider = Objects.requireNonNull(this.valueProvider);
             textareaDescription.newValueHandler = Objects.requireNonNull(this.newValueHandler);
+            textareaDescription.diagnosticsProvider = Objects.requireNonNull(this.diagnosticsProvider);
+            textareaDescription.kindProvider = Objects.requireNonNull(this.kindProvider);
+            textareaDescription.messageProvider = Objects.requireNonNull(this.messageProvider);
             return textareaDescription;
         }
     }

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/description/TextfieldDescription.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/description/TextfieldDescription.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Obeo.
+ * Copyright (c) 2019, 2021 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -13,6 +13,7 @@
 package org.eclipse.sirius.web.forms.description;
 
 import java.text.MessageFormat;
+import java.util.List;
 import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -83,6 +84,12 @@ public final class TextfieldDescription extends AbstractWidgetDescription {
 
         private BiFunction<VariableManager, String, Status> newValueHandler;
 
+        private Function<VariableManager, List<Object>> diagnosticsProvider;
+
+        private Function<Object, String> kindProvider;
+
+        private Function<Object, String> messageProvider;
+
         private Builder(String id) {
             this.id = Objects.requireNonNull(id);
         }
@@ -107,6 +114,21 @@ public final class TextfieldDescription extends AbstractWidgetDescription {
             return this;
         }
 
+        public Builder diagnosticsProvider(Function<VariableManager, List<Object>> diagnosticsProvider) {
+            this.diagnosticsProvider = Objects.requireNonNull(diagnosticsProvider);
+            return this;
+        }
+
+        public Builder kindProvider(Function<Object, String> kindProvider) {
+            this.kindProvider = Objects.requireNonNull(kindProvider);
+            return this;
+        }
+
+        public Builder messageProvider(Function<Object, String> messageProvider) {
+            this.messageProvider = Objects.requireNonNull(messageProvider);
+            return this;
+        }
+
         public TextfieldDescription build() {
             TextfieldDescription textfieldDescription = new TextfieldDescription();
             textfieldDescription.id = Objects.requireNonNull(this.id);
@@ -114,6 +136,9 @@ public final class TextfieldDescription extends AbstractWidgetDescription {
             textfieldDescription.labelProvider = Objects.requireNonNull(this.labelProvider);
             textfieldDescription.valueProvider = Objects.requireNonNull(this.valueProvider);
             textfieldDescription.newValueHandler = Objects.requireNonNull(this.newValueHandler);
+            textfieldDescription.diagnosticsProvider = Objects.requireNonNull(this.diagnosticsProvider);
+            textfieldDescription.kindProvider = Objects.requireNonNull(this.kindProvider);
+            textfieldDescription.messageProvider = Objects.requireNonNull(this.messageProvider);
             return textfieldDescription;
         }
     }

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/elements/CheckboxElementProps.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/elements/CheckboxElementProps.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Obeo.
+ * Copyright (c) 2019, 2021 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -13,10 +13,12 @@
 package org.eclipse.sirius.web.forms.elements;
 
 import java.text.MessageFormat;
+import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
 
 import org.eclipse.sirius.web.annotations.Immutable;
+import org.eclipse.sirius.web.components.Element;
 import org.eclipse.sirius.web.components.IProps;
 import org.eclipse.sirius.web.representations.Status;
 
@@ -37,6 +39,8 @@ public final class CheckboxElementProps implements IProps {
 
     private Function<Boolean, Status> newValueHandler;
 
+    private List<Element> children;
+
     private CheckboxElementProps() {
         // Prevent instantiation
     }
@@ -55,6 +59,11 @@ public final class CheckboxElementProps implements IProps {
 
     public Function<Boolean, Status> getNewValueHandler() {
         return this.newValueHandler;
+    }
+
+    @Override
+    public List<Element> getChildren() {
+        return this.children;
     }
 
     public static Builder newCheckboxElementProps(String id) {
@@ -82,6 +91,8 @@ public final class CheckboxElementProps implements IProps {
 
         private Function<Boolean, Status> newValueHandler;
 
+        private List<Element> children;
+
         private Builder(String id) {
             this.id = Objects.requireNonNull(id);
         }
@@ -101,12 +112,18 @@ public final class CheckboxElementProps implements IProps {
             return this;
         }
 
+        public Builder children(List<Element> children) {
+            this.children = Objects.requireNonNull(children);
+            return this;
+        }
+
         public CheckboxElementProps build() {
             CheckboxElementProps checkboxElementProps = new CheckboxElementProps();
             checkboxElementProps.id = Objects.requireNonNull(this.id);
             checkboxElementProps.label = Objects.requireNonNull(this.label);
             checkboxElementProps.value = Objects.requireNonNull(this.value);
             checkboxElementProps.newValueHandler = Objects.requireNonNull(this.newValueHandler);
+            checkboxElementProps.children = Objects.requireNonNull(this.children);
             return checkboxElementProps;
         }
     }

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/elements/ListElementProps.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/elements/ListElementProps.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Obeo.
+ * Copyright (c) 2019, 2021 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Objects;
 
 import org.eclipse.sirius.web.annotations.Immutable;
+import org.eclipse.sirius.web.components.Element;
 import org.eclipse.sirius.web.components.IProps;
 import org.eclipse.sirius.web.forms.ListItem;
 
@@ -35,6 +36,8 @@ public final class ListElementProps implements IProps {
 
     private List<ListItem> items;
 
+    private List<Element> children;
+
     private ListElementProps() {
         // Prevent instantiation
     }
@@ -49,6 +52,11 @@ public final class ListElementProps implements IProps {
 
     public List<ListItem> getItems() {
         return this.items;
+    }
+
+    @Override
+    public List<Element> getChildren() {
+        return this.children;
     }
 
     public static Builder newListElementProps(String id) {
@@ -75,6 +83,8 @@ public final class ListElementProps implements IProps {
 
         private List<ListItem> items;
 
+        private List<Element> children;
+
         private Builder(String id) {
             this.id = Objects.requireNonNull(id);
         }
@@ -89,11 +99,17 @@ public final class ListElementProps implements IProps {
             return this;
         }
 
+        public Builder children(List<Element> children) {
+            this.children = Objects.requireNonNull(children);
+            return this;
+        }
+
         public ListElementProps build() {
             ListElementProps listElementProps = new ListElementProps();
             listElementProps.id = Objects.requireNonNull(this.id);
             listElementProps.label = Objects.requireNonNull(this.label);
             listElementProps.items = Objects.requireNonNull(this.items);
+            listElementProps.children = Objects.requireNonNull(this.children);
             return listElementProps;
         }
     }

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/elements/RadioElementProps.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/elements/RadioElementProps.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Obeo.
+ * Copyright (c) 2019, 2021 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -18,6 +18,7 @@ import java.util.Objects;
 import java.util.function.Function;
 
 import org.eclipse.sirius.web.annotations.Immutable;
+import org.eclipse.sirius.web.components.Element;
 import org.eclipse.sirius.web.components.IProps;
 import org.eclipse.sirius.web.forms.RadioOption;
 import org.eclipse.sirius.web.representations.Status;
@@ -39,6 +40,8 @@ public final class RadioElementProps implements IProps {
 
     private Function<String, Status> newValueHandler;
 
+    private List<Element> children;
+
     private RadioElementProps() {
         // Prevent instantiation
     }
@@ -57,6 +60,11 @@ public final class RadioElementProps implements IProps {
 
     public Function<String, Status> getNewValueHandler() {
         return this.newValueHandler;
+    }
+
+    @Override
+    public List<Element> getChildren() {
+        return this.children;
     }
 
     public static Builder newRadioElementProps(String id) {
@@ -84,6 +92,8 @@ public final class RadioElementProps implements IProps {
 
         private Function<String, Status> newValueHandler;
 
+        private List<Element> children;
+
         private Builder(String id) {
             this.id = Objects.requireNonNull(id);
         }
@@ -103,12 +113,18 @@ public final class RadioElementProps implements IProps {
             return this;
         }
 
+        public Builder children(List<Element> children) {
+            this.children = Objects.requireNonNull(children);
+            return this;
+        }
+
         public RadioElementProps build() {
             RadioElementProps radioElementProps = new RadioElementProps();
             radioElementProps.id = Objects.requireNonNull(this.id);
             radioElementProps.label = Objects.requireNonNull(this.label);
             radioElementProps.options = Objects.requireNonNull(this.options);
             radioElementProps.newValueHandler = Objects.requireNonNull(this.newValueHandler);
+            radioElementProps.children = Objects.requireNonNull(this.children);
             return radioElementProps;
         }
     }

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/elements/SelectElementProps.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/elements/SelectElementProps.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Obeo.
+ * Copyright (c) 2019, 2021 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -18,6 +18,7 @@ import java.util.Objects;
 import java.util.function.Function;
 
 import org.eclipse.sirius.web.annotations.Immutable;
+import org.eclipse.sirius.web.components.Element;
 import org.eclipse.sirius.web.components.IProps;
 import org.eclipse.sirius.web.forms.SelectOption;
 import org.eclipse.sirius.web.representations.Status;
@@ -41,6 +42,8 @@ public final class SelectElementProps implements IProps {
 
     private Function<String, Status> newValueHandler;
 
+    private List<Element> children;
+
     private SelectElementProps() {
         // Prevent instantiation
     }
@@ -63,6 +66,11 @@ public final class SelectElementProps implements IProps {
 
     public Function<String, Status> getNewValueHandler() {
         return this.newValueHandler;
+    }
+
+    @Override
+    public List<Element> getChildren() {
+        return this.children;
     }
 
     public static Builder newSelectElementProps(String id) {
@@ -93,6 +101,8 @@ public final class SelectElementProps implements IProps {
 
         private Function<String, Status> newValueHandler;
 
+        private List<Element> children;
+
         private Builder(String id) {
             this.id = Objects.requireNonNull(id);
         }
@@ -117,6 +127,11 @@ public final class SelectElementProps implements IProps {
             return this;
         }
 
+        public Builder children(List<Element> children) {
+            this.children = Objects.requireNonNull(children);
+            return this;
+        }
+
         public SelectElementProps build() {
             SelectElementProps selectElementProps = new SelectElementProps();
             selectElementProps.id = Objects.requireNonNull(this.id);
@@ -124,6 +139,7 @@ public final class SelectElementProps implements IProps {
             selectElementProps.options = Objects.requireNonNull(this.options);
             selectElementProps.value = this.value;
             selectElementProps.newValueHandler = Objects.requireNonNull(this.newValueHandler);
+            selectElementProps.children = Objects.requireNonNull(this.children);
             return selectElementProps;
         }
     }

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/elements/TextareaElementProps.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/elements/TextareaElementProps.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Obeo.
+ * Copyright (c) 2019, 2021 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -13,10 +13,12 @@
 package org.eclipse.sirius.web.forms.elements;
 
 import java.text.MessageFormat;
+import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
 
 import org.eclipse.sirius.web.annotations.Immutable;
+import org.eclipse.sirius.web.components.Element;
 import org.eclipse.sirius.web.components.IProps;
 import org.eclipse.sirius.web.representations.Status;
 
@@ -37,6 +39,8 @@ public final class TextareaElementProps implements IProps {
 
     private Function<String, Status> newValueHandler;
 
+    private List<Element> children;
+
     private TextareaElementProps() {
         // Prevent instantiation
     }
@@ -55,6 +59,11 @@ public final class TextareaElementProps implements IProps {
 
     public Function<String, Status> getNewValueHandler() {
         return this.newValueHandler;
+    }
+
+    @Override
+    public List<Element> getChildren() {
+        return this.children;
     }
 
     public static Builder newTextareaElementProps(String id) {
@@ -82,6 +91,8 @@ public final class TextareaElementProps implements IProps {
 
         private Function<String, Status> newValueHandler;
 
+        private List<Element> children;
+
         private Builder(String id) {
             this.id = Objects.requireNonNull(id);
         }
@@ -101,12 +112,18 @@ public final class TextareaElementProps implements IProps {
             return this;
         }
 
+        public Builder children(List<Element> children) {
+            this.children = Objects.requireNonNull(children);
+            return this;
+        }
+
         public TextareaElementProps build() {
             TextareaElementProps textareaElementProps = new TextareaElementProps();
             textareaElementProps.id = Objects.requireNonNull(this.id);
             textareaElementProps.label = Objects.requireNonNull(this.label);
             textareaElementProps.value = Objects.requireNonNull(this.value);
             textareaElementProps.newValueHandler = Objects.requireNonNull(this.newValueHandler);
+            textareaElementProps.children = Objects.requireNonNull(this.children);
             return textareaElementProps;
         }
     }

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/elements/TextfieldElementProps.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/elements/TextfieldElementProps.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Obeo.
+ * Copyright (c) 2019, 2021 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -13,10 +13,12 @@
 package org.eclipse.sirius.web.forms.elements;
 
 import java.text.MessageFormat;
+import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
 
 import org.eclipse.sirius.web.annotations.Immutable;
+import org.eclipse.sirius.web.components.Element;
 import org.eclipse.sirius.web.components.IProps;
 import org.eclipse.sirius.web.representations.Status;
 
@@ -37,6 +39,8 @@ public final class TextfieldElementProps implements IProps {
 
     private Function<String, Status> newValueHandler;
 
+    private List<Element> children;
+
     private TextfieldElementProps() {
         // Prevent instantiation
     }
@@ -51,6 +55,11 @@ public final class TextfieldElementProps implements IProps {
 
     public String getValue() {
         return this.value;
+    }
+
+    @Override
+    public List<Element> getChildren() {
+        return this.children;
     }
 
     public Function<String, Status> getNewValueHandler() {
@@ -82,6 +91,8 @@ public final class TextfieldElementProps implements IProps {
 
         private Function<String, Status> newValueHandler;
 
+        private List<Element> children;
+
         private Builder(String id) {
             this.id = Objects.requireNonNull(id);
         }
@@ -101,12 +112,18 @@ public final class TextfieldElementProps implements IProps {
             return this;
         }
 
+        public Builder children(List<Element> children) {
+            this.children = Objects.requireNonNull(children);
+            return this;
+        }
+
         public TextfieldElementProps build() {
             TextfieldElementProps textfieldElementProps = new TextfieldElementProps();
             textfieldElementProps.id = Objects.requireNonNull(this.id);
             textfieldElementProps.label = Objects.requireNonNull(this.label);
             textfieldElementProps.value = Objects.requireNonNull(this.value);
             textfieldElementProps.newValueHandler = Objects.requireNonNull(this.newValueHandler);
+            textfieldElementProps.children = Objects.requireNonNull(this.children);
             return textfieldElementProps;
         }
     }

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/renderer/FormComponentPropsValidator.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/renderer/FormComponentPropsValidator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Obeo.
+ * Copyright (c) 2019, 2021 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -38,6 +38,8 @@ import org.eclipse.sirius.web.forms.components.TextfieldComponent;
 import org.eclipse.sirius.web.forms.components.TextfieldComponentProps;
 import org.eclipse.sirius.web.forms.components.WidgetComponent;
 import org.eclipse.sirius.web.forms.components.WidgetComponentProps;
+import org.eclipse.sirius.web.forms.validation.DiagnosticComponent;
+import org.eclipse.sirius.web.forms.validation.DiagnosticComponentProps;
 
 /**
  * Used to validate the properties of a component.
@@ -74,6 +76,8 @@ public class FormComponentPropsValidator implements IComponentPropsValidator {
             checkValidProps = props instanceof TextareaComponentProps;
         } else if (TextfieldComponent.class.equals(componentType)) {
             checkValidProps = props instanceof TextfieldComponentProps;
+        } else if (DiagnosticComponent.class.equals(componentType)) {
+            checkValidProps = props instanceof DiagnosticComponentProps;
         }
 
         return checkValidProps;

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/renderer/FormElementFactory.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/renderer/FormElementFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Obeo.
+ * Copyright (c) 2019, 2021 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -35,6 +35,8 @@ import org.eclipse.sirius.web.forms.elements.RadioElementProps;
 import org.eclipse.sirius.web.forms.elements.SelectElementProps;
 import org.eclipse.sirius.web.forms.elements.TextareaElementProps;
 import org.eclipse.sirius.web.forms.elements.TextfieldElementProps;
+import org.eclipse.sirius.web.forms.validation.Diagnostic;
+import org.eclipse.sirius.web.forms.validation.DiagnosticElementProps;
 
 /**
  * Used to instantiate the elements of the form.
@@ -64,6 +66,8 @@ public class FormElementFactory implements IElementFactory {
             object = this.instantiateTextarea((TextareaElementProps) props, children);
         } else if (TextfieldElementProps.TYPE.equals(type) && props instanceof TextfieldElementProps) {
             object = this.instantiateTextfield((TextfieldElementProps) props, children);
+        } else if (DiagnosticElementProps.TYPE.equals(type) && props instanceof DiagnosticElementProps) {
+            object = this.instantiateDiagnostic((DiagnosticElementProps) props, children);
         }
         return object;
     }
@@ -113,61 +117,97 @@ public class FormElementFactory implements IElementFactory {
     }
 
     private Checkbox instantiateCheckbox(CheckboxElementProps props, List<Object> children) {
+        List<Diagnostic> diagnostics = this.getDiagnosticsFromChildren(children);
+
         // @formatter:off
         return Checkbox.newCheckbox(props.getId())
                 .label(props.getLabel())
                 .value(props.isValue())
                 .newValueHandler(props.getNewValueHandler())
+                .diagnostics(diagnostics)
                 .build();
         // @formatter:on
     }
 
     private org.eclipse.sirius.web.forms.List instantiateList(ListElementProps props, List<Object> children) {
+        List<Diagnostic> diagnostics = this.getDiagnosticsFromChildren(children);
+
         // @formatter:off
         return org.eclipse.sirius.web.forms.List.newList(props.getId())
                 .label(props.getLabel())
                 .items(props.getItems())
+                .diagnostics(diagnostics)
                 .build();
         // @formatter:on
     }
 
     private Radio instantiateRadio(RadioElementProps props, List<Object> children) {
+        List<Diagnostic> diagnostics = this.getDiagnosticsFromChildren(children);
+
         // @formatter:off
         return Radio.newRadio(props.getId())
                 .label(props.getLabel())
                 .options(props.getOptions())
                 .newValueHandler(props.getNewValueHandler())
+                .diagnostics(diagnostics)
                 .build();
         // @formatter:on
     }
 
     private Select instantiateSelect(SelectElementProps props, List<Object> children) {
+        List<Diagnostic> diagnostics = this.getDiagnosticsFromChildren(children);
+
         // @formatter:off
         return Select.newSelect(props.getId())
                 .label(props.getLabel())
                 .options(props.getOptions())
                 .value(props.getValue())
                 .newValueHandler(props.getNewValueHandler())
+                .diagnostics(diagnostics)
                 .build();
         // @formatter:on
     }
 
     private Textarea instantiateTextarea(TextareaElementProps props, List<Object> children) {
+        List<Diagnostic> diagnostics = this.getDiagnosticsFromChildren(children);
+
         // @formatter:off
         return Textarea.newTextarea(props.getId())
                 .label(props.getLabel())
                 .value(props.getValue())
+                .diagnostics(diagnostics)
                 .build();
         // @formatter:on
     }
 
     private Textfield instantiateTextfield(TextfieldElementProps props, List<Object> children) {
+        List<Diagnostic> diagnostics = this.getDiagnosticsFromChildren(children);
+
         // @formatter:off
         return Textfield.newTextfield(props.getId())
                 .label(props.getLabel())
                 .value(props.getValue())
                 .newValueHandler(props.getNewValueHandler())
+                .diagnostics(diagnostics)
                 .build();
+        // @formatter:on
+    }
+
+    private Object instantiateDiagnostic(DiagnosticElementProps props, List<Object> children) {
+        // @formatter:off
+        return Diagnostic.newDiagnostic(props.getId())
+                .kind(props.getKind())
+                .message(props.getMessage())
+                .build();
+        // @formatter:on
+    }
+
+    private List<Diagnostic> getDiagnosticsFromChildren(List<Object> children) {
+        // @formatter:off
+        return children.stream()
+                .filter(Diagnostic.class::isInstance)
+                .map(Diagnostic.class::cast)
+                .collect(Collectors.toList());
         // @formatter:on
     }
 

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/renderer/FormInstancePropsValidator.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/renderer/FormInstancePropsValidator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Obeo.
+ * Copyright (c) 2019, 2021 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -23,6 +23,7 @@ import org.eclipse.sirius.web.forms.elements.RadioElementProps;
 import org.eclipse.sirius.web.forms.elements.SelectElementProps;
 import org.eclipse.sirius.web.forms.elements.TextareaElementProps;
 import org.eclipse.sirius.web.forms.elements.TextfieldElementProps;
+import org.eclipse.sirius.web.forms.validation.DiagnosticElementProps;
 
 /**
  * Used to validate the instance props.
@@ -53,6 +54,8 @@ public class FormInstancePropsValidator implements IInstancePropsValidator {
             checkValidProps = props instanceof TextareaElementProps;
         } else if (TextfieldElementProps.TYPE.equals(type)) {
             checkValidProps = props instanceof TextfieldElementProps;
+        } else if (DiagnosticElementProps.TYPE.equals(type)) {
+            checkValidProps = props instanceof DiagnosticElementProps;
         }
 
         return checkValidProps;

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/validation/Diagnostic.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/validation/Diagnostic.java
@@ -1,0 +1,103 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.forms.validation;
+
+import java.util.Objects;
+import java.util.UUID;
+
+import org.eclipse.sirius.web.annotations.Immutable;
+import org.eclipse.sirius.web.annotations.graphql.GraphQLField;
+import org.eclipse.sirius.web.annotations.graphql.GraphQLID;
+import org.eclipse.sirius.web.annotations.graphql.GraphQLNonNull;
+import org.eclipse.sirius.web.annotations.graphql.GraphQLObjectType;
+
+/**
+ * The diagnostic of a widget.
+ *
+ * @author gcoutable
+ */
+@Immutable
+@GraphQLObjectType
+public final class Diagnostic {
+
+    private UUID id;
+
+    private String kind;
+
+    private String message;
+
+    private Diagnostic() {
+        // Prevent instantiation
+    }
+
+    @GraphQLID
+    @GraphQLField
+    @GraphQLNonNull
+    public UUID getId() {
+        return this.id;
+    }
+
+    @GraphQLField
+    @GraphQLNonNull
+    public String getKind() {
+        return this.kind;
+    }
+
+    @GraphQLField
+    @GraphQLNonNull
+    public String getMessage() {
+        return this.message;
+    }
+
+    public static Builder newDiagnostic(UUID id) {
+        return new Builder(id);
+    }
+
+    /**
+     * The builder used to create a new diagnostic.
+     *
+     * @author gcoutable
+     */
+    @SuppressWarnings("checkstyle:HiddenField")
+    public static final class Builder {
+
+        private UUID id;
+
+        private String kind;
+
+        private String message;
+
+        public Builder(UUID id) {
+            this.id = Objects.requireNonNull(id);
+        }
+
+        public Builder kind(String kind) {
+            this.kind = Objects.requireNonNull(kind);
+            return this;
+        }
+
+        public Builder message(String message) {
+            this.message = Objects.requireNonNull(message);
+            return this;
+        }
+
+        public Diagnostic build() {
+            Diagnostic diagnostic = new Diagnostic();
+            diagnostic.id = Objects.requireNonNull(this.id);
+            diagnostic.kind = Objects.requireNonNull(this.kind);
+            diagnostic.message = Objects.requireNonNull(this.message);
+            return diagnostic;
+        }
+
+    }
+}

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/validation/DiagnosticComponent.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/validation/DiagnosticComponent.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.forms.validation;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import org.eclipse.sirius.web.components.Element;
+import org.eclipse.sirius.web.components.Fragment;
+import org.eclipse.sirius.web.components.FragmentProps;
+import org.eclipse.sirius.web.components.IComponent;
+import org.eclipse.sirius.web.forms.description.AbstractWidgetDescription;
+import org.eclipse.sirius.web.representations.VariableManager;
+
+/**
+ * The component used to render the diagnostic for forms.
+ *
+ * @author gcoutable
+ */
+public class DiagnosticComponent implements IComponent {
+
+    private final DiagnosticComponentProps props;
+
+    public DiagnosticComponent(DiagnosticComponentProps props) {
+        this.props = props;
+    }
+
+    @Override
+    public Element render() {
+        AbstractWidgetDescription widgetDescription = this.props.getWidgetDescription();
+        VariableManager variableManager = this.props.getVariableManager();
+
+        List<Element> children = new ArrayList<>();
+
+        List<Object> diagnostics = widgetDescription.getDiagnosticsProvider().apply(variableManager);
+        for (Object diagnostic : diagnostics) {
+            UUID id = UUID.randomUUID();
+            String kind = widgetDescription.getKindProvider().apply(diagnostic);
+            String message = widgetDescription.getMessageProvider().apply(diagnostic);
+
+            // @formatter:off
+            DiagnosticElementProps diagnosticElementProps = DiagnosticElementProps.newDiagnosticElementProps(id)
+                    .kind(kind)
+                    .message(message)
+                    .build();
+            // @formatter:on
+
+            children.add(new Element(DiagnosticElementProps.TYPE, diagnosticElementProps));
+        }
+
+        FragmentProps fragmentProps = new FragmentProps(children);
+        return new Fragment(fragmentProps);
+    }
+
+}

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/validation/DiagnosticComponentProps.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/validation/DiagnosticComponentProps.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.forms.validation;
+
+import java.util.Objects;
+
+import org.eclipse.sirius.web.components.IProps;
+import org.eclipse.sirius.web.forms.description.AbstractWidgetDescription;
+import org.eclipse.sirius.web.representations.VariableManager;
+
+/**
+ * The properties of the diagnostic component for forms.
+ *
+ * @author gcoutable
+ */
+public class DiagnosticComponentProps implements IProps {
+
+    private final AbstractWidgetDescription widgetDescription;
+
+    private final VariableManager variableManager;
+
+    public DiagnosticComponentProps(AbstractWidgetDescription widgetDescription, VariableManager variableManager) {
+        this.widgetDescription = Objects.requireNonNull(widgetDescription);
+        this.variableManager = Objects.requireNonNull(variableManager);
+    }
+
+    public AbstractWidgetDescription getWidgetDescription() {
+        return this.widgetDescription;
+    }
+
+    public VariableManager getVariableManager() {
+        return this.variableManager;
+    }
+
+}

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/validation/DiagnosticElementProps.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/validation/DiagnosticElementProps.java
@@ -1,0 +1,100 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.forms.validation;
+
+import java.text.MessageFormat;
+import java.util.Objects;
+import java.util.UUID;
+
+import org.eclipse.sirius.web.annotations.Immutable;
+import org.eclipse.sirius.web.components.IProps;
+
+/**
+ * The properties of the diagnostic element for forms.
+ *
+ * @author gcoutable
+ */
+@Immutable
+public final class DiagnosticElementProps implements IProps {
+    public static final String TYPE = "Diagnostic"; //$NON-NLS-1$
+
+    private UUID id;
+
+    private String kind;
+
+    private String message;
+
+    private DiagnosticElementProps() {
+        // Prevent instantiation
+    }
+
+    public UUID getId() {
+        return this.id;
+    }
+
+    public String getKind() {
+        return this.kind;
+    }
+
+    public String getMessage() {
+        return this.message;
+    }
+
+    public static Builder newDiagnosticElementProps(UUID id) {
+        return new Builder(id);
+    }
+
+    @Override
+    public String toString() {
+        String pattern = "{0} '{'id: {1}, kind: {2}'}'"; //$NON-NLS-1$
+        return MessageFormat.format(pattern, this.getClass().getSimpleName(), this.id, this.kind);
+    }
+
+    /**
+     * The builder of the diagnostic element props.
+     *
+     * @author gcoutable
+     */
+    @SuppressWarnings("checkstyle:HiddenField")
+    public static final class Builder {
+
+        private UUID id;
+
+        private String kind;
+
+        private String message;
+
+        private Builder(UUID id) {
+            this.id = Objects.requireNonNull(id);
+        }
+
+        public Builder kind(String kind) {
+            this.kind = Objects.requireNonNull(kind);
+            return this;
+        }
+
+        public Builder message(String message) {
+            this.message = Objects.requireNonNull(message);
+            return this;
+        }
+
+        public DiagnosticElementProps build() {
+            DiagnosticElementProps diagnosticElementProps = new DiagnosticElementProps();
+            diagnosticElementProps.id = Objects.requireNonNull(this.id);
+            diagnosticElementProps.kind = Objects.requireNonNull(this.kind);
+            diagnosticElementProps.message = Objects.requireNonNull(this.message);
+            return diagnosticElementProps;
+        }
+    }
+
+}

--- a/backend/sirius-web-spring-collaborative-forms/src/test/java/org/eclipse/sirius/web/spring/collaborative/forms/handlers/EditCheckboxEventHandlerTests.java
+++ b/backend/sirius-web-spring-collaborative-forms/src/test/java/org/eclipse/sirius/web/spring/collaborative/forms/handlers/EditCheckboxEventHandlerTests.java
@@ -56,6 +56,7 @@ public class EditCheckboxEventHandlerTests {
         Checkbox checkbox = Checkbox.newCheckbox(id)
                 .label("label") //$NON-NLS-1$
                 .newValueHandler(newValueHandler)
+                .diagnostics(List.of())
                 .build();
 
         Group group = Group.newGroup("groupId") //$NON-NLS-1$

--- a/backend/sirius-web-spring-collaborative-forms/src/test/java/org/eclipse/sirius/web/spring/collaborative/forms/handlers/EditRadioEventHandlerTests.java
+++ b/backend/sirius-web-spring-collaborative-forms/src/test/java/org/eclipse/sirius/web/spring/collaborative/forms/handlers/EditRadioEventHandlerTests.java
@@ -63,6 +63,7 @@ public class EditRadioEventHandlerTests {
                 .label("label") //$NON-NLS-1$
                 .newValueHandler(newValueHandler)
                 .options(List.of(option))
+                .diagnostics(List.of())
                 .build();
 
         Group group = Group.newGroup("groupId") //$NON-NLS-1$

--- a/backend/sirius-web-spring-collaborative-forms/src/test/java/org/eclipse/sirius/web/spring/collaborative/forms/handlers/EditTextfieldEventHandlerTests.java
+++ b/backend/sirius-web-spring-collaborative-forms/src/test/java/org/eclipse/sirius/web/spring/collaborative/forms/handlers/EditTextfieldEventHandlerTests.java
@@ -57,6 +57,7 @@ public class EditTextfieldEventHandlerTests {
                 .label("label") //$NON-NLS-1$
                 .value("Previous value") //$NON-NLS-1$
                 .newValueHandler(newValueHandler)
+                .diagnostics(List.of())
                 .build();
 
         Group group = Group.newGroup("groupId") //$NON-NLS-1$

--- a/backend/sirius-web-validation/src/main/java/org/eclipse/sirius/web/validation/components/ValidationComponent.java
+++ b/backend/sirius-web-validation/src/main/java/org/eclipse/sirius/web/validation/components/ValidationComponent.java
@@ -48,7 +48,7 @@ public class ValidationComponent implements IComponent {
 
         List<Element> children = new ArrayList<>();
 
-        List<Object> diagnostics = validationDescription.getDiagnosticsProviders().apply(variableManager);
+        List<Object> diagnostics = validationDescription.getDiagnosticsProvider().apply(variableManager);
         for (Object diagnostic : diagnostics) {
             DiagnosticComponentProps diagnosticComponentProps = new DiagnosticComponentProps(diagnostic, validationDescription);
             children.add(new Element(DiagnosticComponent.class, diagnosticComponentProps));

--- a/backend/sirius-web-validation/src/main/java/org/eclipse/sirius/web/validation/description/ValidationDescription.java
+++ b/backend/sirius-web-validation/src/main/java/org/eclipse/sirius/web/validation/description/ValidationDescription.java
@@ -43,14 +43,14 @@ public final class ValidationDescription implements IRepresentationDescription {
 
     private Predicate<VariableManager> canCreatePredicate;
 
-    private Function<VariableManager, List<Object>> diagnosticsProviders;
+    private Function<VariableManager, List<Object>> diagnosticsProvider;
 
     private Function<Object, String> kindProvider;
 
     private Function<Object, String> messageProvider;
-    
+
     private ValidationDescription() {
-     // Prevent instantiation
+        // Prevent instantiation
     }
 
     @Override
@@ -73,8 +73,8 @@ public final class ValidationDescription implements IRepresentationDescription {
         return this.canCreatePredicate;
     }
 
-    public Function<VariableManager, List<Object>> getDiagnosticsProviders() {
-        return this.diagnosticsProviders;
+    public Function<VariableManager, List<Object>> getDiagnosticsProvider() {
+        return this.diagnosticsProvider;
     }
 
     public Function<Object, String> getKindProvider() {
@@ -108,7 +108,7 @@ public final class ValidationDescription implements IRepresentationDescription {
 
         private Predicate<VariableManager> canCreatePredicate;
 
-        private Function<VariableManager, List<Object>> diagnosticsProviders;
+        private Function<VariableManager, List<Object>> diagnosticsProvider;
 
         private Function<Object, String> kindProvider;
 
@@ -128,8 +128,8 @@ public final class ValidationDescription implements IRepresentationDescription {
             return this;
         }
 
-        public Builder diagnosticsProviders(Function<VariableManager, List<Object>> diagnosticsProviders) {
-            this.diagnosticsProviders = Objects.requireNonNull(diagnosticsProviders);
+        public Builder diagnosticsProvider(Function<VariableManager, List<Object>> diagnosticsProvider) {
+            this.diagnosticsProvider = Objects.requireNonNull(diagnosticsProvider);
             return this;
         }
 
@@ -148,7 +148,7 @@ public final class ValidationDescription implements IRepresentationDescription {
             validationDescription.id = Objects.requireNonNull(this.id);
             validationDescription.label = Objects.requireNonNull(this.label);
             validationDescription.canCreatePredicate = Objects.requireNonNull(this.canCreatePredicate);
-            validationDescription.diagnosticsProviders = Objects.requireNonNull(this.diagnosticsProviders);
+            validationDescription.diagnosticsProvider = Objects.requireNonNull(this.diagnosticsProvider);
             validationDescription.kindProvider = Objects.requireNonNull(this.kindProvider);
             validationDescription.messageProvider = Objects.requireNonNull(this.messageProvider);
             return validationDescription;

--- a/frontend/src/form/Form.types.ts
+++ b/frontend/src/form/Form.types.ts
@@ -33,6 +33,13 @@ export interface Group {
 export interface Widget {
   id: string;
   __typename: string;
+  diagnostics: Diagnostic[];
+}
+
+export interface Diagnostic {
+  id: string;
+  kind: string;
+  message: string;
 }
 
 export interface WidgetSubscription {

--- a/frontend/src/form/FormEventFragments.ts
+++ b/frontend/src/form/FormEventFragments.ts
@@ -48,6 +48,11 @@ export const formRefreshedEventPayloadFragment = gql`
           widgets {
             id
             __typename
+            diagnostics {
+              id
+              kind
+              message
+            }
             ... on Textfield {
               label
               stringValue: value

--- a/frontend/src/form/FormEventFragments.types.ts
+++ b/frontend/src/form/FormEventFragments.types.ts
@@ -69,6 +69,13 @@ export interface GQLGroup {
 export interface GQLWidget {
   id: string;
   __typename: string;
+  diagnostics: GQLDiagnostic[];
+}
+
+export interface GQLDiagnostic {
+  id: string;
+  kind: string;
+  message: string;
 }
 
 export interface GQLTextfield extends GQLWidget {

--- a/frontend/src/properties/propertysections/CheckboxPropertySection.tsx
+++ b/frontend/src/properties/propertysections/CheckboxPropertySection.tsx
@@ -11,7 +11,10 @@
  *     Obeo - initial API and implementation
  *******************************************************************************/
 import { useMutation } from '@apollo/client';
+import { FormHelperText } from '@material-ui/core';
 import Checkbox from '@material-ui/core/Checkbox';
+import FormControl from '@material-ui/core/FormControl';
+import FormGroup from '@material-ui/core/FormGroup';
 import IconButton from '@material-ui/core/IconButton';
 import Snackbar from '@material-ui/core/Snackbar';
 import CloseIcon from '@material-ui/icons/Close';
@@ -126,18 +129,21 @@ export const CheckboxPropertySection = ({
   const onBlur = () => sendUpdateWidgetFocus(false);
 
   return (
-    <div>
+    <FormControl error={widget.diagnostics.length > 0}>
       <PropertySectionLabel label={widget.label} subscribers={subscribers} />
-      <Checkbox
-        name={widget.label}
-        color="primary"
-        checked={widget.booleanValue}
-        onChange={onChange}
-        onFocus={onFocus}
-        onBlur={onBlur}
-        data-testid={widget.label}
-        disabled={readOnly}
-      />
+      <FormGroup row>
+        <Checkbox
+          name={widget.label}
+          color="primary"
+          checked={widget.booleanValue}
+          onChange={onChange}
+          onFocus={onFocus}
+          onBlur={onBlur}
+          data-testid={widget.label}
+          disabled={readOnly}
+        />
+      </FormGroup>
+      <FormHelperText>{widget.diagnostics[0]?.message}</FormHelperText>
       <Snackbar
         anchorOrigin={{
           vertical: 'bottom',
@@ -154,6 +160,6 @@ export const CheckboxPropertySection = ({
         }
         data-testid="error"
       />
-    </div>
+    </FormControl>
   );
 };

--- a/frontend/src/properties/propertysections/ListPropertySection.tsx
+++ b/frontend/src/properties/propertysections/ListPropertySection.tsx
@@ -10,6 +10,8 @@
  * Contributors:
  *     Obeo - initial API and implementation
  *******************************************************************************/
+import { FormHelperText } from '@material-ui/core';
+import FormControl from '@material-ui/core/FormControl';
 import { makeStyles } from '@material-ui/core/styles';
 import Table from '@material-ui/core/Table';
 import TableBody from '@material-ui/core/TableBody';
@@ -51,7 +53,7 @@ export const ListPropertySection = ({ widget, subscribers }: ListPropertySection
   }
 
   return (
-    <div>
+    <FormControl error={widget.diagnostics.length > 0}>
       <PropertySectionLabel label={widget.label} subscribers={subscribers} />
       <Table className={classes.table}>
         <TableBody>
@@ -73,6 +75,7 @@ export const ListPropertySection = ({ widget, subscribers }: ListPropertySection
           ))}
         </TableBody>
       </Table>
-    </div>
+      <FormHelperText>{widget.diagnostics[0]?.message}</FormHelperText>
+    </FormControl>
   );
 };

--- a/frontend/src/properties/propertysections/RadioPropertySection.tsx
+++ b/frontend/src/properties/propertysections/RadioPropertySection.tsx
@@ -11,6 +11,8 @@
  *     Obeo - initial API and implementation
  *******************************************************************************/
 import { useMutation } from '@apollo/client';
+import { FormHelperText } from '@material-ui/core';
+import FormControl from '@material-ui/core/FormControl';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import IconButton from '@material-ui/core/IconButton';
 import Radio from '@material-ui/core/Radio';
@@ -139,7 +141,7 @@ export const RadioPropertySection = ({
 
   const selectedOption = widget.options.find((option) => option.selected);
   return (
-    <div>
+    <FormControl error={widget.diagnostics.length > 0}>
       <PropertySectionLabel label={widget.label} subscribers={subscribers} />
       <RadioGroup
         classes={{ root: classes.radioGroupRoot }}
@@ -157,6 +159,7 @@ export const RadioPropertySection = ({
           />
         ))}
       </RadioGroup>
+      <FormHelperText>{widget.diagnostics[0]?.message}</FormHelperText>
       <Snackbar
         anchorOrigin={{
           vertical: 'bottom',
@@ -173,6 +176,6 @@ export const RadioPropertySection = ({
         }
         data-testid="error"
       />
-    </div>
+    </FormControl>
   );
 };

--- a/frontend/src/properties/propertysections/SelectPropertySection.tsx
+++ b/frontend/src/properties/propertysections/SelectPropertySection.tsx
@@ -11,6 +11,8 @@
  *     Obeo - initial API and implementation
  *******************************************************************************/
 import { useMutation } from '@apollo/client';
+import { FormHelperText } from '@material-ui/core';
+import FormControl from '@material-ui/core/FormControl';
 import IconButton from '@material-ui/core/IconButton';
 import MenuItem from '@material-ui/core/MenuItem';
 import Select from '@material-ui/core/Select';
@@ -136,7 +138,7 @@ export const SelectPropertySection = ({
   };
 
   return (
-    <div>
+    <FormControl error={widget.diagnostics.length > 0}>
       <PropertySectionLabel label={widget.label} subscribers={subscribers} />
       <Select
         value={widget.value || ''}
@@ -156,6 +158,7 @@ export const SelectPropertySection = ({
           </MenuItem>
         ))}
       </Select>
+      <FormHelperText>{widget.diagnostics[0]?.message}</FormHelperText>
       <Snackbar
         anchorOrigin={{
           vertical: 'bottom',
@@ -172,6 +175,6 @@ export const SelectPropertySection = ({
         }
         data-testid="error"
       />
-    </div>
+    </FormControl>
   );
 };

--- a/frontend/src/properties/propertysections/TextfieldPropertySection.tsx
+++ b/frontend/src/properties/propertysections/TextfieldPropertySection.tsx
@@ -207,6 +207,8 @@ export const TextfieldPropertySection = ({
         onKeyPress={onKeyPress}
         data-testid={widget.label}
         disabled={readOnly}
+        error={widget.diagnostics.length > 0}
+        helperText={widget.diagnostics[0]?.message}
       />
       <Snackbar
         anchorOrigin={{


### PR DESCRIPTION
### Type of this PR 

- [ ] Bug fix
- [x] New feature or improvement
- [ ] Documentation
- [ ] Cleanup
- [ ] Test
- [ ] Build/Releng

### Issue(s)

https://github.com/eclipse-sirius/sirius-components/issues/556

### What does this PR do?

- Adds support for validation with Textfields
- Adds support for validation of NodeStyle and ConditionalNodeStyle
- It reuses validators defined for the Validation representation

### Screenshot/screencast of this PR

![image](https://user-images.githubusercontent.com/7371042/124775513-f8cbbc00-df3e-11eb-9f23-7feae48f4a8d.png)

### How to test this PR?

- [ ] Frontend Unit tests
- [ ] Backend Unit tests
- [ ] Cypress : please specify
- [ ] Manual Test : please specify
