### PR TITLE
[610] Revert the previous commit to remove the global CSS rule

### DIFF
--- a/frontend/src/core/contextmenu/ContextMenu.module.css
+++ b/frontend/src/core/contextmenu/ContextMenu.module.css
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 Obeo.
+ * Copyright (c) 2019, 2020 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -119,8 +119,4 @@
   border-top-style: solid;
   border-top-width: 1px;
   margin: 4px 8px;
-}
-
-a {
-  text-decoration: none;
 }


### PR DESCRIPTION
This reverts commit b18570719a784be59b9c101fbcc25dc02dfda1d8.

Bug: https://github.com/eclipse-sirius/sirius-components/issues/610
Signed-off-by: Stéphane Bégaudeau <stephane.begaudeau@obeo.fr>