### PR TITLE
[640] Use accordions for the layout of the left and right sites

### DIFF
--- a/frontend/src/explorer/Explorer.module.css
+++ b/frontend/src/explorer/Explorer.module.css
@@ -15,5 +15,4 @@
   grid-template-columns: 1fr;
   grid-template-rows: 1fr;
   padding: 8px 0px;
-  overflow: auto;
 }

--- a/frontend/src/properties/Properties.tsx
+++ b/frontend/src/properties/Properties.tsx
@@ -30,7 +30,6 @@ const usePropertiesStyles = makeStyles((theme) => ({
   content: {
     overflowX: 'hidden',
     overflowY: 'auto',
-    backgroundColor: theme.palette.background.default,
   },
   subscribers: {
     marginLeft: 'auto',

--- a/frontend/src/workbench/LeftSite.tsx
+++ b/frontend/src/workbench/LeftSite.tsx
@@ -11,72 +11,125 @@
  *     Obeo - initial API and implementation
  *******************************************************************************/
 
-import { makeStyles } from '@material-ui/core/styles';
-import Tab from '@material-ui/core/Tab';
-import Tabs from '@material-ui/core/Tabs';
+import MuiAccordion from '@material-ui/core/Accordion';
+import AccordionDetails from '@material-ui/core/AccordionDetails';
+import MuiAccordionSummary from '@material-ui/core/AccordionSummary';
+import MuiCollapse from '@material-ui/core/Collapse';
+import { makeStyles, withStyles } from '@material-ui/core/styles';
+import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import { ExplorerWebSocketContainer } from 'explorer/ExplorerWebSocketContainer';
 import React from 'react';
+import { ValidationWebSocketContainer } from 'validation/ValidationWebSocketContainer';
 import { LeftSiteProps } from './LeftSite.types';
 
 const useSiteStyles = makeStyles((theme) => ({
   site: {
-    display: 'flex',
-    flexDirection: 'column',
-    '& > *:nth-child(2)': {
-      flexGrow: 1,
-    },
+    display: 'grid',
+    gridTemplateColumns: 'minmax(0,1fr)',
   },
-  tabsRoot: {
-    minHeight: theme.spacing(4),
-    borderBottomColor: theme.palette.divider,
-    borderBottomWidth: '1px',
-    borderBottomStyle: 'solid',
+  bothExpanded: {
+    gridTemplateRows: 'minmax(0,1fr) minmax(0,1fr)',
   },
-  tabRoot: {
-    minHeight: theme.spacing(4),
-    textTransform: 'none',
+  noneExpanded: {
+    gridTemplateRows: 'min-content min-content',
   },
-  tabLabel: {
-    display: 'flex',
-    flexDirection: 'row',
-    alignItems: 'center',
-    '& > *:nth-child(2)': {
-      marginLeft: theme.spacing(1),
-    },
+  explorerExpandedOnly: {
+    gridTemplateRows: 'minmax(0,1fr) min-content',
+  },
+  validationExpandedOnly: {
+    gridTemplateRows: 'min-content minmax(0,1fr)',
   },
 }));
 
-const a11yProps = (id: string) => {
-  return {
-    id: `simple-tab-${id}`,
-    'aria-controls': `simple-tabpanel-${id}`,
-  };
-};
+const Accordion = withStyles({
+  root: {
+    display: 'grid',
+    gridTemplateColumns: 'minmax(0,1fr)',
+    gridTemplateRows: 'min-content minmax(0,1fr)',
+    border: '1px solid rgba(0, 0, 0, .125)',
+    boxShadow: 'none',
+    '&:not(:last-child)': {
+      borderBottom: '0px',
+    },
+    '&:before': {
+      display: 'none',
+    },
+    '&$expanded': {
+      margin: '0px',
+    },
+  },
+  expanded: {},
+})(MuiAccordion);
+
+const AccordionSummary = withStyles({
+  root: {
+    borderBottom: '1px solid rgba(0, 0, 0, .125)',
+    marginBottom: -1,
+    '&$expanded': {
+      minHeight: 48,
+    },
+  },
+  content: {
+    '&$expanded': {
+      margin: '0px',
+    },
+  },
+  expanded: {},
+})(MuiAccordionSummary);
+
+const CustomCollapse = withStyles({
+  entered: {
+    overflow: 'auto',
+  },
+})(MuiCollapse);
 
 export const LeftSite = ({ editingContextId, setSelection, selection, readOnly }: LeftSiteProps) => {
   const classes = useSiteStyles();
 
+  const [explorerExpanded, setExplorerExpanded] = React.useState<boolean>(true);
+  const [validationExpanded, setValidationExpanded] = React.useState<boolean>(false);
+
+  let classSite = classes.site;
+  if (explorerExpanded && validationExpanded) {
+    classSite = `${classSite} ${classes.bothExpanded}`;
+  }
+  if (!explorerExpanded && !validationExpanded) {
+    classSite = `${classSite} ${classes.noneExpanded}`;
+  }
+  if (explorerExpanded && !validationExpanded) {
+    classSite = `${classSite} ${classes.explorerExpandedOnly}`;
+  }
+  if (!explorerExpanded && validationExpanded) {
+    classSite = `${classSite} ${classes.validationExpandedOnly}`;
+  }
+
   return (
-    <div className={classes.site}>
-      <Tabs
-        classes={{ root: classes.tabsRoot }}
-        textColor="primary"
-        indicatorColor="primary"
-        variant="fullWidth"
-        value={0}>
-        <Tab
-          {...a11yProps('explorer')}
-          classes={{ root: classes.tabRoot }}
-          data-testid="explorer"
-          label={<div className={classes.tabLabel}>Explorer</div>}
-        />
-      </Tabs>
-      <ExplorerWebSocketContainer
-        editingContextId={editingContextId}
-        setSelection={setSelection}
-        selection={selection}
-        readOnly={readOnly}
-      />
+    <div className={classSite}>
+      <Accordion
+        square
+        expanded={explorerExpanded}
+        onChange={(event, isExpanded) => setExplorerExpanded(isExpanded)}
+        TransitionComponent={CustomCollapse as any}>
+        <AccordionSummary expandIcon={<ExpandMoreIcon />}>Explorer</AccordionSummary>
+        <AccordionDetails>
+          <ExplorerWebSocketContainer
+            editingContextId={editingContextId}
+            setSelection={setSelection}
+            selection={selection}
+            readOnly={readOnly}
+          />
+        </AccordionDetails>
+      </Accordion>
+      <Accordion
+        square
+        expanded={validationExpanded}
+        onChange={(event, isExpanded) => setValidationExpanded(isExpanded)}
+        TransitionComponent={CustomCollapse as any}>
+        <AccordionSummary expandIcon={<ExpandMoreIcon />}>Validation</AccordionSummary>
+        <AccordionDetails>
+          <ValidationWebSocketContainer editingContextId={editingContextId} />
+        </AccordionDetails>
+      </Accordion>
     </div>
   );
 };

--- a/frontend/src/workbench/RightSite.tsx
+++ b/frontend/src/workbench/RightSite.tsx
@@ -11,93 +11,79 @@
  *     Obeo - initial API and implementation
  *******************************************************************************/
 
-import { makeStyles } from '@material-ui/core/styles';
-import Tab from '@material-ui/core/Tab';
-import Tabs from '@material-ui/core/Tabs';
+import MuiAccordion from '@material-ui/core/Accordion';
+import AccordionDetails from '@material-ui/core/AccordionDetails';
+import MuiAccordionSummary from '@material-ui/core/AccordionSummary';
+import MuiCollapse from '@material-ui/core/Collapse';
+import { makeStyles, withStyles } from '@material-ui/core/styles';
 import { PropertiesWebSocketContainer } from 'properties/PropertiesWebSocketContainer';
-import React, { useState } from 'react';
-import { ValidationWebSocketContainer } from 'validation/ValidationWebSocketContainer';
-import { RightSiteProps, TabPanelProps } from './RightSite.types';
+import React from 'react';
+import { RightSiteProps } from './RightSite.types';
 
 const useSiteStyles = makeStyles((theme) => ({
   site: {
-    display: 'flex',
-    flexDirection: 'column',
-    '& > *:nth-child(2)': {
-      flexGrow: 1,
-    },
+    display: 'grid',
+    gridTemplateColumns: 'minmax(0,1fr)',
+    gridTemplateRows: 'minmax(0,1fr)',
   },
-  tabsRoot: {
-    minHeight: theme.spacing(4),
-    borderBottomColor: theme.palette.divider,
-    borderBottomWidth: '1px',
-    borderBottomStyle: 'solid',
-  },
-  tabRoot: {
-    minHeight: theme.spacing(4),
-    textTransform: 'none',
-  },
-  tabLabel: {
-    display: 'flex',
-    flexDirection: 'row',
-    alignItems: 'center',
-    '& > *:nth-child(2)': {
-      marginLeft: theme.spacing(1),
-    },
+  accordionDetailsRoot: {
+    display: 'block',
   },
 }));
 
-const a11yProps = (id: string) => {
-  return {
-    id: `simple-tab-${id}`,
-    'aria-controls': `simple-tabpanel-${id}`,
-  };
-};
+const Accordion = withStyles({
+  root: {
+    display: 'grid',
+    gridTemplateColumns: 'minmax(0,1fr)',
+    gridTemplateRows: 'min-content minmax(0,1fr)',
+    border: '1px solid rgba(0, 0, 0, .125)',
+    boxShadow: 'none',
+    '&:not(:last-child)': {
+      borderBottom: '0px',
+    },
+    '&:before': {
+      display: 'none',
+    },
+    '&$expanded': {
+      margin: '0px',
+    },
+  },
+  expanded: {},
+})(MuiAccordion);
 
-const TabPanel = ({ children, value, index }: TabPanelProps) => {
-  return (
-    <div
-      role="tabpanel"
-      hidden={value !== index}
-      id={`simple-tabpanel-${index}`}
-      aria-labelledby={`simple-tab-${index}`}>
-      {value === index && <div>{children}</div>}
-    </div>
-  );
-};
+const AccordionSummary = withStyles({
+  root: {
+    borderBottom: '1px solid rgba(0, 0, 0, .125)',
+    marginBottom: -1,
+    '&$expanded': {
+      minHeight: 48,
+    },
+  },
+  content: {
+    '&$expanded': {
+      margin: '0px',
+    },
+  },
+  expanded: {},
+})(MuiAccordionSummary);
+
+const CustomCollapse = withStyles({
+  entered: {
+    overflow: 'auto',
+  },
+})(MuiCollapse);
 
 export const RightSite = ({ editingContextId, selection, readOnly }: RightSiteProps) => {
   const classes = useSiteStyles();
-  const [value, setValue] = useState(0);
 
   return (
     <div className={classes.site}>
-      <Tabs
-        classes={{ root: classes.tabsRoot }}
-        textColor="primary"
-        indicatorColor="primary"
-        value={value}
-        onChange={(_, newValue: number) => setValue(newValue)}
-        variant="fullWidth">
-        <Tab
-          {...a11yProps('properties')}
-          classes={{ root: classes.tabRoot }}
-          data-testid="properties"
-          label={<div className={classes.tabLabel}>Properties</div>}
-        />
-        <Tab
-          {...a11yProps('validation')}
-          classes={{ root: classes.tabRoot }}
-          data-testid="validation"
-          label={<div className={classes.tabLabel}>Validation</div>}
-        />
-      </Tabs>
-      <TabPanel value={value} index={0}>
-        <PropertiesWebSocketContainer editingContextId={editingContextId} selection={selection} readOnly={readOnly} />
-      </TabPanel>
-      <TabPanel value={value} index={1}>
-        <ValidationWebSocketContainer editingContextId={editingContextId} />
-      </TabPanel>
+      <Accordion square expanded={true} TransitionComponent={CustomCollapse as any}>
+        <AccordionSummary>Details</AccordionSummary>
+        <AccordionDetails className={classes.accordionDetailsRoot}>
+          <PropertiesWebSocketContainer editingContextId={editingContextId} selection={selection} readOnly={readOnly} />
+        </AccordionDetails>
+      </Accordion>
     </div>
   );
 };

--- a/frontend/src/workbench/RightSite.types.ts
+++ b/frontend/src/workbench/RightSite.types.ts
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/******************************************************************************
  * Copyright (c) 2021 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -9,17 +9,11 @@
  *
  * Contributors:
  *     Obeo - initial API and implementation
- *******************************************************************************/
+ ******************************************************************************/
 import { Selection } from 'workbench/Workbench.types';
 
 export interface RightSiteProps {
   editingContextId: string;
   selection?: Selection;
   readOnly: boolean;
-}
-
-export interface TabPanelProps {
-  children?: React.ReactNode;
-  index: any;
-  value: any;
 }


### PR DESCRIPTION
### Type of this PR 

- [ ] Bug fix
- [x] New feature or improvement
- [ ] Documentation
- [ ] Cleanup
- [ ] Test
- [ ] Build/Releng

### Issue(s)

#640

### What does this PR do?

- Replaces Tabs by Accordion on side views
- Removes the overflow rule on explorer to let it be handled by the
accordion container.
- Fixes the overflow that could be displayed on the whole application.
- Removes the background-color rule on properties to make it the same as
its container.
- Move the Validation view to the left, under the Explorer view.

### Checklist

- [x] I have read CONTRIBUTING carefully.
- [x] I have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All my commits are signed-off (`-s`) with my mail address of my Eclipse Account.
- [ ] I have covered my changes by unit tests or integration tests or manual tests.
- [x] All tests pass.
- [ ] I have updated the documentation accordingly
- [ ] New React components are availables in storybook
