### PR TITLE
[642][WIP] Move Project Explorer Contextual Menus to Material UI

### DIFF
--- a/frontend/src/tree/TreeItemDiagramContextMenu.tsx
+++ b/frontend/src/tree/TreeItemDiagramContextMenu.tsx
@@ -10,36 +10,68 @@
  * Contributors:
  *     Obeo - initial API and implementation
  *******************************************************************************/
-import { ContextMenu, Entry, LEFT_START, Separator } from 'core/contextmenu/ContextMenu';
-import { Delete, Edit } from 'icons';
+import { makeStyles } from '@material-ui/core';
+import ListItemIcon from '@material-ui/core/ListItemIcon';
+import ListItemText from '@material-ui/core/ListItemText';
+import Menu from '@material-ui/core/Menu';
+import MenuItem from '@material-ui/core/MenuItem';
+import DeleteIcon from '@material-ui/icons/Delete';
+import EditIcon from '@material-ui/icons/Edit';
 import React from 'react';
 import { TreeItemDiagramContextMenuProps } from './TreeItemDiagramContextMenu.types';
 
+const useTreeItemDiagramContextMenuStyles = makeStyles((theme) => ({
+  item: {
+    paddingTop: theme.spacing(1),
+    paddingBottom: theme.spacing(1),
+  },
+}));
+
 export const TreeItemDiagramContextMenu = ({
-  x,
-  y,
   onDeleteRepresentation,
   onRenameRepresentation,
   onClose,
   readOnly,
+  menuAnchor,
 }: TreeItemDiagramContextMenuProps) => {
+  const classes = useTreeItemDiagramContextMenuStyles();
+
   return (
-    <ContextMenu x={x} y={y} caretPosition={LEFT_START} onClose={onClose} data-testid="treeitemdiagram-contextmenu">
-      <Entry
-        icon={<Edit title="" />}
-        label="Rename"
+    <Menu
+      id="treeitemdiagram-contextmenu"
+      anchorEl={menuAnchor}
+      keepMounted
+      open
+      onClose={onClose}
+      data-testid="treeitemdiagram-contextmenu"
+      getContentAnchorEl={null}
+      anchorOrigin={{
+        vertical: 'bottom',
+        horizontal: 'right',
+      }}>
+      <MenuItem
+        divider
         onClick={onRenameRepresentation}
         data-testid="rename-representation"
         disabled={readOnly}
-      />
-      <Separator />
-      <Entry
-        icon={<Delete title="" />}
-        label="Delete"
+        dense
+        className={classes.item}>
+        <ListItemIcon>
+          <EditIcon fontSize="small" />
+        </ListItemIcon>
+        <ListItemText primary="Rename" />
+      </MenuItem>
+      <MenuItem
         onClick={onDeleteRepresentation}
         data-testid="delete-representation"
         disabled={readOnly}
-      />
-    </ContextMenu>
+        dense
+        className={classes.item}>
+        <ListItemIcon>
+          <DeleteIcon fontSize="small" />
+        </ListItemIcon>
+        <ListItemText primary="Delete" />
+      </MenuItem>
+    </Menu>
   );
 };

--- a/frontend/src/tree/TreeItemDiagramContextMenu.types.ts
+++ b/frontend/src/tree/TreeItemDiagramContextMenu.types.ts
@@ -12,10 +12,9 @@
  *******************************************************************************/
 
 export interface TreeItemDiagramContextMenuProps {
-  x: number;
-  y: number;
   onDeleteRepresentation: () => void;
   onRenameRepresentation: () => void;
   onClose: () => void;
   readOnly: boolean;
+  menuAnchor: HTMLElement;
 }

--- a/frontend/src/tree/TreeItemDocumentContextMenu.tsx
+++ b/frontend/src/tree/TreeItemDocumentContextMenu.tsx
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Obeo.
+ * Copyright (c) 2019, 2021 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -10,48 +10,85 @@
  * Contributors:
  *     Obeo - initial API and implementation
  *******************************************************************************/
+import { makeStyles } from '@material-ui/core';
+import ListItemIcon from '@material-ui/core/ListItemIcon';
+import ListItemText from '@material-ui/core/ListItemText';
+import Menu from '@material-ui/core/Menu';
+import MenuItem from '@material-ui/core/MenuItem';
+import AddIcon from '@material-ui/icons/Add';
+import DeleteIcon from '@material-ui/icons/Delete';
+import EditIcon from '@material-ui/icons/Edit';
+import GetAppIcon from '@material-ui/icons/GetApp';
 import { httpOrigin } from 'common/URL';
-import { ContextMenu, Entry, LEFT_START, Separator } from 'core/contextmenu/ContextMenu';
-import { Delete, Edit } from 'icons';
 import React from 'react';
 import { TreeItemDocumentContextMenuProps } from './TreeItemDocumentContextMenu.types';
+
+const useTreeItemDocumentContextMenuStyles = makeStyles((theme) => ({
+  item: {
+    paddingTop: theme.spacing(0),
+    paddingBottom: theme.spacing(0),
+  },
+}));
 
 export const TreeItemDocumentContextMenu = ({
   editingContextId,
   documentId,
-  x,
-  y,
   onNewObject,
   onRenameDocument,
   onDownload,
   onDeleteDocument,
   onClose,
   readOnly,
+  menuAnchor,
 }: TreeItemDocumentContextMenuProps) => {
+  const classes = useTreeItemDocumentContextMenuStyles();
+
   return (
-    <ContextMenu x={x} y={y} caretPosition={LEFT_START} onClose={onClose} data-testid="treeitemdocument-contextmenu">
-      <Entry label="New object" onClick={onNewObject} data-testid="new-object" disabled={readOnly} />
-      <Entry
-        icon={<Edit title="" />}
-        label="Rename"
-        onClick={onRenameDocument}
-        data-testid="rename"
-        disabled={readOnly}
-      />
-      <a
+    <Menu
+      id="treeitemdocument-contextmenu"
+      anchorEl={menuAnchor}
+      keepMounted
+      open
+      onClose={onClose}
+      data-testid="treeitemdocument-contextmenu"
+      getContentAnchorEl={null}
+      anchorOrigin={{
+        vertical: 'bottom',
+        horizontal: 'right',
+      }}>
+      <MenuItem onClick={onNewObject} data-testid="new-object" disabled={readOnly} dense className={classes.item}>
+        <ListItemIcon>
+          <AddIcon fontSize="small" />
+        </ListItemIcon>
+        <ListItemText primary="New object" />
+      </MenuItem>
+      <MenuItem onClick={onRenameDocument} data-testid="rename" disabled={readOnly} dense className={classes.item}>
+        <ListItemIcon>
+          <EditIcon fontSize="small" />
+        </ListItemIcon>
+        <ListItemText primary="Rename" />
+      </MenuItem>
+      <MenuItem
+        divider
+        onClick={onDownload}
+        component="a"
         href={`${httpOrigin}/api/editingcontexts/${editingContextId}/documents/${documentId}`}
         type="application/octet-stream"
-        data-testid="download-link">
-        <Entry label="Download" onClick={onDownload} data-testid="download" />
-      </a>
-      <Separator />
-      <Entry
-        icon={<Delete title="" />}
-        label="Delete"
-        onClick={onDeleteDocument}
-        data-testid="delete"
+        data-testid="download"
         disabled={readOnly}
-      />
-    </ContextMenu>
+        dense
+        className={classes.item}>
+        <ListItemIcon>
+          <GetAppIcon fontSize="small" />
+        </ListItemIcon>
+        <ListItemText primary="Download" />
+      </MenuItem>
+      <MenuItem onClick={onDeleteDocument} data-testid="delete" disabled={readOnly} dense className={classes.item}>
+        <ListItemIcon>
+          <DeleteIcon fontSize="small" />
+        </ListItemIcon>
+        <ListItemText primary="Delete" />
+      </MenuItem>
+    </Menu>
   );
 };

--- a/frontend/src/tree/TreeItemDocumentContextMenu.types.ts
+++ b/frontend/src/tree/TreeItemDocumentContextMenu.types.ts
@@ -14,12 +14,11 @@
 export interface TreeItemDocumentContextMenuProps {
   editingContextId: string;
   documentId: string;
-  x: number;
-  y: number;
   onNewObject: () => void;
   onRenameDocument: () => void;
   onDownload: () => void;
   onDeleteDocument: () => void;
   onClose: () => void;
   readOnly: boolean;
+  menuAnchor: HTMLElement;
 }

--- a/frontend/src/tree/TreeItemObjectContextMenu.tsx
+++ b/frontend/src/tree/TreeItemObjectContextMenu.tsx
@@ -10,14 +10,25 @@
  * Contributors:
  *     Obeo - initial API and implementation
  *******************************************************************************/
-import { ContextMenu, Entry, LEFT_START, Separator } from 'core/contextmenu/ContextMenu';
-import { Delete, Edit } from 'icons';
+import { makeStyles } from '@material-ui/core';
+import ListItemIcon from '@material-ui/core/ListItemIcon';
+import ListItemText from '@material-ui/core/ListItemText';
+import Menu from '@material-ui/core/Menu';
+import MenuItem from '@material-ui/core/MenuItem';
+import AddIcon from '@material-ui/icons/Add';
+import DeleteIcon from '@material-ui/icons/Delete';
+import EditIcon from '@material-ui/icons/Edit';
 import React from 'react';
 import { TreeItemObjectContextMenuProps } from './TreeItemObjectContextMenu.types';
 
+const useTreeItemObjectContextMenuStyles = makeStyles((theme) => ({
+  item: {
+    paddingTop: theme.spacing(1),
+    paddingBottom: theme.spacing(1),
+  },
+}));
+
 export const TreeItemObjectContextMenu = ({
-  x,
-  y,
   onCreateNewObject,
   onCreateRepresentation,
   onRenameObject,
@@ -25,39 +36,59 @@ export const TreeItemObjectContextMenu = ({
   onDeleteObject,
   onClose,
   readOnly,
+  menuAnchor,
 }: TreeItemObjectContextMenuProps) => {
-  let renameEntry = null;
-  if (editable) {
-    renameEntry = (
-      <>
-        <Entry
-          icon={<Edit title="" />}
-          label="Rename"
-          onClick={onRenameObject}
-          data-testid="rename-object"
-          disabled={readOnly}></Entry>
-        <Separator />
-      </>
-    );
-  }
+  const classes = useTreeItemObjectContextMenuStyles();
+
   return (
-    <ContextMenu x={x} y={y} caretPosition={LEFT_START} onClose={onClose} data-testid="treeitemobject-contextmenu">
-      <Entry label="New object" onClick={onCreateNewObject} data-testid="new-object" disabled={readOnly} />
-      <Entry
-        label="New representation"
+    <Menu
+      id="treeitemobject-contextmenu"
+      anchorEl={menuAnchor}
+      keepMounted
+      open
+      onClose={onClose}
+      data-testid="treeitemobject-contextmenu"
+      getContentAnchorEl={null}
+      anchorOrigin={{
+        vertical: 'bottom',
+        horizontal: 'right',
+      }}>
+      <MenuItem onClick={onCreateNewObject} data-testid="new-object" disabled={readOnly} dense className={classes.item}>
+        <ListItemIcon>
+          <AddIcon fontSize="small" />
+        </ListItemIcon>
+        <ListItemText primary="New object" />
+      </MenuItem>
+      <MenuItem
+        divider
         onClick={onCreateRepresentation}
         data-testid="new-representation"
         disabled={readOnly}
-      />
-      <Separator />
-      {renameEntry}
-      <Entry
-        icon={<Delete title="" />}
-        label="Delete"
-        onClick={onDeleteObject}
-        data-testid="delete-object"
-        disabled={readOnly}
-      />
-    </ContextMenu>
+        dense
+        className={classes.item}>
+        <ListItemIcon>
+          <AddIcon fontSize="small" />
+        </ListItemIcon>
+        <ListItemText primary="New representation" />
+      </MenuItem>
+      <MenuItem
+        divider
+        onClick={onRenameObject}
+        data-testid="rename-object"
+        disabled={readOnly || !editable}
+        dense
+        className={classes.item}>
+        <ListItemIcon>
+          <EditIcon fontSize="small" />
+        </ListItemIcon>
+        <ListItemText primary="Rename" />
+      </MenuItem>
+      <MenuItem onClick={onDeleteObject} data-testid="delete-object" disabled={readOnly} dense className={classes.item}>
+        <ListItemIcon>
+          <DeleteIcon fontSize="small" />
+        </ListItemIcon>
+        <ListItemText primary="Delete" />
+      </MenuItem>
+    </Menu>
   );
 };

--- a/frontend/src/tree/TreeItemObjectContextMenu.types.ts
+++ b/frontend/src/tree/TreeItemObjectContextMenu.types.ts
@@ -12,8 +12,6 @@
  *******************************************************************************/
 
 export interface TreeItemObjectContextMenuProps {
-  x: number;
-  y: number;
   onCreateNewObject: () => void;
   onCreateRepresentation: () => void;
   editable?: boolean;
@@ -21,4 +19,5 @@ export interface TreeItemObjectContextMenuProps {
   onDeleteObject: () => void;
   onClose: () => void;
   readOnly: boolean;
+  menuAnchor: HTMLElement;
 }


### PR DESCRIPTION
### Type of this PR 

- [ ] Bug fix
- [x] New feature or improvement
- [ ] Documentation
- [ ] Cleanup
- [ ] Test
- [ ] Build/Releng

### Issue(s)

Bug: https://github.com/eclipse-sirius/sirius-components/issues/642

### What does this PR do?

This PR moves the Project Explorer Contextual Menus to Material UI.

Warning : [WIP] The "rename" actions on tree items contextual menus don't work anymore.
This has to be fixed before integration.

### Screenshot/screencast of this PR

<img width="303" alt="Capture d’écran 2021-07-19 à 18 42 39" src="https://user-images.githubusercontent.com/717752/126525375-4cb69468-2f19-4fe6-8384-0f594c0a13fb.png"> 

### How to test this PR?

- [ ] Frontend Unit tests
- [ ] Backend Unit tests
- [ ] Cypress : please specify
- [x] Manual Test : please specify

### Checklist

- [ ] I have read CONTRIBUTING carefully.
- [ ] I have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [ ] All my commits are signed-off (`-s`) with my mail address of my Eclipse Account.
- [ ] I have covered my changes by unit tests or integration tests or manual tests.
- [ ] All tests pass.
- [ ] I have updated the documentation accordingly
- [ ] New React components are availables in storybook
