### PR TITLE
[enh] Add a validation rule on domain name

### DIFF
--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/services/EMFValidationService.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/services/EMFValidationService.java
@@ -69,6 +69,7 @@ public class EMFValidationService implements IValidationService {
             if (Diagnostic.OK != diagnostic.getSeverity()) {
                 // @formatter:off
                 return diagnostic.getChildren().stream()
+                        .filter(diag -> this.filterDiagnosticByObject(diag, object))
                         .filter(diag -> this.filterDiagnosticByFeature(diag, feature))
                         .collect(Collectors.toList());
                 // @formatter:on
@@ -76,6 +77,16 @@ public class EMFValidationService implements IValidationService {
         }
 
         return List.of();
+    }
+
+    private boolean filterDiagnosticByObject(Diagnostic diagnostic, Object object) {
+        if (diagnostic.getData() != null && !diagnostic.getData().isEmpty() && object != null) {
+            // @formatter:off
+            return diagnostic.getData().stream()
+                    .anyMatch(object::equals);
+            // @formatter:on
+        }
+        return false;
     }
 
     private boolean filterDiagnosticByFeature(Diagnostic diagnostic, Object feature) {


### PR DESCRIPTION
### Type of this PR 

- [x] Bug fix
- [x] New feature or improvement
- [ ] Documentation
- [ ] Cleanup
- [ ] Test
- [ ] Build/Releng

### What does this PR do?

- This rule will return an error if two entities have the same name. The
case is ignored.
- Prevents all named attributes in Domain to have a validation error when
only one named attribute had one validation error.

### Screenshot/screencast of this PR

![image](https://user-images.githubusercontent.com/7371042/128357805-b05147c4-ba0a-496f-8772-ca6115620201.png)
