### PR TITLE
[677] Add new representation default name

### DIFF
--- a/frontend/src/modals/new-representation/NewRepresentationModal.tsx
+++ b/frontend/src/modals/new-representation/NewRepresentationModal.tsx
@@ -242,7 +242,7 @@ export const NewRepresentationModal = ({
               name="name"
               value={name}
               placeholder="Enter the name of the representation"
-              data-testid="name"
+              inputProps={{ 'data-testid': 'name' }}
               autoFocus={true}
               onChange={onNameChange}
               disabled={newRepresentationModal === 'loading' || newRepresentationModal === 'creatingRepresentation'}


### PR DESCRIPTION
### Type of this PR 

- [ ] Bug fix
- [x] New feature or improvement
- [ ] Documentation
- [ ] Cleanup
- [ ] Test
- [ ] Build/Releng

### Issue(s)

Bug: #677

### What does this PR do?

Updates  the name of the representation in the new representation dialog so that it matches the selected representation type, as long as the user doesn't modify the name field.

### How to test this PR?

- [ ] Frontend Unit tests
- [ ] Backend Unit tests
- [x] Cypress
- [ ] Manual Test : please specify

### Checklist

- [x] I have read CONTRIBUTING carefully.
- [x] I have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All my commits are signed-off (`-s`) with my mail address of my Eclipse Account.
- [x] I have covered my changes by unit tests or integration tests or manual tests.
- [x] All tests pass.
- [ ] I have updated the documentation accordingly
- [ ] New React components are available in storybook
