### PR TITLE
Avoid resetting edge's routing in some cases when it is not needed

### DIFF
--- a/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/incremental/updater/ContainmentUpdater.java
+++ b/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/incremental/updater/ContainmentUpdater.java
@@ -215,7 +215,7 @@ public class ContainmentUpdater {
     }
 
     private double getPaddingHeight(IContainerLayoutData container) {
-        double nodeLabelPaddingHeight = 0;
+        double nodeLabelPaddingHeight = LayoutOptionValues.DEFAULT_ELK_PADDING;
         if (container instanceof NodeLayoutData) {
             NodeLayoutData nodeLayoutData = (NodeLayoutData) container;
             if (NodeType.NODE_LIST.equals(nodeLayoutData.getNodeType())) {
@@ -234,7 +234,7 @@ public class ContainmentUpdater {
                 return NODE_LIST_PADDING_WIDTH;
             }
         }
-        return 0;
+        return LayoutOptionValues.DEFAULT_ELK_PADDING;
     }
 
     private void shift(IContainerLayoutData container, double shiftX, double shiftY) {

--- a/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/incremental/updater/ContainmentUpdater.java
+++ b/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/incremental/updater/ContainmentUpdater.java
@@ -160,7 +160,8 @@ public class ContainmentUpdater {
     private void updateBottomRight(IContainerLayoutData container) {
         Size contentSize = this.computeContentSize(container);
 
-        if (!container.getSize().equals(contentSize)) {
+        // Only update the conttainer's size if it is too small for its content.
+        if (container.getSize().getWidth() < contentSize.getWidth() || container.getSize().getHeight() < contentSize.getHeight()) {
             container.setSize(contentSize);
             if (container instanceof IConnectable) {
                 ((IConnectable) container).setChanged(true);

--- a/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/incremental/updater/ContainmentUpdater.java
+++ b/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/incremental/updater/ContainmentUpdater.java
@@ -160,15 +160,18 @@ public class ContainmentUpdater {
     private void updateBottomRight(IContainerLayoutData container) {
         Size contentSize = this.computeContentSize(container);
 
-        // Only update the conttainer's size if it is too small for its content.
-        if (container.getSize().getWidth() < contentSize.getWidth() || container.getSize().getHeight() < contentSize.getHeight()) {
+        // For "normal" containers, we only resize if they are too small to hold their contents.
+        // Lists however are always resized to match exactly their content, even it is means making them smaller.
+        boolean isNodeListContainer = container instanceof NodeLayoutData && NodeType.NODE_LIST.equals(((NodeLayoutData) container).getNodeType());
+        boolean isTooSmallForContent = container.getSize().getWidth() < contentSize.getWidth() || container.getSize().getHeight() < contentSize.getHeight();
+        boolean shouldResize = isTooSmallForContent || (isNodeListContainer && !container.getSize().equals(contentSize));
+        if (shouldResize) {
             container.setSize(contentSize);
             if (container instanceof IConnectable) {
                 ((IConnectable) container).setChanged(true);
             }
         }
-
-        if (container instanceof NodeLayoutData && NodeType.NODE_LIST.equals(((NodeLayoutData) container).getNodeType())) {
+        if (isNodeListContainer) {
             for (NodeLayoutData child : container.getChildrenNodes()) {
                 child.setSize(Size.of(container.getSize().getWidth(), child.getSize().getHeight()));
                 if (child instanceof IConnectable) {

--- a/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/incremental/updater/ContainmentUpdater.java
+++ b/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/incremental/updater/ContainmentUpdater.java
@@ -158,24 +158,10 @@ public class ContainmentUpdater {
     }
 
     private void updateBottomRight(IContainerLayoutData container) {
-        double width = container.getSize().getWidth();
-        double height = container.getSize().getHeight();
-        double maxWidth = LayoutOptionValues.MIN_WIDTH_CONSTRAINT;
-        double maxHeight = LayoutOptionValues.MIN_HEIGHT_CONSTRAINT;
+        Size contentSize = this.computeContentSize(container);
 
-        if (this.isLabelContained(container)) {
-            LabelLayoutData label = ((NodeLayoutData) container).getLabel();
-            maxWidth = Math.max(maxWidth, label.getTextBounds().getSize().getWidth() + this.getNodeLabelPaddingWidth(container));
-            maxHeight = Math.max(maxHeight, label.getTextBounds().getSize().getHeight() + this.getNodeLabelPaddingHeight(container));
-        }
-
-        for (NodeLayoutData child : container.getChildrenNodes()) {
-            maxWidth = Math.max(maxWidth, child.getPosition().getX() + child.getSize().getWidth() + this.getPaddingWidth(container));
-            maxHeight = Math.max(maxHeight, child.getPosition().getY() + child.getSize().getHeight() + this.getPaddingHeight(container));
-        }
-
-        if (maxWidth != width || maxHeight != height) {
-            container.setSize(Size.of(maxWidth, maxHeight));
+        if (!container.getSize().equals(contentSize)) {
+            container.setSize(contentSize);
             if (container instanceof IConnectable) {
                 ((IConnectable) container).setChanged(true);
             }
@@ -189,7 +175,29 @@ public class ContainmentUpdater {
                 }
             }
         }
+    }
 
+    /**
+     * Determines the "natural" size needed for the container to hold all its content (label and children), with
+     * appropriate padding.
+     */
+    private Size computeContentSize(IContainerLayoutData container) {
+        double contentWidth = LayoutOptionValues.MIN_WIDTH_CONSTRAINT;
+        double contentHeight = LayoutOptionValues.MIN_HEIGHT_CONSTRAINT;
+
+        if (this.isLabelContained(container)) {
+            LabelLayoutData label = ((NodeLayoutData) container).getLabel();
+            Size labelSize = label.getTextBounds().getSize();
+            contentWidth = Math.max(contentWidth, labelSize.getWidth() + this.getNodeLabelPaddingWidth(container));
+            contentHeight = Math.max(contentHeight, labelSize.getHeight() + this.getNodeLabelPaddingHeight(container));
+        }
+
+        for (NodeLayoutData child : container.getChildrenNodes()) {
+            contentWidth = Math.max(contentWidth, child.getPosition().getX() + child.getSize().getWidth() + this.getPaddingWidth(container));
+            contentHeight = Math.max(contentHeight, child.getPosition().getY() + child.getSize().getHeight() + this.getPaddingHeight(container));
+        }
+
+        return Size.of(contentWidth, contentHeight);
     }
 
     private double getNodeLabelPaddingHeight(IContainerLayoutData container) {


### PR DESCRIPTION
- [550] Consider the same padding as ELK's in the incremental layout
- [550] Refactor for clarity
- [550] Only change container size if it is too small to hold its content