### PR TITLE
Update README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -31,7 +31,7 @@ If you use WSL and encounter error messages like _"Maximum call stack size excee
 === GitHub Access Token
 
 The backend part of _Sirius Components_ depends on https://github.com/eclipse-sirius/sirius-emf-json[`sirius-emf-json`], which is published as Maven artifacts in _GitHub Packages_.
-To build `sirius-components` locally, you need a _GitHub Access Token_ so that Maven can download the `sirius-emf-json` artifacts.
+To build `sirius-components` locally, you need a _GitHub Access Token_ so that Maven can download the `sirius-emf-json` and `Flow-Designer` artifacts.
 
 . Create a personal token with a scope of `read:package` by following https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token[the GitHub documentation] if you do not have one already.
 +
@@ -50,12 +50,18 @@ WARNING: Once generated, a token cannot be displayed anymore, so make sure to co
       <username>$GITHUB_USERNAME</username>
       <password>$GITHUB_ACCESS_TOKEN</password>
     </server>
+    <server>
+      <id>github-flow</id>
+      <username>$GITHUB_USERNAME</username>
+      <password>$GITHUB_ACCESS_TOKEN</password>
+    </server>
+  </servers>
 </settings>
 ----
 +
 Be sure to replace `$GITHUB_USERNAME` with your GitHub user id, and `$GITHUB_ACCESS_TOKEN` with the value of your acess token.
 +
-IMPORTANT: The `id` used in your `settings.xml` *must* be `github-sirius-emfjson` to match what is used in the POMs.
+IMPORTANT: The `id` used in your `settings.xml` *must* be `github-sirius-emfjson` and `github-flow` to match what is used in the POMs.
 
 === Build steps
 


### PR DESCRIPTION
### Type of this PR 

- [ ] Bug fix
- [ ] New feature or improvement
- [x] Documentation
- [ ] Cleanup
- [ ] Test
- [ ] Build/Releng

### Issue(s)

The readme file misses an access token declaration for the Flow-Designer artifact. 
This repository is necessary since it is declared in the sirius-web-emf artifact.

### What does this PR do?

This PR corrects the readme file.

### How to test this PR?

- [ ] Frontend Unit tests
- [ ] Backend Unit tests
- [ ] Cypress : please specify
- [x] Manual Test : Replace the content of .m2/settings.xml file by the new content specified in the readme file and build the backend components.

### Checklist

- [x] I have read CONTRIBUTING carefully.
- [x] I have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All my commits are signed-off (`-s`) with my mail address of my Eclipse Account.
- [ ] I have covered my changes by unit tests or integration tests or manual tests.
- [x] All tests pass.
- [x] I have updated the documentation accordingly
- [ ] New React components are availables in storybook
