### PR TITLE
[559] Add data attributes in SelectionDialogWebSocketContainer

### DIFF
--- a/frontend/src/selection/SelectionDialogWebSocketContainer.tsx
+++ b/frontend/src/selection/SelectionDialogWebSocketContainer.tsx
@@ -139,17 +139,24 @@ export const SelectionDialogWebSocketContainer = ({
 
   return (
     <>
-      <Dialog open onClose={onClose} aria-labelledby="dialog-title" maxWidth="xs" fullWidth>
+      <Dialog
+        open
+        onClose={onClose}
+        aria-labelledby="dialog-title"
+        maxWidth="xs"
+        fullWidth
+        data-testid="selection-dialog">
         <DialogTitle id="selection-dialog-title">Selection Dialog</DialogTitle>
         <DialogContent>
-          <DialogContentText>{selection?.message}</DialogContentText>
+          <DialogContentText data-testid="selection-dialog-message">{selection?.message}</DialogContentText>
           <List className={classes.root}>
             {selection?.objects.map((selectionObject) => (
               <ListItem
                 button
                 key={`item-${selectionObject.id}`}
                 selected={selectedObjectId === selectionObject.id}
-                onClick={() => handleListItemClick(selectionObject.id)}>
+                onClick={() => handleListItemClick(selectionObject.id)}
+                data-testid={selectionObject.label}>
                 <ListItemIcon>
                   {selectionObject.iconURL ? (
                     <img

--- a/frontend/src/workbench/RepresentationNavigation.tsx
+++ b/frontend/src/workbench/RepresentationNavigation.tsx
@@ -91,6 +91,7 @@ export const RepresentationNavigation = ({
             key={representation.id}
             data-testid={`representation-tab-${representation.label}`}
             data-testselected={representation.id === displayedRepresentation.id}
+            data-representationid={representation.id}
           />
         );
       })}


### PR DESCRIPTION
### Type of this PR 

- [ ] Bug fix
- [x] New feature or improvement
- [ ] Documentation
- [ ] Cleanup
- [ ] Test
- [ ] Build/Releng

### Issue(s)

Bug: https://github.com/eclipse-sirius/sirius-components/issues/559

### What does this PR do?

Add data-testid attributes in SelectionDialogWebSocketContainer to be able to test it with Cypress

### How to test this PR?

- [ ] Frontend Unit tests
- [ ] Backend Unit tests
- [x] Cypress
- [ ] Manual Test : please specify

### Checklist

- [x] I have read CONTRIBUTING carefully.
- [x] I have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All my commits are signed-off (`-s`) with my mail address of my Eclipse Account.
- [x] I have covered my changes by unit tests or integration tests or manual tests.
- [x] All tests pass.
- [ ] I have updated the documentation accordingly
- [ ] New React components are availables in storybook
