### PR TITLE
[fix] Fix the create document dialog

### DIFF
--- a/frontend/src/modals/new-document/NewDocumentModal.tsx
+++ b/frontend/src/modals/new-document/NewDocumentModal.tsx
@@ -66,8 +66,12 @@ const getStereotypeDescriptionsQuery = gql`
     viewer {
       editingContext(editingContextId: $editingContextId) {
         stereotypeDescriptions {
-          id
-          label
+          edges {
+            node {
+              id
+              label
+            }
+          }
         }
       }
     }

--- a/frontend/src/modals/new-document/NewDocumentModal.types.ts
+++ b/frontend/src/modals/new-document/NewDocumentModal.types.ts
@@ -34,7 +34,15 @@ export interface GQLViewer {
 }
 
 export interface GQLEditingContext {
-  stereotypeDescriptions: GQLStereotypeDescription[];
+  stereotypeDescriptions: GQLStereotypeDescriptionConnection;
+}
+
+export interface GQLStereotypeDescriptionConnection {
+  edges: GQLStereotypeDescriptionEdge[];
+}
+
+export interface GQLStereotypeDescriptionEdge {
+  node: GQLStereotypeDescription;
 }
 
 export interface GQLStereotypeDescription {

--- a/frontend/src/modals/new-document/NewDocumentModalMachine.ts
+++ b/frontend/src/modals/new-document/NewDocumentModalMachine.ts
@@ -46,7 +46,7 @@ export interface NewDocumentModalContext {
   name: string;
   nameMessage: string;
   nameIsInvalid: boolean;
-  selectedStereotypeDescriptionId: string | null;
+  selectedStereotypeDescriptionId: string;
   stereotypeDescriptions: StereotypeDescription[];
   message: string | null;
 }
@@ -85,7 +85,7 @@ export const newDocumentModalMachine = Machine<
       name: '',
       nameMessage: 'The name cannot be empty',
       nameIsInvalid: false,
-      selectedStereotypeDescriptionId: null,
+      selectedStereotypeDescriptionId: '',
       stereotypeDescriptions: [],
       message: null,
     },
@@ -203,8 +203,12 @@ export const newDocumentModalMachine = Machine<
     actions: {
       updateStereotypeDescriptions: assign((_, event) => {
         const { data } = event as FetchedStereotypeDescriptionsEvent;
-        const { stereotypeDescriptions } = data.viewer.editingContext;
-        const selectedStereotypeDescriptionId = stereotypeDescriptions.length > 0 ? stereotypeDescriptions[0].id : null;
+        const { stereotypeDescriptions: stereotypeDescriptionsConnections } = data.viewer.editingContext;
+        const selectedStereotypeDescriptionId =
+          stereotypeDescriptionsConnections.edges.length > 0
+            ? stereotypeDescriptionsConnections.edges[0].node.id
+            : null;
+        const stereotypeDescriptions = stereotypeDescriptionsConnections.edges.map((edge) => edge.node);
         return { stereotypeDescriptions, selectedStereotypeDescriptionId };
       }),
       updateName: assign((_, event) => {


### PR DESCRIPTION
### Type of this PR 

- [x] Bug fix
- [ ] New feature or improvement
- [ ] Documentation
- [ ] Cleanup
- [ ] Test
- [ ] Build/Releng

### What does this PR do?

This PR fixes the CreateDocumentModal which has not been updated when `StereotypeDescriptions` in the `EditingContext` have been paginated.
