### PR TITLE
[602] Improve the properties and validation view

### DIFF
--- a/frontend/src/properties/PropertiesWebSocketContainer.tsx
+++ b/frontend/src/properties/PropertiesWebSocketContainer.tsx
@@ -125,11 +125,14 @@ export const PropertiesWebSocketContainer = ({
     }
   }, [error, dispatch]);
 
-  let content = (
-    <div className={classes.idle}>
-      <Typography variant="subtitle2">No object selected</Typography>
-    </div>
-  );
+  let content = null;
+  if (!selection) {
+    content = (
+      <div className={classes.idle}>
+        <Typography variant="subtitle2">No object selected</Typography>
+      </div>
+    );
+  }
   if ((propertiesWebSocketContainer === 'idle' && form) || propertiesWebSocketContainer === 'ready') {
     content = (
       <Properties

--- a/frontend/src/validation/ValidationWebSocketContainer.tsx
+++ b/frontend/src/validation/ValidationWebSocketContainer.tsx
@@ -119,11 +119,7 @@ export const ValidationWebSocketContainer = ({ editingContextId }: ValidationWeb
     }
   }, [error, dispatch]);
 
-  let content = (
-    <div className={classes.idle}>
-      <Typography variant="subtitle2">No diagnostics received</Typography>
-    </div>
-  );
+  let content = null;
 
   if (validationWebSocketContainer === 'ready') {
     const accordions = validation.categories.map((category) => {


### PR DESCRIPTION
### Type of this PR 

- [x] Bug fix
- [ ] New feature or improvement
- [ ] Documentation
- [ ] Cleanup
- [ ] Test
- [ ] Build/Releng

### Issue(s)

https://github.com/eclipse-sirius/sirius-components/issues/602

### What does this PR do?

- It prevents the properties view to display the "empty" state message
while there is a selection
- It removes the empty state message because it is not needed