### PR TITLE
[432] Fix direct edit tool invocation from the palette

### DIFF
--- a/frontend/src/diagram/DiagramWebSocketContainer.tsx
+++ b/frontend/src/diagram/DiagramWebSocketContainer.tsx
@@ -748,7 +748,7 @@ export const DiagramWebSocketContainer = ({
       invokeLabelEditFromContextualPalette = () =>
         diagramServer.actionDispatcher.dispatchAll([
           { kind: HIDE_CONTEXTUAL_TOOLBAR_ACTION },
-          new EditLabelAction(element.id + '_label'),
+          new EditLabelAction(element.editableLabel.id),
         ]);
     }
     let invokeDeleteFromContextualPalette;

--- a/frontend/src/diagram/sprotty/WebSocketDiagramServer.tsx
+++ b/frontend/src/diagram/sprotty/WebSocketDiagramServer.tsx
@@ -35,8 +35,6 @@ export const SPROTTY_DELETE_ACTION = 'sprottyDeleteElement';
 /** Action to select a sprotty element */
 export const SPROTTY_SELECT_ACTION = 'sprottySelectElement';
 /** Action to select an Sirius element */
-export const SIRIUS_LABEL_EDIT_ACTION = 'siriusLabelEditElement';
-/** Action to select an Sirius element */
 export const SIRIUS_SELECT_ACTION = 'siriusSelectElement';
 /** Action to select an Sirius element */
 export const SIRIUS_UPDATE_MODEL_ACTION = 'siriusUpdateModel';
@@ -108,7 +106,6 @@ export class SiriusWebWebSocketDiagramServer extends ModelSource {
     registry.register(UpdateModelAction.KIND, this);
     registry.register(MoveCommand.KIND, this);
     registry.register(SiriusResizeCommand.KIND, this);
-    registry.register(SIRIUS_LABEL_EDIT_ACTION, this);
     registry.register(SIRIUS_UPDATE_MODEL_ACTION, this);
     registry.register(SIRIUS_SELECT_ACTION, this);
     registry.register(SPROTTY_SELECT_ACTION, this);
@@ -144,9 +141,6 @@ export class SiriusWebWebSocketDiagramServer extends ModelSource {
         break;
       case SiriusResizeCommand.KIND:
         this.handleResizeAction(action);
-        break;
-      case SIRIUS_LABEL_EDIT_ACTION:
-        this.handleSiriusLabelEditAction(action);
         break;
       case SIRIUS_UPDATE_MODEL_ACTION:
         this.handleSiriusUpdateModelAction(action);
@@ -226,13 +220,6 @@ export class SiriusWebWebSocketDiagramServer extends ModelSource {
       const { elementId, newPosition, newSize } = resize;
       this.resizeElement(elementId, newPosition?.x, newPosition?.y, newSize.width, newSize.height);
     }
-  }
-  handleSiriusLabelEditAction(action) {
-    const { elementId } = action;
-    this.actionDispatcher.dispatchAll([
-      { kind: HIDE_CONTEXTUAL_TOOLBAR_ACTION },
-      new EditLabelAction(elementId + '_label'),
-    ]);
   }
 
   handleSprottySelectAction(action) {


### PR DESCRIPTION
Bug: https://github.com/eclipse-sirius/sirius-components/issues/432
Signed-off-by: Pierre-Charles David <pierre-charles.david@obeo.fr>

### Type of this PR 

- [x] Bug fix
- [ ] New feature or improvement
- [ ] Documentation
- [ ] Cleanup
- [ ] Test
- [ ] Build/Releng

### Issue(s)

...

### What does this PR do?

...

### Screenshot/screencast of this PR

...
 

### Potential side effects

...

### How to test this PR?

- [ ] Frontend Unit tests
- [ ] Backend Unit tests
- [ ] Cypress : please specify
- [ ] Manual Test : please specify

### Checklist

- [ ] I have read CONTRIBUTING carefully.
- [ ] I have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [ ] All my commits are signed-off (`-s`) with my mail address of my Eclipse Account.
- [ ] I have covered my changes by unit tests or integration tests or manual tests.
- [ ] All tests pass.
- [ ] I have updated the documentation accordingly
- [ ] New React components are availables in storybook
