### PR TITLE
[428] Support for editing multi-valued references in the properties view

### DIFF
--- a/backend/sirius-web-collaborative-forms-api/src/main/java/org/eclipse/sirius/web/collaborative/forms/api/dto/EditMultiSelectInput.java
+++ b/backend/sirius-web-collaborative-forms-api/src/main/java/org/eclipse/sirius/web/collaborative/forms/api/dto/EditMultiSelectInput.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.collaborative.forms.api.dto;
+
+import java.text.MessageFormat;
+import java.util.List;
+import java.util.UUID;
+
+import org.eclipse.sirius.web.annotations.graphql.GraphQLField;
+import org.eclipse.sirius.web.annotations.graphql.GraphQLID;
+import org.eclipse.sirius.web.annotations.graphql.GraphQLInputObjectType;
+import org.eclipse.sirius.web.annotations.graphql.GraphQLNonNull;
+import org.eclipse.sirius.web.collaborative.forms.api.IFormInput;
+
+/**
+ * The input object for the multi select edition mutation.
+ *
+ * @author arichard
+ */
+@GraphQLInputObjectType
+public final class EditMultiSelectInput implements IFormInput {
+    private UUID id;
+
+    private UUID editingContextId;
+
+    private UUID representationId;
+
+    private String selectId;
+
+    private List<String> newValues;
+
+    @Override
+    @GraphQLID
+    @GraphQLField
+    @GraphQLNonNull
+    public UUID getId() {
+        return this.id;
+    }
+
+    @GraphQLID
+    @GraphQLField
+    @GraphQLNonNull
+    public UUID getEditingContextId() {
+        return this.editingContextId;
+    }
+
+    @Override
+    @GraphQLID
+    @GraphQLField
+    @GraphQLNonNull
+    public UUID getRepresentationId() {
+        return this.representationId;
+    }
+
+    @GraphQLID
+    @GraphQLField
+    @GraphQLNonNull
+    public String getSelectId() {
+        return this.selectId;
+    }
+
+    @GraphQLField
+    @GraphQLNonNull
+    public List<String> getNewValues() {
+        return this.newValues;
+    }
+
+    @Override
+    public String toString() {
+        String pattern = "{0} '{'id: {1}, editingContextId: {2}, representationId: {3}, selectId: {4}, newValues: {5}'}'"; //$NON-NLS-1$
+        return MessageFormat.format(pattern, this.getClass().getSimpleName(), this.id, this.editingContextId, this.representationId, this.selectId, this.newValues);
+    }
+}

--- a/backend/sirius-web-collaborative-forms-api/src/main/java/org/eclipse/sirius/web/collaborative/forms/api/dto/EditMultiSelectSuccessPayload.java
+++ b/backend/sirius-web-collaborative-forms-api/src/main/java/org/eclipse/sirius/web/collaborative/forms/api/dto/EditMultiSelectSuccessPayload.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.collaborative.forms.api.dto;
+
+import java.text.MessageFormat;
+import java.util.Objects;
+import java.util.UUID;
+
+import org.eclipse.sirius.web.annotations.graphql.GraphQLField;
+import org.eclipse.sirius.web.annotations.graphql.GraphQLID;
+import org.eclipse.sirius.web.annotations.graphql.GraphQLNonNull;
+import org.eclipse.sirius.web.annotations.graphql.GraphQLObjectType;
+import org.eclipse.sirius.web.core.api.IPayload;
+
+/**
+ * The payload of the edit multi select mutation.
+ *
+ * @author arichard
+ */
+@GraphQLObjectType
+public final class EditMultiSelectSuccessPayload implements IPayload {
+
+    private final UUID id;
+
+    private final String status;
+
+    public EditMultiSelectSuccessPayload(UUID id, String status) {
+        this.id = Objects.requireNonNull(id);
+        this.status = Objects.requireNonNull(status);
+    }
+
+    @Override
+    @GraphQLID
+    @GraphQLField
+    @GraphQLNonNull
+    public UUID getId() {
+        return this.id;
+    }
+
+    @GraphQLField
+    @GraphQLNonNull
+    public String getStatus() {
+        return this.status;
+    }
+
+    @Override
+    public String toString() {
+        String pattern = "{0} '{'id: {1}, status: {2}'}'"; //$NON-NLS-1$
+        return MessageFormat.format(pattern, this.getClass().getSimpleName(), this.id, this.status);
+    }
+}

--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/properties/MonoValuedNonContainmentReferenceIfDescriptionProvider.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/properties/MonoValuedNonContainmentReferenceIfDescriptionProvider.java
@@ -114,8 +114,8 @@ public class MonoValuedNonContainmentReferenceIfDescriptionProvider {
                         try {
                             eObject.eSet(eReference, newValueToSet);
                             return Status.OK;
-                        } catch (IllegalArgumentException | ClassCastException | ArrayStoreException e) {
-                            this.logger.error(e.getMessage(), e);
+                        } catch (IllegalArgumentException | ClassCastException | ArrayStoreException exception) {
+                            this.logger.warn(exception.getMessage(), exception);
                         }
                     }
                 }

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/MultiSelect.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/MultiSelect.java
@@ -1,0 +1,138 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.forms;
+
+import java.text.MessageFormat;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+
+import org.eclipse.sirius.web.annotations.Immutable;
+import org.eclipse.sirius.web.annotations.graphql.GraphQLField;
+import org.eclipse.sirius.web.annotations.graphql.GraphQLNonNull;
+import org.eclipse.sirius.web.annotations.graphql.GraphQLObjectType;
+import org.eclipse.sirius.web.forms.validation.Diagnostic;
+import org.eclipse.sirius.web.representations.Status;
+
+/**
+ * The select widget.
+ *
+ * @author pcdavid
+ * @author arichard
+ */
+@Immutable
+@GraphQLObjectType
+public final class MultiSelect extends AbstractWidget {
+    private String label;
+
+    private List<SelectOption> options;
+
+    private List<String> values;
+
+    private Function<List<String>, Status> newValuesHandler;
+
+    private MultiSelect() {
+        // Prevent instantiation
+    }
+
+    @GraphQLField
+    @GraphQLNonNull
+    public String getLabel() {
+        return this.label;
+    }
+
+    @GraphQLField
+    @GraphQLNonNull
+    public List<@GraphQLNonNull SelectOption> getOptions() {
+        return this.options;
+    }
+
+    @GraphQLField
+    public List<String> getValues() {
+        return this.values;
+    }
+
+    public Function<List<String>, Status> getNewValuesHandler() {
+        return this.newValuesHandler;
+    }
+
+    public static Builder newMultiSelect(String id) {
+        return new Builder(id);
+    }
+
+    @Override
+    public String toString() {
+        String pattern = "{0} '{'id: {1}, label: {2}, values: {3}, options: {4}'}'"; //$NON-NLS-1$
+        return MessageFormat.format(pattern, this.getClass().getSimpleName(), this.getId(), this.label, this.values, this.options);
+    }
+
+    /**
+     * The builder used to create the select.
+     *
+     * @author lfasani
+     */
+    @SuppressWarnings("checkstyle:HiddenField")
+    public static final class Builder {
+        private String id;
+
+        private String label;
+
+        private List<SelectOption> options;
+
+        private List<String> values;
+
+        private Function<List<String>, Status> newValuesHandler;
+
+        private List<Diagnostic> diagnostics;
+
+        private Builder(String id) {
+            this.id = Objects.requireNonNull(id);
+        }
+
+        public Builder label(String label) {
+            this.label = Objects.requireNonNull(label);
+            return this;
+        }
+
+        public Builder options(List<SelectOption> options) {
+            this.options = Objects.requireNonNull(options);
+            return this;
+        }
+
+        public Builder values(List<String> values) {
+            this.values = List.copyOf(values);
+            return this;
+        }
+
+        public Builder newValuesHandler(Function<List<String>, Status> newValuesHandler) {
+            this.newValuesHandler = Objects.requireNonNull(newValuesHandler);
+            return this;
+        }
+
+        public Builder diagnostics(List<Diagnostic> diagnostics) {
+            this.diagnostics = Objects.requireNonNull(diagnostics);
+            return this;
+        }
+
+        public MultiSelect build() {
+            MultiSelect select = new MultiSelect();
+            select.id = Objects.requireNonNull(this.id);
+            select.label = Objects.requireNonNull(this.label);
+            select.options = Objects.requireNonNull(this.options);
+            select.values = this.values;
+            select.newValuesHandler = Objects.requireNonNull(this.newValuesHandler);
+            select.diagnostics = Objects.requireNonNull(this.diagnostics);
+            return select;
+        }
+    }
+}

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/components/MultiSelectComponent.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/components/MultiSelectComponent.java
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.forms.components;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+
+import org.eclipse.sirius.web.components.Element;
+import org.eclipse.sirius.web.components.IComponent;
+import org.eclipse.sirius.web.forms.SelectOption;
+import org.eclipse.sirius.web.forms.description.MultiSelectDescription;
+import org.eclipse.sirius.web.forms.elements.MultiSelectElementProps;
+import org.eclipse.sirius.web.forms.validation.DiagnosticComponent;
+import org.eclipse.sirius.web.forms.validation.DiagnosticComponentProps;
+import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.VariableManager;
+
+/**
+ * The component used to create the select widget and its options.
+ *
+ * @author pcdavid
+ * @author arichard
+ */
+public class MultiSelectComponent implements IComponent {
+
+    public static final String CANDIDATE_VARIABLE = "candidate"; //$NON-NLS-1$
+
+    private MultiSelectComponentProps props;
+
+    public MultiSelectComponent(MultiSelectComponentProps props) {
+        this.props = Objects.requireNonNull(props);
+    }
+
+    @Override
+    public Element render() {
+        VariableManager variableManager = this.props.getVariableManager();
+        MultiSelectDescription multiSelectDescription = this.props.getMultiSelectDescription();
+
+        String id = multiSelectDescription.getIdProvider().apply(variableManager);
+        String label = multiSelectDescription.getLabelProvider().apply(variableManager);
+        List<Object> optionCandidates = multiSelectDescription.getOptionsProvider().apply(variableManager);
+        List<String> values = multiSelectDescription.getValuesProvider().apply(variableManager);
+
+        List<Element> children = List.of(new Element(DiagnosticComponent.class, new DiagnosticComponentProps(multiSelectDescription, variableManager)));
+
+        List<SelectOption> options = new ArrayList<>();
+        for (Object candidate : optionCandidates) {
+            VariableManager optionVariableManager = variableManager.createChild();
+            optionVariableManager.put(CANDIDATE_VARIABLE, candidate);
+
+            String optionId = multiSelectDescription.getOptionIdProvider().apply(optionVariableManager);
+            String optionLabel = multiSelectDescription.getOptionLabelProvider().apply(optionVariableManager);
+
+            // @formatter:off
+            SelectOption option = SelectOption.newSelectOption(optionId)
+                    .label(optionLabel)
+                    .build();
+            // @formatter:on
+
+            options.add(option);
+        }
+        Function<List<String>, Status> newValuesHandler = newValues -> {
+            return multiSelectDescription.getNewValuesHandler().apply(variableManager, newValues);
+        };
+
+        // @formatter:off
+        MultiSelectElementProps selectElementProps = MultiSelectElementProps.newMultiSelectElementProps(id)
+                .label(label)
+                .options(options)
+                .values(values)
+                .newValuesHandler(newValuesHandler)
+                .children(children)
+                .build();
+        return new Element(MultiSelectElementProps.TYPE, selectElementProps);
+        // @formatter:on
+    }
+}

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/components/MultiSelectComponentProps.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/components/MultiSelectComponentProps.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.forms.components;
+
+import java.util.Objects;
+
+import org.eclipse.sirius.web.components.IProps;
+import org.eclipse.sirius.web.forms.description.MultiSelectDescription;
+import org.eclipse.sirius.web.representations.VariableManager;
+
+/**
+ * The properties of the multi-select component.
+ *
+ * @author sbegaudeau
+ */
+public class MultiSelectComponentProps implements IProps {
+
+    private VariableManager variableManager;
+
+    private MultiSelectDescription selectDescription;
+
+    public MultiSelectComponentProps(VariableManager variableManager, MultiSelectDescription selectDescription) {
+        this.variableManager = Objects.requireNonNull(variableManager);
+        this.selectDescription = Objects.requireNonNull(selectDescription);
+    }
+
+    public VariableManager getVariableManager() {
+        return this.variableManager;
+    }
+
+    public MultiSelectDescription getMultiSelectDescription() {
+        return this.selectDescription;
+    }
+}

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/components/WidgetComponent.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/components/WidgetComponent.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Obeo.
+ * Copyright (c) 2019, 2021 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -19,6 +19,7 @@ import org.eclipse.sirius.web.components.IComponent;
 import org.eclipse.sirius.web.forms.description.AbstractWidgetDescription;
 import org.eclipse.sirius.web.forms.description.CheckboxDescription;
 import org.eclipse.sirius.web.forms.description.ListDescription;
+import org.eclipse.sirius.web.forms.description.MultiSelectDescription;
 import org.eclipse.sirius.web.forms.description.RadioDescription;
 import org.eclipse.sirius.web.forms.description.SelectDescription;
 import org.eclipse.sirius.web.forms.description.TextareaDescription;
@@ -60,6 +61,9 @@ public class WidgetComponent implements IComponent {
         } else if (widgetDescription instanceof SelectDescription) {
             SelectComponentProps selectProps = new SelectComponentProps(variableManager, (SelectDescription) widgetDescription);
             element = new Element(SelectComponent.class, selectProps);
+        } else if (widgetDescription instanceof MultiSelectDescription) {
+            MultiSelectComponentProps multiSelectProps = new MultiSelectComponentProps(variableManager, (MultiSelectDescription) widgetDescription);
+            element = new Element(MultiSelectComponent.class, multiSelectProps);
         } else if (widgetDescription instanceof RadioDescription) {
             RadioComponentProps radioProps = new RadioComponentProps(variableManager, (RadioDescription) widgetDescription);
             element = new Element(RadioComponent.class, radioProps);

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/description/MultiSelectDescription.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/description/MultiSelectDescription.java
@@ -1,0 +1,191 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.forms.description;
+
+import java.text.MessageFormat;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import org.eclipse.sirius.web.annotations.Immutable;
+import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.VariableManager;
+
+/**
+ * The description of the multi-select widget.
+ *
+ * @author pcdavid
+ * @author arichard
+ */
+@Immutable
+public final class MultiSelectDescription extends AbstractWidgetDescription {
+
+    private Function<VariableManager, String> idProvider;
+
+    private Function<VariableManager, String> labelProvider;
+
+    private Function<VariableManager, List<Object>> optionsProvider;
+
+    private Function<VariableManager, String> optionIdProvider;
+
+    private Function<VariableManager, String> optionLabelProvider;
+
+    private Function<VariableManager, List<String>> valuesProvider;
+
+    private BiFunction<VariableManager, List<String>, Status> newValuesHandler;
+
+    private MultiSelectDescription() {
+        // Prevent instantiation
+    }
+
+    public Function<VariableManager, String> getIdProvider() {
+        return this.idProvider;
+    }
+
+    public Function<VariableManager, String> getLabelProvider() {
+        return this.labelProvider;
+    }
+
+    public Function<VariableManager, List<Object>> getOptionsProvider() {
+        return this.optionsProvider;
+    }
+
+    public Function<VariableManager, String> getOptionIdProvider() {
+        return this.optionIdProvider;
+    }
+
+    public Function<VariableManager, String> getOptionLabelProvider() {
+        return this.optionLabelProvider;
+    }
+
+    public Function<VariableManager, List<String>> getValuesProvider() {
+        return this.valuesProvider;
+    }
+
+    public BiFunction<VariableManager, List<String>, Status> getNewValuesHandler() {
+        return this.newValuesHandler;
+    }
+
+    public static Builder newMultiSelectDescription(String id) {
+        return new Builder(id);
+    }
+
+    @Override
+    public String toString() {
+        String pattern = "{0} '{'id: {1}'}'"; //$NON-NLS-1$
+        return MessageFormat.format(pattern, this.getClass().getSimpleName(), this.getId());
+    }
+
+    /**
+     * Builder used to create the select description.
+     *
+     * @author pcdavid
+     * @author arichard
+     */
+    @SuppressWarnings("checkstyle:HiddenField")
+    public static final class Builder {
+        private String id;
+
+        private Function<VariableManager, String> idProvider;
+
+        private Function<VariableManager, String> labelProvider;
+
+        private Function<VariableManager, List<Object>> optionsProvider;
+
+        private Function<VariableManager, String> optionIdProvider;
+
+        private Function<VariableManager, String> optionLabelProvider;
+
+        private Function<VariableManager, List<String>> valuesProvider;
+
+        private BiFunction<VariableManager, List<String>, Status> newValuesHandler;
+
+        private Function<VariableManager, List<Object>> diagnosticsProvider;
+
+        private Function<Object, String> kindProvider;
+
+        private Function<Object, String> messageProvider;
+
+        private Builder(String id) {
+            this.id = Objects.requireNonNull(id);
+        }
+
+        public Builder idProvider(Function<VariableManager, String> idProvider) {
+            this.idProvider = Objects.requireNonNull(idProvider);
+            return this;
+        }
+
+        public Builder labelProvider(Function<VariableManager, String> labelProvider) {
+            this.labelProvider = Objects.requireNonNull(labelProvider);
+            return this;
+        }
+
+        public Builder optionsProvider(Function<VariableManager, List<Object>> optionsProvider) {
+            this.optionsProvider = Objects.requireNonNull(optionsProvider);
+            return this;
+        }
+
+        public Builder optionIdProvider(Function<VariableManager, String> optionIdProvider) {
+            this.optionIdProvider = Objects.requireNonNull(optionIdProvider);
+            return this;
+        }
+
+        public Builder optionLabelProvider(Function<VariableManager, String> optionLabelProvider) {
+            this.optionLabelProvider = Objects.requireNonNull(optionLabelProvider);
+            return this;
+        }
+
+        public Builder valuesProvider(Function<VariableManager, List<String>> valuesProvider) {
+            this.valuesProvider = Objects.requireNonNull(valuesProvider);
+            return this;
+        }
+
+        public Builder newValuesHandler(BiFunction<VariableManager, List<String>, Status> newValuesHandler) {
+            this.newValuesHandler = Objects.requireNonNull(newValuesHandler);
+            return this;
+        }
+
+        public Builder diagnosticsProvider(Function<VariableManager, List<Object>> diagnosticsProvider) {
+            this.diagnosticsProvider = Objects.requireNonNull(diagnosticsProvider);
+            return this;
+        }
+
+        public Builder kindProvider(Function<Object, String> kindProvider) {
+            this.kindProvider = Objects.requireNonNull(kindProvider);
+            return this;
+        }
+
+        public Builder messageProvider(Function<Object, String> messageProvider) {
+            this.messageProvider = Objects.requireNonNull(messageProvider);
+            return this;
+        }
+
+        public MultiSelectDescription build() {
+            MultiSelectDescription multiSelectDescription = new MultiSelectDescription();
+            multiSelectDescription.id = Objects.requireNonNull(this.id);
+            multiSelectDescription.idProvider = Objects.requireNonNull(this.idProvider);
+            multiSelectDescription.labelProvider = Objects.requireNonNull(this.labelProvider);
+            multiSelectDescription.optionsProvider = Objects.requireNonNull(this.optionsProvider);
+            multiSelectDescription.optionIdProvider = Objects.requireNonNull(this.optionIdProvider);
+            multiSelectDescription.optionLabelProvider = Objects.requireNonNull(this.optionLabelProvider);
+            multiSelectDescription.valuesProvider = Objects.requireNonNull(this.valuesProvider);
+            multiSelectDescription.newValuesHandler = Objects.requireNonNull(this.newValuesHandler);
+            multiSelectDescription.diagnosticsProvider = Objects.requireNonNull(this.diagnosticsProvider);
+            multiSelectDescription.kindProvider = Objects.requireNonNull(this.kindProvider);
+            multiSelectDescription.messageProvider = Objects.requireNonNull(this.messageProvider);
+            return multiSelectDescription;
+        }
+
+    }
+}

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/elements/MultiSelectElementProps.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/elements/MultiSelectElementProps.java
@@ -1,0 +1,147 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.forms.elements;
+
+import java.text.MessageFormat;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+
+import org.eclipse.sirius.web.annotations.Immutable;
+import org.eclipse.sirius.web.components.Element;
+import org.eclipse.sirius.web.components.IProps;
+import org.eclipse.sirius.web.forms.SelectOption;
+import org.eclipse.sirius.web.representations.Status;
+
+/**
+ * The properties of the multi-select element.
+ *
+ * @author pcdavid
+ * @author arichard
+ */
+@Immutable
+public final class MultiSelectElementProps implements IProps {
+    public static final String TYPE = "MultiSelect"; //$NON-NLS-1$
+
+    private String id;
+
+    private String label;
+
+    private List<SelectOption> options;
+
+    private List<String> values;
+
+    private Function<List<String>, Status> newValuesHandler;
+
+    private List<Element> children;
+
+    private MultiSelectElementProps() {
+        // Prevent instantiation
+    }
+
+    public String getId() {
+        return this.id;
+    }
+
+    public String getLabel() {
+        return this.label;
+    }
+
+    public List<SelectOption> getOptions() {
+        return this.options;
+    }
+
+    public List<String> getValues() {
+        return this.values;
+    }
+
+    public Function<List<String>, Status> getNewValuesHandler() {
+        return this.newValuesHandler;
+    }
+
+    @Override
+    public List<Element> getChildren() {
+        return this.children;
+    }
+
+    public static Builder newMultiSelectElementProps(String id) {
+        return new Builder(id);
+    }
+
+    @Override
+    public String toString() {
+        String pattern = "{0} '{'id: {1}, label: {2}, value: {3}, options:{4}'}'"; //$NON-NLS-1$
+        return MessageFormat.format(pattern, this.getClass().getSimpleName(), this.id, this.label, this.values, this.options);
+    }
+
+    /**
+     * The builder of the select element props.
+     *
+     * @author lfasani
+     */
+    @SuppressWarnings("checkstyle:HiddenField")
+    public static final class Builder {
+
+        private String id;
+
+        private String label;
+
+        private List<SelectOption> options;
+
+        private List<String> values;
+
+        private Function<List<String>, Status> newValuesHandler;
+
+        private List<Element> children;
+
+        private Builder(String id) {
+            this.id = Objects.requireNonNull(id);
+        }
+
+        public Builder label(String label) {
+            this.label = Objects.requireNonNull(label);
+            return this;
+        }
+
+        public Builder options(List<SelectOption> options) {
+            this.options = Objects.requireNonNull(options);
+            return this;
+        }
+
+        public Builder values(List<String> values) {
+            this.values = Objects.requireNonNull(values);
+            return this;
+        }
+
+        public Builder newValuesHandler(Function<List<String>, Status> newValuesHandler) {
+            this.newValuesHandler = Objects.requireNonNull(newValuesHandler);
+            return this;
+        }
+
+        public Builder children(List<Element> children) {
+            this.children = Objects.requireNonNull(children);
+            return this;
+        }
+
+        public MultiSelectElementProps build() {
+            MultiSelectElementProps multiSelectElementProps = new MultiSelectElementProps();
+            multiSelectElementProps.id = Objects.requireNonNull(this.id);
+            multiSelectElementProps.label = Objects.requireNonNull(this.label);
+            multiSelectElementProps.options = Objects.requireNonNull(this.options);
+            multiSelectElementProps.values = List.copyOf(this.values);
+            multiSelectElementProps.newValuesHandler = Objects.requireNonNull(this.newValuesHandler);
+            multiSelectElementProps.children = Objects.requireNonNull(this.children);
+            return multiSelectElementProps;
+        }
+    }
+}

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/renderer/FormComponentPropsValidator.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/renderer/FormComponentPropsValidator.java
@@ -26,6 +26,8 @@ import org.eclipse.sirius.web.forms.components.IfComponent;
 import org.eclipse.sirius.web.forms.components.IfComponentProps;
 import org.eclipse.sirius.web.forms.components.ListComponent;
 import org.eclipse.sirius.web.forms.components.ListComponentProps;
+import org.eclipse.sirius.web.forms.components.MultiSelectComponent;
+import org.eclipse.sirius.web.forms.components.MultiSelectComponentProps;
 import org.eclipse.sirius.web.forms.components.PageComponent;
 import org.eclipse.sirius.web.forms.components.PageComponentProps;
 import org.eclipse.sirius.web.forms.components.RadioComponent;
@@ -72,6 +74,8 @@ public class FormComponentPropsValidator implements IComponentPropsValidator {
             checkValidProps = props instanceof RadioComponentProps;
         } else if (SelectComponent.class.equals(componentType)) {
             checkValidProps = props instanceof SelectComponentProps;
+        } else if (MultiSelectComponent.class.equals(componentType)) {
+            checkValidProps = props instanceof MultiSelectComponentProps;
         } else if (TextareaComponent.class.equals(componentType)) {
             checkValidProps = props instanceof TextareaComponentProps;
         } else if (TextfieldComponent.class.equals(componentType)) {

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/renderer/FormElementFactory.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/renderer/FormElementFactory.java
@@ -21,6 +21,7 @@ import org.eclipse.sirius.web.forms.AbstractWidget;
 import org.eclipse.sirius.web.forms.Checkbox;
 import org.eclipse.sirius.web.forms.Form;
 import org.eclipse.sirius.web.forms.Group;
+import org.eclipse.sirius.web.forms.MultiSelect;
 import org.eclipse.sirius.web.forms.Page;
 import org.eclipse.sirius.web.forms.Radio;
 import org.eclipse.sirius.web.forms.Select;
@@ -30,6 +31,7 @@ import org.eclipse.sirius.web.forms.elements.CheckboxElementProps;
 import org.eclipse.sirius.web.forms.elements.FormElementProps;
 import org.eclipse.sirius.web.forms.elements.GroupElementProps;
 import org.eclipse.sirius.web.forms.elements.ListElementProps;
+import org.eclipse.sirius.web.forms.elements.MultiSelectElementProps;
 import org.eclipse.sirius.web.forms.elements.PageElementProps;
 import org.eclipse.sirius.web.forms.elements.RadioElementProps;
 import org.eclipse.sirius.web.forms.elements.SelectElementProps;
@@ -62,6 +64,8 @@ public class FormElementFactory implements IElementFactory {
             object = this.instantiateRadio((RadioElementProps) props, children);
         } else if (SelectElementProps.TYPE.equals(type) && props instanceof SelectElementProps) {
             object = this.instantiateSelect((SelectElementProps) props, children);
+        } else if (MultiSelectElementProps.TYPE.equals(type) && props instanceof MultiSelectElementProps) {
+            object = this.instantiateMultiSelect((MultiSelectElementProps) props, children);
         } else if (TextareaElementProps.TYPE.equals(type) && props instanceof TextareaElementProps) {
             object = this.instantiateTextarea((TextareaElementProps) props, children);
         } else if (TextfieldElementProps.TYPE.equals(type) && props instanceof TextfieldElementProps) {
@@ -163,6 +167,20 @@ public class FormElementFactory implements IElementFactory {
                 .options(props.getOptions())
                 .value(props.getValue())
                 .newValueHandler(props.getNewValueHandler())
+                .diagnostics(diagnostics)
+                .build();
+        // @formatter:on
+    }
+
+    private MultiSelect instantiateMultiSelect(MultiSelectElementProps props, List<Object> children) {
+        List<Diagnostic> diagnostics = this.getDiagnosticsFromChildren(children);
+
+        // @formatter:off
+        return MultiSelect.newMultiSelect(props.getId())
+                .label(props.getLabel())
+                .options(props.getOptions())
+                .values(props.getValues())
+                .newValuesHandler(props.getNewValuesHandler())
                 .diagnostics(diagnostics)
                 .build();
         // @formatter:on

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/renderer/FormInstancePropsValidator.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/renderer/FormInstancePropsValidator.java
@@ -18,6 +18,7 @@ import org.eclipse.sirius.web.forms.elements.CheckboxElementProps;
 import org.eclipse.sirius.web.forms.elements.FormElementProps;
 import org.eclipse.sirius.web.forms.elements.GroupElementProps;
 import org.eclipse.sirius.web.forms.elements.ListElementProps;
+import org.eclipse.sirius.web.forms.elements.MultiSelectElementProps;
 import org.eclipse.sirius.web.forms.elements.PageElementProps;
 import org.eclipse.sirius.web.forms.elements.RadioElementProps;
 import org.eclipse.sirius.web.forms.elements.SelectElementProps;
@@ -50,6 +51,8 @@ public class FormInstancePropsValidator implements IInstancePropsValidator {
             checkValidProps = props instanceof RadioElementProps;
         } else if (SelectElementProps.TYPE.equals(type)) {
             checkValidProps = props instanceof SelectElementProps;
+        } else if (MultiSelectElementProps.TYPE.equals(type)) {
+            checkValidProps = props instanceof MultiSelectElementProps;
         } else if (TextareaElementProps.TYPE.equals(type)) {
             checkValidProps = props instanceof TextareaElementProps;
         } else if (TextfieldElementProps.TYPE.equals(type)) {

--- a/backend/sirius-web-graphql-schema/src/main/java/org/eclipse/sirius/web/graphql/schema/FormTypesProvider.java
+++ b/backend/sirius-web-graphql-schema/src/main/java/org/eclipse/sirius/web/graphql/schema/FormTypesProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Obeo.
+ * Copyright (c) 2019, 2021 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -23,6 +23,7 @@ import org.eclipse.sirius.web.forms.Checkbox;
 import org.eclipse.sirius.web.forms.Form;
 import org.eclipse.sirius.web.forms.Group;
 import org.eclipse.sirius.web.forms.ListItem;
+import org.eclipse.sirius.web.forms.MultiSelect;
 import org.eclipse.sirius.web.forms.Page;
 import org.eclipse.sirius.web.forms.Radio;
 import org.eclipse.sirius.web.forms.RadioOption;
@@ -57,6 +58,8 @@ public class FormTypesProvider implements ITypeProvider {
 
     public static final String SELECT_TYPE = "Select"; //$NON-NLS-1$
 
+    public static final String MULTI_SELECT_TYPE = "MultiSelect"; //$NON-NLS-1$
+
     public static final String RADIO_TYPE = "Radio"; //$NON-NLS-1$
 
     private final GraphQLObjectTypeProvider graphQLObjectTypeProvider = new GraphQLObjectTypeProvider();
@@ -76,6 +79,7 @@ public class FormTypesProvider implements ITypeProvider {
             Radio.class,
             RadioOption.class,
             Select.class,
+            MultiSelect.class,
             SelectOption.class,
             org.eclipse.sirius.web.forms.List.class,
             ListItem.class,

--- a/backend/sirius-web-graphql/src/main/java/org/eclipse/sirius/web/graphql/datafetchers/mutation/MutationEditMultiSelectDataFetcher.java
+++ b/backend/sirius-web-graphql/src/main/java/org/eclipse/sirius/web/graphql/datafetchers/mutation/MutationEditMultiSelectDataFetcher.java
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.graphql.datafetchers.mutation;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.Objects;
+
+import org.eclipse.sirius.web.annotations.graphql.GraphQLMutationTypes;
+import org.eclipse.sirius.web.annotations.spring.graphql.MutationDataFetcher;
+import org.eclipse.sirius.web.collaborative.api.services.IEditingContextEventProcessorRegistry;
+import org.eclipse.sirius.web.collaborative.forms.api.dto.EditMultiSelectInput;
+import org.eclipse.sirius.web.collaborative.forms.api.dto.EditMultiSelectSuccessPayload;
+import org.eclipse.sirius.web.core.api.ErrorPayload;
+import org.eclipse.sirius.web.core.api.IPayload;
+import org.eclipse.sirius.web.graphql.messages.IGraphQLMessageService;
+import org.eclipse.sirius.web.graphql.schema.MutationTypeProvider;
+import org.eclipse.sirius.web.spring.graphql.api.IDataFetcherWithFieldCoordinates;
+
+import graphql.schema.DataFetchingEnvironment;
+
+/**
+ * The data fetcher used to edit a select.
+ * <p>
+ * It will be used to handle the following GraphQL field:
+ * </p>
+ *
+ * <pre>
+ * type Mutation {
+ *   multiEditSelect(input: EditMultiSelectInput!): EditMultiSelectPayload!
+ * }
+ * </pre>
+ *
+ * @author arichard
+ */
+//@formatter:off
+@GraphQLMutationTypes(
+    input = EditMultiSelectInput.class,
+    payloads = {
+        EditMultiSelectSuccessPayload.class
+    }
+)
+@MutationDataFetcher(type = MutationTypeProvider.TYPE, field = MutationEditMultiSelectDataFetcher.EDIT_MULTI_SELECT_FIELD)
+//@formatter:on
+public class MutationEditMultiSelectDataFetcher implements IDataFetcherWithFieldCoordinates<IPayload> {
+
+    public static final String EDIT_MULTI_SELECT_FIELD = "editMultiSelect"; //$NON-NLS-1$
+
+    private final ObjectMapper objectMapper;
+
+    private final IEditingContextEventProcessorRegistry editingContextEventProcessorRegistry;
+
+    private final IGraphQLMessageService messageService;
+
+    public MutationEditMultiSelectDataFetcher(ObjectMapper objectMapper, IEditingContextEventProcessorRegistry editingContextEventProcessorRegistry, IGraphQLMessageService messageService) {
+        this.objectMapper = Objects.requireNonNull(objectMapper);
+        this.editingContextEventProcessorRegistry = Objects.requireNonNull(editingContextEventProcessorRegistry);
+        this.messageService = Objects.requireNonNull(messageService);
+    }
+
+    @Override
+    public IPayload get(DataFetchingEnvironment environment) throws Exception {
+        Object argument = environment.getArgument(MutationTypeProvider.INPUT_ARGUMENT);
+        var input = this.objectMapper.convertValue(argument, EditMultiSelectInput.class);
+
+        // @formatter:off
+        return this.editingContextEventProcessorRegistry.dispatchEvent(input.getEditingContextId(), input)
+                .orElse(new ErrorPayload(input.getId(), this.messageService.unexpectedError()));
+        // @formatter:on
+    }
+}

--- a/backend/sirius-web-spring-collaborative-forms/src/main/java/org/eclipse/sirius/web/spring/collaborative/forms/handlers/EditMultiSelectEventHandler.java
+++ b/backend/sirius-web-spring-collaborative-forms/src/main/java/org/eclipse/sirius/web/spring/collaborative/forms/handlers/EditMultiSelectEventHandler.java
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.spring.collaborative.forms.handlers;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import org.eclipse.sirius.web.collaborative.api.services.ChangeDescription;
+import org.eclipse.sirius.web.collaborative.api.services.ChangeKind;
+import org.eclipse.sirius.web.collaborative.api.services.EventHandlerResponse;
+import org.eclipse.sirius.web.collaborative.api.services.Monitoring;
+import org.eclipse.sirius.web.collaborative.forms.api.IFormEventHandler;
+import org.eclipse.sirius.web.collaborative.forms.api.IFormInput;
+import org.eclipse.sirius.web.collaborative.forms.api.IFormQueryService;
+import org.eclipse.sirius.web.collaborative.forms.api.dto.EditMultiSelectInput;
+import org.eclipse.sirius.web.collaborative.forms.api.dto.EditMultiSelectSuccessPayload;
+import org.eclipse.sirius.web.core.api.ErrorPayload;
+import org.eclipse.sirius.web.forms.Form;
+import org.eclipse.sirius.web.forms.MultiSelect;
+import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.spring.collaborative.forms.messages.ICollaborativeFormMessageService;
+import org.springframework.stereotype.Service;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+
+/**
+ * The handler of the edit multi select event.
+ *
+ * @author arichard
+ */
+@Service
+public class EditMultiSelectEventHandler implements IFormEventHandler {
+
+    private final IFormQueryService formQueryService;
+
+    private final ICollaborativeFormMessageService messageService;
+
+    private final Counter counter;
+
+    public EditMultiSelectEventHandler(IFormQueryService formQueryService, ICollaborativeFormMessageService messageService, MeterRegistry meterRegistry) {
+        this.formQueryService = Objects.requireNonNull(formQueryService);
+        this.messageService = Objects.requireNonNull(messageService);
+
+        // @formatter:off
+        this.counter = Counter.builder(Monitoring.EVENT_HANDLER)
+                .tag(Monitoring.NAME, this.getClass().getSimpleName())
+                .register(meterRegistry);
+        // @formatter:on
+    }
+
+    @Override
+    public boolean canHandle(IFormInput formInput) {
+        return formInput instanceof EditMultiSelectInput;
+    }
+
+    @Override
+    public EventHandlerResponse handle(Form form, IFormInput formInput) {
+        this.counter.increment();
+
+        if (formInput instanceof EditMultiSelectInput) {
+            EditMultiSelectInput input = (EditMultiSelectInput) formInput;
+
+            // @formatter:off
+            Optional<MultiSelect> optionalMultiSelect = this.formQueryService.findWidget(form, input.getSelectId())
+                    .filter(MultiSelect.class::isInstance)
+                    .map(MultiSelect.class::cast);
+
+            Status status = optionalMultiSelect.map(MultiSelect::getNewValuesHandler)
+                    .map(handler -> handler.apply(input.getNewValues()))
+                    .orElse(Status.ERROR);
+            // @formatter:on
+            return new EventHandlerResponse(new ChangeDescription(ChangeKind.SEMANTIC_CHANGE, formInput.getRepresentationId()),
+                    new EditMultiSelectSuccessPayload(formInput.getId(), status.toString()));
+        }
+        String message = this.messageService.invalidInput(formInput.getClass().getSimpleName(), EditMultiSelectInput.class.getSimpleName());
+        return new EventHandlerResponse(new ChangeDescription(ChangeKind.NOTHING, formInput.getRepresentationId()), new ErrorPayload(formInput.getId(), message));
+    }
+}

--- a/backend/sirius-web-spring-graphql/src/main/java/org/eclipse/sirius/web/spring/graphql/ws/handlers/StartMessageHandler.java
+++ b/backend/sirius-web-spring-graphql/src/main/java/org/eclipse/sirius/web/spring/graphql/ws/handlers/StartMessageHandler.java
@@ -115,6 +115,7 @@ public class StartMessageHandler implements IWebSocketMessageHandler {
     private void subscribe(String id, Publisher<ExecutionResult> publisher) {
         Consumer<ExecutionResult> consumer = result -> this.send(this.objectMapper, this.session, new DataMessage(id, result.toSpecification()), this.logger);
         Consumer<Throwable> onErrorConsumer = error -> {
+            this.logger.warn(error.getMessage(), error);
             this.send(this.objectMapper, this.session, new ErrorMessage(id, null), this.logger);
         };
         Runnable onCompleteConsumer = () -> this.send(this.objectMapper, this.session, new CompleteMessage(id), this.logger);

--- a/frontend/src/form/Form.types.ts
+++ b/frontend/src/form/Form.types.ts
@@ -68,6 +68,12 @@ export interface Select extends Widget {
   options: SelectOption[];
 }
 
+export interface MultiSelect extends Widget {
+  label: string;
+  values: string[];
+  options: SelectOption[];
+}
+
 export interface SelectOption {
   id: string;
   label: string;

--- a/frontend/src/form/FormEventFragments.ts
+++ b/frontend/src/form/FormEventFragments.ts
@@ -73,6 +73,14 @@ export const formRefreshedEventPayloadFragment = gql`
                 label
               }
             }
+            ... on MultiSelect {
+              label
+              values
+              options {
+                id
+                label
+              }
+            }
             ... on Radio {
               label
               options {

--- a/frontend/src/form/FormEventFragments.types.ts
+++ b/frontend/src/form/FormEventFragments.types.ts
@@ -99,6 +99,11 @@ export interface GQLSelect extends GQLWidget {
   options: GQLSelectOption[];
 }
 
+export interface GQLMultiSelect extends GQLWidget {
+  label: string;
+  values: string[];
+  options: GQLSelectOption[];
+}
 export interface GQLSelectOption {
   id: string;
   label: string;

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -82,6 +82,7 @@ export * from './properties/Properties';
 export * from './properties/PropertiesWebSocketContainer';
 export * from './properties/propertysections/CheckboxPropertySection';
 export * from './properties/propertysections/ListPropertySection';
+export * from './properties/propertysections/MultiSelectPropertySection';
 export * from './properties/propertysections/RadioPropertySection';
 export * from './properties/propertysections/SelectPropertySection';
 export * from './properties/propertysections/TextfieldPropertySection';

--- a/frontend/src/properties/Group.tsx
+++ b/frontend/src/properties/Group.tsx
@@ -12,10 +12,21 @@
  *******************************************************************************/
 import { makeStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
-import { Checkbox, List, Radio, Select, Textarea, Textfield, Widget, WidgetSubscription } from 'form/Form.types';
+import {
+  Checkbox,
+  List,
+  MultiSelect,
+  Radio,
+  Select,
+  Textarea,
+  Textfield,
+  Widget,
+  WidgetSubscription,
+} from 'form/Form.types';
 import { GroupProps } from 'properties/Group.types';
 import { CheckboxPropertySection } from 'properties/propertysections/CheckboxPropertySection';
 import { ListPropertySection } from 'properties/propertysections/ListPropertySection';
+import { MultiSelectPropertySection } from 'properties/propertysections/MultiSelectPropertySection';
 import { RadioPropertySection } from 'properties/propertysections/RadioPropertySection';
 import { SelectPropertySection } from 'properties/propertysections/SelectPropertySection';
 import { TextfieldPropertySection } from 'properties/propertysections/TextfieldPropertySection';
@@ -61,6 +72,7 @@ const isTextfield = (widget: Widget): widget is Textfield => widget.__typename =
 const isTextarea = (widget: Widget): widget is Textarea => widget.__typename === 'Textarea';
 const isCheckbox = (widget: Widget): widget is Checkbox => widget.__typename === 'Checkbox';
 const isSelect = (widget: Widget): widget is Select => widget.__typename === 'Select';
+const isMultiSelect = (widget: Widget): widget is MultiSelect => widget.__typename === 'MultiSelect';
 const isRadio = (widget: Widget): widget is Radio => widget.__typename === 'Radio';
 const isList = (widget: Widget): widget is List => widget.__typename === 'List';
 
@@ -102,6 +114,17 @@ const widgetToPropertySection = (
   } else if (isSelect(widget)) {
     propertySection = (
       <SelectPropertySection
+        editingContextId={editingContextId}
+        formId={formId}
+        widget={widget}
+        subscribers={subscribers}
+        key={widget.id}
+        readOnly={readOnly}
+      />
+    );
+  } else if (isMultiSelect(widget)) {
+    propertySection = (
+      <MultiSelectPropertySection
         editingContextId={editingContextId}
         formId={formId}
         widget={widget}

--- a/frontend/src/properties/propertysections/ListPropertySection.tsx
+++ b/frontend/src/properties/propertysections/ListPropertySection.tsx
@@ -10,8 +10,8 @@
  * Contributors:
  *     Obeo - initial API and implementation
  *******************************************************************************/
-import { FormHelperText } from '@material-ui/core';
 import FormControl from '@material-ui/core/FormControl';
+import FormHelperText from '@material-ui/core/FormHelperText';
 import { makeStyles } from '@material-ui/core/styles';
 import Table from '@material-ui/core/Table';
 import TableBody from '@material-ui/core/TableBody';

--- a/frontend/src/properties/propertysections/MultiSelectPropertySection.types.ts
+++ b/frontend/src/properties/propertysections/MultiSelectPropertySection.types.ts
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+import { MultiSelect, Subscriber } from 'form/Form.types';
+
+export interface MultiSelectPropertySectionProps {
+  editingContextId: string;
+  formId: string;
+  widget: MultiSelect;
+  subscribers: Subscriber[];
+  readOnly: boolean;
+}
+
+export interface GQLEditMultiSelectMutationData {
+  editMultiSelect: GQLEditMultiSelectPayload;
+}
+
+export interface GQLEditMultiSelectPayload {
+  __typename: string;
+}
+
+export interface GQLErrorPayload extends GQLEditMultiSelectPayload, GQLUpdateWidgetFocusPayload {
+  message: string;
+}
+
+export interface GQLUpdateWidgetFocusMutationData {
+  updateWidgetFocus: GQLUpdateWidgetFocusPayload;
+}
+
+export interface GQLUpdateWidgetFocusPayload {
+  __typename: string;
+}

--- a/frontend/src/properties/propertysections/RadioPropertySection.tsx
+++ b/frontend/src/properties/propertysections/RadioPropertySection.tsx
@@ -11,9 +11,9 @@
  *     Obeo - initial API and implementation
  *******************************************************************************/
 import { useMutation } from '@apollo/client';
-import { FormHelperText } from '@material-ui/core';
 import FormControl from '@material-ui/core/FormControl';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
+import FormHelperText from '@material-ui/core/FormHelperText';
 import IconButton from '@material-ui/core/IconButton';
 import Radio from '@material-ui/core/Radio';
 import RadioGroup from '@material-ui/core/RadioGroup';

--- a/frontend/src/properties/propertysections/SelectPropertySection.tsx
+++ b/frontend/src/properties/propertysections/SelectPropertySection.tsx
@@ -11,8 +11,8 @@
  *     Obeo - initial API and implementation
  *******************************************************************************/
 import { useMutation } from '@apollo/client';
-import { FormHelperText } from '@material-ui/core';
 import FormControl from '@material-ui/core/FormControl';
+import FormHelperText from '@material-ui/core/FormHelperText';
 import IconButton from '@material-ui/core/IconButton';
 import MenuItem from '@material-ui/core/MenuItem';
 import Select from '@material-ui/core/Select';


### PR DESCRIPTION
### Type of this PR 

- [ ] Bug fix
- [x] New feature or improvement
- [ ] Documentation
- [ ] Cleanup
- [ ] Test
- [ ] Build/Releng

### Issue(s)

https://github.com/eclipse-sirius/sirius-components/issues/428

### What does this PR do?

Use the https://material-ui.com/components/selects/#multiple-select widget with the tag option to handle multi-valued references in the properties view.
When the widget is selected, a scrollable list of options is displayed to the user, and each option can be selected through a checkbox.

### Screenshot/screencast of this PR

<img width="158" alt="Capture d’écran 2021-07-19 à 15 17 13" src="https://user-images.githubusercontent.com/717752/126165808-da62a5d7-2bfd-47eb-a979-44c777702bc7.png">

<img width="326" alt="Capture d’écran 2021-07-19 à 15 17 24" src="https://user-images.githubusercontent.com/717752/126165826-3326dfbb-c6bc-4826-9366-6185dfea4b75.png">


### Potential side effects

All multi-valued non-contained references are now displayed in the Properties View, even the `eOpposite` ones.

### How to test this PR?

- [ ] Frontend Unit tests
- [ ] Backend Unit tests
- [ ] Cypress : please specify
- [x] Manual Test : please specify

### Checklist

- [x] I have read CONTRIBUTING carefully.
- [x] I have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All my commits are signed-off (`-s`) with my mail address of my Eclipse Account.
- [x] I have covered my changes by unit tests or integration tests or manual tests.
- [x] All tests pass.
- [ ] I have updated the documentation accordingly
- [ ] New React components are availables in storybook
