### PR TITLE
[610] Fix "Download" menu entry underlined

### DIFF
--- a/frontend/src/core/contextmenu/ContextMenu.module.css
+++ b/frontend/src/core/contextmenu/ContextMenu.module.css
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Obeo.
+ * Copyright (c) 2019, 2021 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -119,4 +119,8 @@
   border-top-style: solid;
   border-top-width: 1px;
   margin: 4px 8px;
+}
+
+a {
+  text-decoration: none;
 }


### PR DESCRIPTION



Signed-off-by: Axel RICHARD <axel.richard@obeo.fr>

### Type of this PR 

- [x] Bug fix
- [ ] New feature or improvement
- [ ] Documentation
- [ ] Cleanup
- [ ] Test
- [ ] Build/Releng

### Issue(s)

Bug: https://github.com/eclipse-sirius/sirius-components/issues/610

### What does this PR do?

This PR fixes the "Download" underlined menu entry.

### Screenshot/screencast of this PR

<img width="396" alt="DL-Link" src="https://user-images.githubusercontent.com/717752/125912751-28394d86-3872-48e9-8da4-e8bee657a77d.png">
 
### Potential side effects

No side effects

### How to test this PR?

- [ ] Frontend Unit tests
- [ ] Backend Unit tests
- [ ] Cypress : please specify
- [x] Manual Test : please specify

### Checklist

- [x] I have read CONTRIBUTING carefully.
- [x] I have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All my commits are signed-off (`-s`) with my mail address of my Eclipse Account.
- [x] I have covered my changes by unit tests or integration tests or manual tests.
- [x] All tests pass.
- [ ] I have updated the documentation accordingly
- [ ] New React components are availables in storybook
