### PR TITLE
[695] Add Link widget and Link representation

### DIFF
--- a/backend/sirius-web-api/src/main/java/org/eclipse/sirius/web/api/configuration/ILinksDescriptionRegistry.java
+++ b/backend/sirius-web-api/src/main/java/org/eclipse/sirius/web/api/configuration/ILinksDescriptionRegistry.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.api.configuration;
+
+import org.eclipse.sirius.web.annotations.PublicApi;
+import org.eclipse.sirius.web.forms.description.FormDescription;
+
+/**
+ * Interface of a registry of {@link FormDescription}s for Links.
+ *
+ * @author ldelaigue
+ */
+@PublicApi
+public interface ILinksDescriptionRegistry {
+    void add(FormDescription formDescription);
+}

--- a/backend/sirius-web-api/src/main/java/org/eclipse/sirius/web/api/configuration/ILinksDescriptionRegistryConfigurer.java
+++ b/backend/sirius-web-api/src/main/java/org/eclipse/sirius/web/api/configuration/ILinksDescriptionRegistryConfigurer.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.api.configuration;
+
+import org.eclipse.sirius.web.annotations.PublicApi;
+
+/**
+ * Interface to be implemented as a Spring configuration in order to configure the Links description registry.
+ *
+ * @author ldelaigue
+ */
+@PublicApi
+public interface ILinksDescriptionRegistryConfigurer {
+
+    void addLinksDescriptions(ILinksDescriptionRegistry registry);
+
+}

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/Link.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/Link.java
@@ -1,0 +1,106 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.forms;
+
+import java.text.MessageFormat;
+import java.util.List;
+import java.util.Objects;
+
+import org.eclipse.sirius.web.annotations.Immutable;
+import org.eclipse.sirius.web.annotations.graphql.GraphQLField;
+import org.eclipse.sirius.web.annotations.graphql.GraphQLNonNull;
+import org.eclipse.sirius.web.annotations.graphql.GraphQLObjectType;
+import org.eclipse.sirius.web.forms.validation.Diagnostic;
+
+/**
+ * The Link widget.
+ *
+ * @author ldelaigue
+ */
+@Immutable
+@GraphQLObjectType
+public final class Link extends AbstractWidget {
+    private String label;
+
+    private String url;
+
+    private Link() {
+        // Prevent instantiation
+    }
+
+    @GraphQLField
+    @GraphQLNonNull
+    public String getLabel() {
+        return this.label;
+    }
+
+    @GraphQLField
+    @GraphQLNonNull
+    public String getUrl() {
+        return this.url;
+    }
+
+    public static Builder newLink(String id) {
+        return new Builder(id);
+    }
+
+    @Override
+    public String toString() {
+        String pattern = "{0} '{'id: {1}, label: {2}, value: {3}'}'"; //$NON-NLS-1$
+        return MessageFormat.format(pattern, this.getClass().getSimpleName(), this.getId(), this.label, this.url);
+    }
+
+    /**
+     * The builder used to create the Link.
+     *
+     * @author ldelaigue
+     */
+    @SuppressWarnings("checkstyle:HiddenField")
+    public static final class Builder {
+        private final String id;
+
+        private String label;
+
+        private String url;
+
+        private List<Diagnostic> diagnostics;
+
+        private Builder(String id) {
+            this.id = Objects.requireNonNull(id);
+        }
+
+        public Builder label(String label) {
+            this.label = Objects.requireNonNull(label);
+            return this;
+        }
+
+        public Builder url(String value) {
+            this.url = Objects.requireNonNull(value);
+            return this;
+        }
+
+        public Builder diagnostics(List<Diagnostic> diagnostics) {
+            this.diagnostics = Objects.requireNonNull(diagnostics);
+            return this;
+        }
+
+        public Link build() {
+            Link link = new Link();
+            link.id = this.id;
+            link.label = Objects.requireNonNull(this.label);
+            link.url = Objects.requireNonNull(this.url);
+            link.diagnostics = Objects.requireNonNull(this.diagnostics);
+            return link;
+        }
+    }
+}

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/components/LinkComponent.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/components/LinkComponent.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 22021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.forms.components;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.eclipse.sirius.web.components.Element;
+import org.eclipse.sirius.web.components.IComponent;
+import org.eclipse.sirius.web.forms.description.LinkDescription;
+import org.eclipse.sirius.web.forms.elements.LinkElementProps;
+import org.eclipse.sirius.web.forms.validation.DiagnosticComponent;
+import org.eclipse.sirius.web.forms.validation.DiagnosticComponentProps;
+import org.eclipse.sirius.web.representations.VariableManager;
+
+/**
+ * The component used to render the Link.
+ *
+ * @author ldelaigue
+ */
+public class LinkComponent implements IComponent {
+
+    private final LinkComponentProps props;
+
+    public LinkComponent(LinkComponentProps props) {
+        this.props = Objects.requireNonNull(props);
+    }
+
+    @Override
+    public Element render() {
+        VariableManager variableManager = this.props.getVariableManager();
+        LinkDescription linkDescription = this.props.getLinkDescription();
+
+        String id = linkDescription.getIdProvider().apply(variableManager);
+        String label = linkDescription.getLabelProvider().apply(variableManager);
+        String url = linkDescription.getUrlProvider().apply(variableManager);
+        List<Element> children = List.of(new Element(DiagnosticComponent.class, new DiagnosticComponentProps(linkDescription, variableManager)));
+
+        // @formatter:off
+        LinkElementProps linkElementProps = LinkElementProps.newLinkElementProps(id)
+                .label(label)
+                .url(url)
+                .children(children)
+                .build();
+        return new Element(LinkElementProps.TYPE, linkElementProps);
+        // @formatter:on
+    }
+}

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/components/LinkComponentProps.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/components/LinkComponentProps.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.forms.components;
+
+import java.util.Objects;
+
+import org.eclipse.sirius.web.components.IProps;
+import org.eclipse.sirius.web.forms.description.LinkDescription;
+import org.eclipse.sirius.web.representations.VariableManager;
+
+/**
+ * The properties of the Link component.
+ *
+ * @author ldelaigue
+ */
+public class LinkComponentProps implements IProps {
+    private final VariableManager variableManager;
+
+    private final LinkDescription linkDescription;
+
+    public LinkComponentProps(VariableManager variableManager, LinkDescription linkDescription) {
+        this.variableManager = Objects.requireNonNull(variableManager);
+        this.linkDescription = Objects.requireNonNull(linkDescription);
+    }
+
+    public VariableManager getVariableManager() {
+        return this.variableManager;
+    }
+
+    public LinkDescription getLinkDescription() {
+        return this.linkDescription;
+    }
+}

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/components/WidgetComponent.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/components/WidgetComponent.java
@@ -18,6 +18,7 @@ import org.eclipse.sirius.web.components.Element;
 import org.eclipse.sirius.web.components.IComponent;
 import org.eclipse.sirius.web.forms.description.AbstractWidgetDescription;
 import org.eclipse.sirius.web.forms.description.CheckboxDescription;
+import org.eclipse.sirius.web.forms.description.LinkDescription;
 import org.eclipse.sirius.web.forms.description.ListDescription;
 import org.eclipse.sirius.web.forms.description.MultiSelectDescription;
 import org.eclipse.sirius.web.forms.description.RadioDescription;
@@ -70,6 +71,9 @@ public class WidgetComponent implements IComponent {
         } else if (widgetDescription instanceof ListDescription) {
             ListComponentProps listProps = new ListComponentProps(variableManager, (ListDescription) widgetDescription);
             element = new Element(ListComponent.class, listProps);
+        } else if (widgetDescription instanceof LinkDescription) {
+            LinkComponentProps linkProps = new LinkComponentProps(variableManager, (LinkDescription) widgetDescription);
+            element = new Element(LinkComponent.class, linkProps);
         } else {
             String pattern = "Unsupported widget description: {}"; //$NON-NLS-1$
             this.logger.warn(pattern, widgetDescription.getClass().getSimpleName());

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/description/LinkDescription.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/description/LinkDescription.java
@@ -1,0 +1,129 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.forms.description;
+
+import java.text.MessageFormat;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+
+import org.eclipse.sirius.web.annotations.Immutable;
+import org.eclipse.sirius.web.representations.VariableManager;
+
+/**
+ * The description of the Link widget.
+ *
+ * @author ldelaigue
+ */
+@Immutable
+public final class LinkDescription extends AbstractWidgetDescription {
+    private Function<VariableManager, String> idProvider;
+
+    private Function<VariableManager, String> labelProvider;
+
+    private Function<VariableManager, String> urlProvider;
+
+    private LinkDescription() {
+        // Prevent instantiation
+    }
+
+    public Function<VariableManager, String> getIdProvider() {
+        return this.idProvider;
+    }
+
+    public Function<VariableManager, String> getLabelProvider() {
+        return this.labelProvider;
+    }
+
+    public Function<VariableManager, String> getUrlProvider() {
+        return this.urlProvider;
+    }
+
+    public static Builder newLinkDescription(String id) {
+        return new Builder(id);
+    }
+
+    @Override
+    public String toString() {
+        String pattern = "{0} '{'id: {1}'}'"; //$NON-NLS-1$
+        return MessageFormat.format(pattern, this.getClass().getSimpleName(), this.getId());
+    }
+
+    /**
+     * Builder used to create the Link description.
+     *
+     * @author ldelaigue
+     */
+    @SuppressWarnings("checkstyle:HiddenField")
+    public static final class Builder {
+        private final String id;
+
+        private Function<VariableManager, String> idProvider;
+
+        private Function<VariableManager, String> labelProvider;
+
+        private Function<VariableManager, String> urlProvider;
+
+        private Function<VariableManager, List<Object>> diagnosticsProvider;
+
+        private Function<Object, String> kindProvider;
+
+        private Function<Object, String> messageProvider;
+
+        private Builder(String id) {
+            this.id = Objects.requireNonNull(id);
+        }
+
+        public Builder idProvider(Function<VariableManager, String> idProvider) {
+            this.idProvider = Objects.requireNonNull(idProvider);
+            return this;
+        }
+
+        public Builder labelProvider(Function<VariableManager, String> labelProvider) {
+            this.labelProvider = Objects.requireNonNull(labelProvider);
+            return this;
+        }
+
+        public Builder urlProvider(Function<VariableManager, String> valueProvider) {
+            this.urlProvider = Objects.requireNonNull(valueProvider);
+            return this;
+        }
+
+        public Builder diagnosticsProvider(Function<VariableManager, List<Object>> diagnosticsProvider) {
+            this.diagnosticsProvider = Objects.requireNonNull(diagnosticsProvider);
+            return this;
+        }
+
+        public Builder kindProvider(Function<Object, String> kindProvider) {
+            this.kindProvider = Objects.requireNonNull(kindProvider);
+            return this;
+        }
+
+        public Builder messageProvider(Function<Object, String> messageProvider) {
+            this.messageProvider = Objects.requireNonNull(messageProvider);
+            return this;
+        }
+
+        public LinkDescription build() {
+            LinkDescription linkDescription = new LinkDescription();
+            linkDescription.id = this.id;
+            linkDescription.idProvider = Objects.requireNonNull(this.idProvider);
+            linkDescription.labelProvider = Objects.requireNonNull(this.labelProvider);
+            linkDescription.urlProvider = Objects.requireNonNull(this.urlProvider);
+            linkDescription.diagnosticsProvider = Objects.requireNonNull(this.diagnosticsProvider);
+            linkDescription.kindProvider = Objects.requireNonNull(this.kindProvider);
+            linkDescription.messageProvider = Objects.requireNonNull(this.messageProvider);
+            return linkDescription;
+        }
+    }
+}

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/elements/LinkElementProps.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/elements/LinkElementProps.java
@@ -1,0 +1,114 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.forms.elements;
+
+import java.text.MessageFormat;
+import java.util.List;
+import java.util.Objects;
+
+import org.eclipse.sirius.web.annotations.Immutable;
+import org.eclipse.sirius.web.components.Element;
+import org.eclipse.sirius.web.components.IProps;
+
+/**
+ * The properties of the Link element.
+ *
+ * @author ldelaigue
+ */
+@Immutable
+public final class LinkElementProps implements IProps {
+    public static final String TYPE = "Link"; //$NON-NLS-1$
+
+    private String id;
+
+    private String label;
+
+    private String url;
+
+    private List<Element> children;
+
+    private LinkElementProps() {
+        // Prevent instantiation
+    }
+
+    public String getId() {
+        return this.id;
+    }
+
+    public String getLabel() {
+        return this.label;
+    }
+
+    public String getUrl() {
+        return this.url;
+    }
+
+    @Override
+    public List<Element> getChildren() {
+        return this.children;
+    }
+
+    public static Builder newLinkElementProps(String id) {
+        return new Builder(id);
+    }
+
+    @Override
+    public String toString() {
+        String pattern = "{0} '{'id: {1}, label: {2}, value: {3}'}'"; //$NON-NLS-1$
+        return MessageFormat.format(pattern, this.getClass().getSimpleName(), this.id, this.label, this.url);
+    }
+
+    /**
+     * The builder of the Link element props.
+     *
+     * @author ldelaigue
+     */
+    @SuppressWarnings("checkstyle:HiddenField")
+    public static final class Builder {
+        private final String id;
+
+        private String label;
+
+        private String url;
+
+        private List<Element> children;
+
+        private Builder(String id) {
+            this.id = Objects.requireNonNull(id);
+        }
+
+        public Builder label(String label) {
+            this.label = Objects.requireNonNull(label);
+            return this;
+        }
+
+        public Builder url(String value) {
+            this.url = Objects.requireNonNull(value);
+            return this;
+        }
+
+        public Builder children(List<Element> children) {
+            this.children = Objects.requireNonNull(children);
+            return this;
+        }
+
+        public LinkElementProps build() {
+            LinkElementProps textfieldElementProps = new LinkElementProps();
+            textfieldElementProps.id = this.id;
+            textfieldElementProps.label = Objects.requireNonNull(this.label);
+            textfieldElementProps.url = Objects.requireNonNull(this.url);
+            textfieldElementProps.children = Objects.requireNonNull(this.children);
+            return textfieldElementProps;
+        }
+    }
+}

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/renderer/FormComponentPropsValidator.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/renderer/FormComponentPropsValidator.java
@@ -24,6 +24,8 @@ import org.eclipse.sirius.web.forms.components.GroupComponent;
 import org.eclipse.sirius.web.forms.components.GroupComponentProps;
 import org.eclipse.sirius.web.forms.components.IfComponent;
 import org.eclipse.sirius.web.forms.components.IfComponentProps;
+import org.eclipse.sirius.web.forms.components.LinkComponent;
+import org.eclipse.sirius.web.forms.components.LinkComponentProps;
 import org.eclipse.sirius.web.forms.components.ListComponent;
 import org.eclipse.sirius.web.forms.components.ListComponentProps;
 import org.eclipse.sirius.web.forms.components.MultiSelectComponent;
@@ -68,6 +70,8 @@ public class FormComponentPropsValidator implements IComponentPropsValidator {
             checkValidProps = props instanceof WidgetComponentProps;
         } else if (CheckboxComponent.class.equals(componentType)) {
             checkValidProps = props instanceof CheckboxComponentProps;
+        } else if (LinkComponent.class.equals(componentType)) {
+            checkValidProps = props instanceof LinkComponentProps;
         } else if (ListComponent.class.equals(componentType)) {
             checkValidProps = props instanceof ListComponentProps;
         } else if (RadioComponent.class.equals(componentType)) {

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/renderer/FormElementFactory.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/renderer/FormElementFactory.java
@@ -30,6 +30,7 @@ import org.eclipse.sirius.web.forms.Textfield;
 import org.eclipse.sirius.web.forms.elements.CheckboxElementProps;
 import org.eclipse.sirius.web.forms.elements.FormElementProps;
 import org.eclipse.sirius.web.forms.elements.GroupElementProps;
+import org.eclipse.sirius.web.forms.elements.LinkElementProps;
 import org.eclipse.sirius.web.forms.elements.ListElementProps;
 import org.eclipse.sirius.web.forms.elements.MultiSelectElementProps;
 import org.eclipse.sirius.web.forms.elements.PageElementProps;
@@ -58,6 +59,8 @@ public class FormElementFactory implements IElementFactory {
             object = this.instantiateGroup((GroupElementProps) props, children);
         } else if (CheckboxElementProps.TYPE.equals(type) && props instanceof CheckboxElementProps) {
             object = this.instantiateCheckbox((CheckboxElementProps) props, children);
+        } else if (LinkElementProps.TYPE.equals(type) && props instanceof LinkElementProps) {
+            object = this.instantiateLink((LinkElementProps) props, children);
         } else if (ListElementProps.TYPE.equals(type) && props instanceof ListElementProps) {
             object = this.instantiateList((ListElementProps) props, children);
         } else if (RadioElementProps.TYPE.equals(type) && props instanceof RadioElementProps) {
@@ -128,6 +131,18 @@ public class FormElementFactory implements IElementFactory {
                 .label(props.getLabel())
                 .value(props.isValue())
                 .newValueHandler(props.getNewValueHandler())
+                .diagnostics(diagnostics)
+                .build();
+        // @formatter:on
+    }
+
+    private org.eclipse.sirius.web.forms.Link instantiateLink(LinkElementProps props, List<Object> children) {
+        List<Diagnostic> diagnostics = this.getDiagnosticsFromChildren(children);
+
+        // @formatter:off
+        return org.eclipse.sirius.web.forms.Link.newLink(props.getId())
+                .label(props.getLabel())
+                .url(props.getUrl())
                 .diagnostics(diagnostics)
                 .build();
         // @formatter:on

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/renderer/FormInstancePropsValidator.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/renderer/FormInstancePropsValidator.java
@@ -17,6 +17,7 @@ import org.eclipse.sirius.web.components.IProps;
 import org.eclipse.sirius.web.forms.elements.CheckboxElementProps;
 import org.eclipse.sirius.web.forms.elements.FormElementProps;
 import org.eclipse.sirius.web.forms.elements.GroupElementProps;
+import org.eclipse.sirius.web.forms.elements.LinkElementProps;
 import org.eclipse.sirius.web.forms.elements.ListElementProps;
 import org.eclipse.sirius.web.forms.elements.MultiSelectElementProps;
 import org.eclipse.sirius.web.forms.elements.PageElementProps;
@@ -45,6 +46,8 @@ public class FormInstancePropsValidator implements IInstancePropsValidator {
             checkValidProps = props instanceof GroupElementProps;
         } else if (CheckboxElementProps.TYPE.equals(type)) {
             checkValidProps = props instanceof CheckboxElementProps;
+        } else if (LinkElementProps.TYPE.equals(type)) {
+            checkValidProps = props instanceof LinkElementProps;
         } else if (ListElementProps.TYPE.equals(type)) {
             checkValidProps = props instanceof ListElementProps;
         } else if (RadioElementProps.TYPE.equals(type)) {

--- a/backend/sirius-web-spring-collaborative-forms/src/main/java/org/eclipse/sirius/web/spring/collaborative/forms/LinksEventProcessorFactory.java
+++ b/backend/sirius-web-spring-collaborative-forms/src/main/java/org/eclipse/sirius/web/spring/collaborative/forms/LinksEventProcessorFactory.java
@@ -1,0 +1,94 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.spring.collaborative.forms;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.eclipse.sirius.web.core.api.IEditingContext;
+import org.eclipse.sirius.web.core.api.IObjectService;
+import org.eclipse.sirius.web.forms.description.FormDescription;
+import org.eclipse.sirius.web.spring.collaborative.api.IRepresentationConfiguration;
+import org.eclipse.sirius.web.spring.collaborative.api.IRepresentationEventProcessor;
+import org.eclipse.sirius.web.spring.collaborative.api.IRepresentationEventProcessorFactory;
+import org.eclipse.sirius.web.spring.collaborative.api.ISubscriptionManagerFactory;
+import org.eclipse.sirius.web.spring.collaborative.forms.api.IFormEventHandler;
+import org.eclipse.sirius.web.spring.collaborative.forms.api.IFormEventProcessor;
+import org.eclipse.sirius.web.spring.collaborative.forms.api.ILinksDescriptionService;
+import org.eclipse.sirius.web.spring.collaborative.forms.api.IWidgetSubscriptionManagerFactory;
+import org.eclipse.sirius.web.spring.collaborative.forms.api.LinksConfiguration;
+import org.springframework.stereotype.Service;
+
+/**
+ * Used to create the links event processors.
+ *
+ * @author ldelaigue
+ */
+@Service
+public class LinksEventProcessorFactory implements IRepresentationEventProcessorFactory {
+
+    private final ILinksDescriptionService linksDescriptionService;
+
+    private final IObjectService objectService;
+
+    private final List<IFormEventHandler> formEventHandlers;
+
+    private final ISubscriptionManagerFactory subscriptionManagerFactory;
+
+    private final IWidgetSubscriptionManagerFactory widgetSubscriptionManagerFactory;
+
+    public LinksEventProcessorFactory(ILinksDescriptionService linksDescriptionService, IObjectService objectService, List<IFormEventHandler> formEventHandlers,
+            ISubscriptionManagerFactory subscriptionManagerFactory, IWidgetSubscriptionManagerFactory widgetSubscriptionManagerFactory) {
+        this.linksDescriptionService = Objects.requireNonNull(linksDescriptionService);
+        this.objectService = Objects.requireNonNull(objectService);
+        this.formEventHandlers = Objects.requireNonNull(formEventHandlers);
+        this.subscriptionManagerFactory = Objects.requireNonNull(subscriptionManagerFactory);
+        this.widgetSubscriptionManagerFactory = Objects.requireNonNull(widgetSubscriptionManagerFactory);
+    }
+
+    @Override
+    public <T extends IRepresentationEventProcessor> boolean canHandle(Class<T> representationEventProcessorClass, IRepresentationConfiguration configuration) {
+        return IFormEventProcessor.class.isAssignableFrom(representationEventProcessorClass) && configuration instanceof LinksConfiguration;
+    }
+
+    @Override
+    public <T extends IRepresentationEventProcessor> Optional<T> createRepresentationEventProcessor(Class<T> representationEventProcessorClass, IRepresentationConfiguration configuration,
+            IEditingContext editingContext) {
+        if (this.canHandle(representationEventProcessorClass, configuration)) {
+            LinksConfiguration linksConfiguration = (LinksConfiguration) configuration;
+
+            List<FormDescription> formDescriptions = this.linksDescriptionService.getLinksDescriptions();
+            if (!formDescriptions.isEmpty()) {
+                Optional<Object> optionalObject = this.objectService.getObject(editingContext, linksConfiguration.getObjectId());
+                if (optionalObject.isPresent()) {
+                    Object object = optionalObject.get();
+                    Optional<FormDescription> optionalFormDescription = new FormDescriptionAggregator().aggregate(formDescriptions, object, this.objectService);
+                    if (optionalFormDescription.isPresent()) {
+                        FormDescription formDescription = optionalFormDescription.get();
+                        IRepresentationEventProcessor formEventProcessor = new FormEventProcessor(editingContext, formDescription, linksConfiguration.getId(), object, this.formEventHandlers,
+                                this.subscriptionManagerFactory.create(), this.widgetSubscriptionManagerFactory.create());
+
+                        // @formatter:off
+                        return Optional.of(formEventProcessor)
+                                .filter(representationEventProcessorClass::isInstance)
+                                .map(representationEventProcessorClass::cast);
+                        // @formatter:on
+                    }
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+}

--- a/backend/sirius-web-spring-collaborative-forms/src/main/java/org/eclipse/sirius/web/spring/collaborative/forms/api/ILinksDescriptionService.java
+++ b/backend/sirius-web-spring-collaborative-forms/src/main/java/org/eclipse/sirius/web/spring/collaborative/forms/api/ILinksDescriptionService.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.spring.collaborative.forms.api;
+
+import java.util.List;
+
+import org.eclipse.sirius.web.forms.description.FormDescription;
+
+/**
+ * This class gives access to all the links descriptions available.
+ *
+ * @author ldelaigue
+ */
+public interface ILinksDescriptionService {
+
+    List<FormDescription> getLinksDescriptions();
+
+}

--- a/backend/sirius-web-spring-collaborative-forms/src/main/java/org/eclipse/sirius/web/spring/collaborative/forms/api/LinksConfiguration.java
+++ b/backend/sirius-web-spring-collaborative-forms/src/main/java/org/eclipse/sirius/web/spring/collaborative/forms/api/LinksConfiguration.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.spring.collaborative.forms.api;
+
+import java.util.Objects;
+import java.util.UUID;
+
+import org.eclipse.sirius.web.spring.collaborative.api.IRepresentationConfiguration;
+
+/**
+ * The configuration used to create a links event processor.
+ *
+ * @author ldelaigue
+ */
+public class LinksConfiguration implements IRepresentationConfiguration {
+
+    private static final String LINKS_PREFIX = "links:"; //$NON-NLS-1$
+
+    private final UUID formId;
+
+    private final String objectId;
+
+    public LinksConfiguration(String objectId) {
+        this.objectId = Objects.requireNonNull(objectId);
+        this.formId = UUID.nameUUIDFromBytes((LINKS_PREFIX + objectId).getBytes());
+    }
+
+    @Override
+    public UUID getId() {
+        return this.formId;
+    }
+
+    public String getObjectId() {
+        return this.objectId;
+    }
+}

--- a/backend/sirius-web-spring-collaborative-forms/src/main/java/org/eclipse/sirius/web/spring/collaborative/forms/configuration/LinksDescriptionConfiguration.java
+++ b/backend/sirius-web-spring-collaborative-forms/src/main/java/org/eclipse/sirius/web/spring/collaborative/forms/configuration/LinksDescriptionConfiguration.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.spring.collaborative.forms.configuration;
+
+import java.util.List;
+
+import org.eclipse.sirius.web.api.configuration.ILinksDescriptionRegistryConfigurer;
+import org.eclipse.sirius.web.spring.collaborative.forms.services.LinksDescriptionRegistry;
+import org.eclipse.sirius.web.spring.collaborative.forms.services.LinksDescriptionService;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * The configuration used to provide the services related to the links descriptions.
+ *
+ * @author ldelaigue
+ */
+@Configuration
+public class LinksDescriptionConfiguration {
+
+    @Bean
+    public LinksDescriptionService linksDescriptionService(List<ILinksDescriptionRegistryConfigurer> linksConfigurers) {
+        LinksDescriptionRegistry registry = new LinksDescriptionRegistry();
+        linksConfigurers.forEach(configurer -> configurer.addLinksDescriptions(registry));
+        return new LinksDescriptionService(registry);
+    }
+}

--- a/backend/sirius-web-spring-collaborative-forms/src/main/java/org/eclipse/sirius/web/spring/collaborative/forms/dto/LinksEventInput.java
+++ b/backend/sirius-web-spring-collaborative-forms/src/main/java/org/eclipse/sirius/web/spring/collaborative/forms/dto/LinksEventInput.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.spring.collaborative.forms.dto;
+
+import java.text.MessageFormat;
+import java.util.UUID;
+
+import org.eclipse.sirius.web.annotations.graphql.GraphQLField;
+import org.eclipse.sirius.web.annotations.graphql.GraphQLID;
+import org.eclipse.sirius.web.annotations.graphql.GraphQLInputObjectType;
+import org.eclipse.sirius.web.annotations.graphql.GraphQLNonNull;
+import org.eclipse.sirius.web.core.api.IInput;
+
+/**
+ * The input of the links event subscription.
+ *
+ * @author ldelaigue
+ */
+@GraphQLInputObjectType
+public final class LinksEventInput implements IInput {
+    private UUID id;
+
+    private UUID editingContextId;
+
+    private String objectId;
+
+    @Override
+    @GraphQLID
+    @GraphQLField
+    @GraphQLNonNull
+    public UUID getId() {
+        return this.id;
+    }
+
+    @GraphQLID
+    @GraphQLField
+    @GraphQLNonNull
+    public UUID getEditingContextId() {
+        return this.editingContextId;
+    }
+
+    @GraphQLID
+    @GraphQLField
+    @GraphQLNonNull
+    public String getObjectId() {
+        return this.objectId;
+    }
+
+    @Override
+    public String toString() {
+        String pattern = "{0} '{'id: {1}, editingContextId: {2}, objectId: {3}'}'"; //$NON-NLS-1$
+        return MessageFormat.format(pattern, this.getClass().getSimpleName(), this.id, this.editingContextId, this.objectId);
+    }
+}

--- a/backend/sirius-web-spring-collaborative-forms/src/main/java/org/eclipse/sirius/web/spring/collaborative/forms/services/LinksDescriptionRegistry.java
+++ b/backend/sirius-web-spring-collaborative-forms/src/main/java/org/eclipse/sirius/web/spring/collaborative/forms/services/LinksDescriptionRegistry.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.spring.collaborative.forms.services;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.eclipse.sirius.web.api.configuration.ILinksDescriptionRegistry;
+import org.eclipse.sirius.web.forms.description.FormDescription;
+
+/**
+ * Registry containing all the links descriptions. It actually contains form descriptions, these forms should contain
+ * only Links, possibly grouped within groups if needed.
+ *
+ * @author ldelaigue
+ */
+public class LinksDescriptionRegistry implements ILinksDescriptionRegistry {
+
+    private final Map<UUID, FormDescription> id2FormDescriptions = Collections.synchronizedMap(new HashMap<>());
+
+    @Override
+    public void add(FormDescription formDescription) {
+        this.id2FormDescriptions.put(formDescription.getId(), formDescription);
+    }
+
+    /**
+     * Lookup a links FormDescription among the registered descriptions, by ID.
+     *
+     * @param id
+     *            The UUID of the desired provider
+     * @return An optional provider, containing the provider with the given ID, empty if such a provider is not
+     *         registered.
+     */
+    public Optional<FormDescription> getLinksDescriptionProvider(UUID id) {
+        return Optional.ofNullable(this.id2FormDescriptions.get(id));
+    }
+
+    /**
+     * Provides a list of the registered links FormDescriptions, that is independent of the registry (i.e. Changes to
+     * the returned list don't affect the registry).
+     *
+     * @return A list of the registered descriptions, never <code>null</code> but possibly empty.
+     */
+    public List<FormDescription> getLinksDescriptions() {
+        return this.id2FormDescriptions.values().stream().collect(Collectors.toList());
+    }
+
+}

--- a/backend/sirius-web-spring-collaborative-forms/src/main/java/org/eclipse/sirius/web/spring/collaborative/forms/services/LinksDescriptionService.java
+++ b/backend/sirius-web-spring-collaborative-forms/src/main/java/org/eclipse/sirius/web/spring/collaborative/forms/services/LinksDescriptionService.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.spring.collaborative.forms.services;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.eclipse.sirius.web.forms.description.FormDescription;
+import org.eclipse.sirius.web.spring.collaborative.forms.api.ILinksDescriptionService;
+
+/**
+ * Service used to query the links descriptions available.
+ *
+ * @author ldelaigue
+ */
+public class LinksDescriptionService implements ILinksDescriptionService {
+
+    private final LinksDescriptionRegistry registry;
+
+    public LinksDescriptionService(LinksDescriptionRegistry registry) {
+        this.registry = Objects.requireNonNull(registry);
+    }
+
+    @Override
+    public List<FormDescription> getLinksDescriptions() {
+        return this.registry.getLinksDescriptions();
+    }
+
+}

--- a/frontend/src/form/Form.types.ts
+++ b/frontend/src/form/Form.types.ts
@@ -100,3 +100,8 @@ export interface ListItem {
   label: string;
   imageURL: string;
 }
+
+export interface Link extends Widget {
+  label: string;
+  url: string;
+}

--- a/frontend/src/form/FormEventFragments.ts
+++ b/frontend/src/form/FormEventFragments.ts
@@ -97,6 +97,10 @@ export const formRefreshedEventPayloadFragment = gql`
                 imageURL
               }
             }
+            ... on Link {
+              label
+              url
+            }
           }
         }
       }

--- a/frontend/src/form/FormEventFragments.types.ts
+++ b/frontend/src/form/FormEventFragments.types.ts
@@ -26,6 +26,14 @@ export interface GQLPropertiesEventPayload {
   __typename: string;
 }
 
+export interface GQLLinksEventSubscription {
+  linksEvent: GQLLinksEventPayload;
+}
+
+export interface GQLLinksEventPayload {
+  __typename: string;
+}
+
 export interface GQLSubscribersUpdatedEventPayload extends GQLFormEventPayload, GQLPropertiesEventPayload {
   id: string;
   subscribers: GQLSubscriber[];

--- a/frontend/src/form/FormEventFragments.types.ts
+++ b/frontend/src/form/FormEventFragments.types.ts
@@ -130,3 +130,9 @@ export interface GQLListItem {
   label: string;
   imageURL: string;
 }
+
+export interface GQLLink {
+  id: string;
+  label: string;
+  url: string;
+}

--- a/frontend/src/properties/Group.tsx
+++ b/frontend/src/properties/Group.tsx
@@ -14,6 +14,7 @@ import { makeStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
 import {
   Checkbox,
+  Link,
   List,
   MultiSelect,
   Radio,
@@ -25,6 +26,7 @@ import {
 } from 'form/Form.types';
 import { GroupProps } from 'properties/Group.types';
 import { CheckboxPropertySection } from 'properties/propertysections/CheckboxPropertySection';
+import { LinkPropertySection } from 'properties/propertysections/LinkPropertySection';
 import { ListPropertySection } from 'properties/propertysections/ListPropertySection';
 import { MultiSelectPropertySection } from 'properties/propertysections/MultiSelectPropertySection';
 import { RadioPropertySection } from 'properties/propertysections/RadioPropertySection';
@@ -75,6 +77,7 @@ const isSelect = (widget: Widget): widget is Select => widget.__typename === 'Se
 const isMultiSelect = (widget: Widget): widget is MultiSelect => widget.__typename === 'MultiSelect';
 const isRadio = (widget: Widget): widget is Radio => widget.__typename === 'Radio';
 const isList = (widget: Widget): widget is List => widget.__typename === 'List';
+const isLink = (widget: Widget): widget is Link => widget.__typename === 'Link';
 
 const widgetToPropertySection = (
   editingContextId: string,
@@ -147,6 +150,16 @@ const widgetToPropertySection = (
   } else if (isList(widget)) {
     propertySection = (
       <ListPropertySection widget={widget} key={widget.id} subscribers={subscribers} readonly={readOnly} />
+    );
+  } else if (isLink(widget)) {
+    propertySection = (
+      <LinkPropertySection
+        editingContextId={editingContextId}
+        formId={formId}
+        widget={widget}
+        key={widget.id}
+        subscribers={subscribers}
+      />
     );
   } else {
     console.error(`Unsupported widget type ${widget.__typename}`);

--- a/frontend/src/properties/LinksWebSocketContainer.tsx
+++ b/frontend/src/properties/LinksWebSocketContainer.tsx
@@ -1,0 +1,167 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+import { useSubscription } from '@apollo/client';
+import IconButton from '@material-ui/core/IconButton';
+import Snackbar from '@material-ui/core/Snackbar';
+import makeStyles from '@material-ui/core/styles/makeStyles';
+import Typography from '@material-ui/core/Typography';
+import CloseIcon from '@material-ui/icons/Close';
+import { useMachine } from '@xstate/react';
+import {
+  formRefreshedEventPayloadFragment,
+  subscribersUpdatedEventPayloadFragment,
+  widgetSubscriptionsUpdatedEventPayloadFragment,
+} from 'form/FormEventFragments';
+import { GQLLinksEventSubscription } from 'form/FormEventFragments.types';
+import gql from 'graphql-tag';
+import {
+  HandleCompleteEvent,
+  HandleSubscriptionResultEvent,
+  HideToastEvent,
+  LinksWebSocketContainerContext,
+  LinksWebSocketContainerEvent,
+  linksWebSocketContainerMachine,
+  SchemaValue,
+  ShowToastEvent,
+  SwitchSelectionEvent,
+} from 'properties/LinksWebSocketContainerMachine';
+import { Properties } from 'properties/Properties';
+import React, { useContext, useEffect } from 'react';
+import { RepresentationContext } from 'workbench/RepresentationContext';
+import { LinksWebSocketContainerProps } from './LinksWebSocketContainer.types';
+
+const linksEventSubscription = gql`
+  subscription linksEvent($input: LinksEventInput!) {
+    linksEvent(input: $input) {
+      __typename
+      ... on SubscribersUpdatedEventPayload {
+        ...subscribersUpdatedEventPayloadFragment
+      }
+      ... on WidgetSubscriptionsUpdatedEventPayload {
+        ...widgetSubscriptionsUpdatedEventPayloadFragment
+      }
+      ... on FormRefreshedEventPayload {
+        ...formRefreshedEventPayloadFragment
+      }
+    }
+  }
+  ${subscribersUpdatedEventPayloadFragment}
+  ${widgetSubscriptionsUpdatedEventPayloadFragment}
+  ${formRefreshedEventPayloadFragment}
+`;
+
+const usePropertiesWebSocketContainerStyles = makeStyles((theme) => ({
+  idle: {
+    padding: theme.spacing(1),
+  },
+}));
+
+/**
+ * Connect the Properties component to the GraphQL API over Web Socket.
+ */
+export const LinksWebSocketContainer = ({ editingContextId, selection }: LinksWebSocketContainerProps) => {
+  const classes = usePropertiesWebSocketContainerStyles();
+  const [{ value, context }, dispatch] = useMachine<LinksWebSocketContainerContext, LinksWebSocketContainerEvent>(
+    linksWebSocketContainerMachine
+  );
+  const { toast, linksWebSocketContainer } = value as SchemaValue;
+  const { id, currentSelection, form, subscribers, widgetSubscriptions, message } = context;
+  const { registry } = useContext(RepresentationContext);
+
+  /**
+   * Displays an other form if the selection indicates that we should display another properties view.
+   */
+  useEffect(() => {
+    if (currentSelection?.id !== selection?.id) {
+      const isRepresentation = registry.isRepresentation(selection.kind);
+      const switchSelectionEvent: SwitchSelectionEvent = { type: 'SWITCH_SELECTION', selection, isRepresentation };
+      dispatch(switchSelectionEvent);
+    }
+  }, [currentSelection, registry, selection, dispatch]);
+
+  const { error } = useSubscription<GQLLinksEventSubscription>(linksEventSubscription, {
+    variables: {
+      input: {
+        id,
+        editingContextId,
+        objectId: currentSelection?.id,
+      },
+    },
+    fetchPolicy: 'no-cache',
+    skip: linksWebSocketContainer === 'empty' || linksWebSocketContainer === 'unsupportedSelection',
+    onSubscriptionData: ({ subscriptionData }) => {
+      const handleDataEvent: HandleSubscriptionResultEvent = {
+        type: 'HANDLE_SUBSCRIPTION_RESULT',
+        result: subscriptionData,
+      };
+      dispatch(handleDataEvent);
+    },
+    onSubscriptionComplete: () => {
+      const completeEvent: HandleCompleteEvent = { type: 'HANDLE_COMPLETE' };
+      dispatch(completeEvent);
+    },
+  });
+
+  useEffect(() => {
+    if (error) {
+      const { message } = error;
+      const showToastEvent: ShowToastEvent = { type: 'SHOW_TOAST', message };
+      dispatch(showToastEvent);
+    }
+  }, [error, dispatch]);
+
+  let content = null;
+  if (!selection || linksWebSocketContainer === 'unsupportedSelection') {
+    content = (
+      <div className={classes.idle}>
+        <Typography variant="subtitle2">No object selected</Typography>
+      </div>
+    );
+  }
+  if ((linksWebSocketContainer === 'idle' && form) || linksWebSocketContainer === 'ready') {
+    content = (
+      <Properties
+        editingContextId={editingContextId}
+        form={form}
+        subscribers={subscribers}
+        widgetSubscriptions={widgetSubscriptions}
+        readOnly={true}
+      />
+    );
+  }
+  return (
+    <>
+      {content}
+      <Snackbar
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'right',
+        }}
+        open={toast === 'visible'}
+        autoHideDuration={3000}
+        onClose={() => dispatch({ type: 'HIDE_TOAST' } as HideToastEvent)}
+        message={message}
+        action={
+          <IconButton
+            size="small"
+            aria-label="close"
+            color="inherit"
+            onClick={() => dispatch({ type: 'HIDE_TOAST' } as HideToastEvent)}>
+            <CloseIcon fontSize="small" />
+          </IconButton>
+        }
+        data-testid="error"
+      />
+    </>
+  );
+};

--- a/frontend/src/properties/LinksWebSocketContainer.types.ts
+++ b/frontend/src/properties/LinksWebSocketContainer.types.ts
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+import { Selection } from 'workbench/Workbench.types';
+
+export interface LinksWebSocketContainerProps {
+  editingContextId: string;
+  selection: Selection;
+}

--- a/frontend/src/properties/LinksWebSocketContainerMachine.ts
+++ b/frontend/src/properties/LinksWebSocketContainerMachine.ts
@@ -1,0 +1,266 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+import { SubscriptionResult } from '@apollo/client';
+import { Form, Subscriber, WidgetSubscription } from 'form/Form.types';
+import {
+  GQLFormRefreshedEventPayload,
+  GQLLinksEventPayload,
+  GQLLinksEventSubscription,
+  GQLSubscribersUpdatedEventPayload,
+  GQLWidgetSubscriptionsUpdatedEventPayload,
+} from 'form/FormEventFragments.types';
+import { v4 as uuid } from 'uuid';
+import { Selection } from 'workbench/Workbench.types';
+import { assign, Machine } from 'xstate';
+
+export interface LinksWebSocketContainerStateSchema {
+  states: {
+    toast: {
+      states: {
+        visible: {};
+        hidden: {};
+      };
+    };
+    linksWebSocketContainer: {
+      states: {
+        empty: {};
+        unsupportedSelection: {};
+        idle: {};
+        ready: {};
+        complete: {};
+      };
+    };
+  };
+}
+
+export type SchemaValue = {
+  toast: 'visible' | 'hidden';
+  linksWebSocketContainer: 'empty' | 'unsupportedSelection' | 'idle' | 'ready' | 'complete';
+};
+
+export interface LinksWebSocketContainerContext {
+  id: string;
+  currentSelection: Selection | null;
+  form: Form | null;
+  subscribers: Subscriber[];
+  widgetSubscriptions: WidgetSubscription[];
+  message: string | null;
+}
+
+export type ShowToastEvent = { type: 'SHOW_TOAST'; message: string };
+export type HideToastEvent = { type: 'HIDE_TOAST' };
+export type SwitchSelectionEvent = { type: 'SWITCH_SELECTION'; selection: Selection; isRepresentation: boolean };
+export type HandleSubscriptionResultEvent = {
+  type: 'HANDLE_SUBSCRIPTION_RESULT';
+  result: SubscriptionResult<GQLLinksEventSubscription>;
+};
+export type HandleCompleteEvent = { type: 'HANDLE_COMPLETE' };
+export type LinksWebSocketContainerEvent =
+  | SwitchSelectionEvent
+  | HandleSubscriptionResultEvent
+  | HandleCompleteEvent
+  | ShowToastEvent
+  | HideToastEvent;
+
+const isFormRefreshedEventPayload = (payload: GQLLinksEventPayload): payload is GQLFormRefreshedEventPayload =>
+  payload.__typename === 'FormRefreshedEventPayload';
+const isSubscribersUpdatedEventPayload = (
+  payload: GQLLinksEventPayload
+): payload is GQLSubscribersUpdatedEventPayload => payload.__typename === 'SubscribersUpdatedEventPayload';
+const isWidgetSubscriptionsUpdatedEventPayload = (
+  payload: GQLLinksEventPayload
+): payload is GQLWidgetSubscriptionsUpdatedEventPayload =>
+  payload.__typename == 'WidgetSubscriptionsUpdatedEventPayload';
+
+export const linksWebSocketContainerMachine = Machine<
+  LinksWebSocketContainerContext,
+  LinksWebSocketContainerStateSchema,
+  LinksWebSocketContainerEvent
+>(
+  {
+    type: 'parallel',
+    context: {
+      id: uuid(),
+      currentSelection: null,
+      form: null,
+      subscribers: [],
+      widgetSubscriptions: [],
+      message: null,
+    },
+    states: {
+      toast: {
+        initial: 'hidden',
+        states: {
+          hidden: {
+            on: {
+              SHOW_TOAST: {
+                target: 'visible',
+                actions: 'setMessage',
+              },
+            },
+          },
+          visible: {
+            on: {
+              HIDE_TOAST: {
+                target: 'hidden',
+                actions: 'clearMessage',
+              },
+            },
+          },
+        },
+      },
+      linksWebSocketContainer: {
+        initial: 'empty',
+        states: {
+          empty: {
+            on: {
+              SWITCH_SELECTION: [
+                {
+                  cond: 'isSelectionUnsupported',
+                  target: 'unsupportedSelection',
+                  actions: ['switchSelection', 'clearForm'],
+                },
+                {
+                  target: 'idle',
+                  actions: 'switchSelection',
+                },
+              ],
+            },
+          },
+          unsupportedSelection: {
+            on: {
+              SWITCH_SELECTION: [
+                {
+                  cond: 'isSelectionUnsupported',
+                  target: 'unsupportedSelection',
+                  actions: ['switchSelection', 'clearForm'],
+                },
+                {
+                  target: 'idle',
+                  actions: 'switchSelection',
+                },
+              ],
+            },
+          },
+          idle: {
+            on: {
+              SWITCH_SELECTION: [
+                {
+                  cond: 'isSelectionUnsupported',
+                  target: 'unsupportedSelection',
+                  actions: ['switchSelection', 'clearForm'],
+                },
+                {
+                  target: 'idle',
+                  actions: 'switchSelection',
+                },
+              ],
+              HANDLE_SUBSCRIPTION_RESULT: [
+                {
+                  cond: 'isFormRefreshedEventPayload',
+                  target: 'ready',
+                  actions: 'handleSubscriptionResult',
+                },
+                {
+                  target: 'idle',
+                  actions: 'handleSubscriptionResult',
+                },
+              ],
+            },
+          },
+          ready: {
+            on: {
+              SWITCH_SELECTION: [
+                {
+                  cond: 'isSelectionUnsupported',
+                  target: 'unsupportedSelection',
+                  actions: ['switchSelection', 'clearForm'],
+                },
+                {
+                  target: 'idle',
+                  actions: 'switchSelection',
+                },
+              ],
+              HANDLE_SUBSCRIPTION_RESULT: {
+                target: 'ready',
+                actions: 'handleSubscriptionResult',
+              },
+              HANDLE_COMPLETE: {
+                target: 'complete',
+              },
+            },
+          },
+          complete: {
+            on: {
+              SWITCH_SELECTION: [
+                {
+                  cond: 'isSelectionUnsupported',
+                  target: 'unsupportedSelection',
+                  actions: ['switchSelection', 'clearForm'],
+                },
+                {
+                  target: 'idle',
+                  actions: 'switchSelection',
+                },
+              ],
+            },
+          },
+        },
+      },
+    },
+  },
+  {
+    guards: {
+      isFormRefreshedEventPayload: (_, event) => {
+        const { result } = event as HandleSubscriptionResultEvent;
+        const { data } = result;
+        return isFormRefreshedEventPayload(data.linksEvent);
+      },
+      isSelectionUnsupported: (_, event) => {
+        const { selection, isRepresentation } = event as SwitchSelectionEvent;
+        return !selection || isRepresentation || selection.kind === 'Unknown' || selection.kind === 'Document';
+      },
+    },
+    actions: {
+      switchSelection: assign((_, event) => {
+        const { selection } = event as SwitchSelectionEvent;
+        return { id: uuid(), currentSelection: selection };
+      }),
+      clearForm: assign((_, event) => {
+        return { form: null };
+      }),
+      handleSubscriptionResult: assign((_, event) => {
+        const { result } = event as HandleSubscriptionResultEvent;
+        const { data } = result;
+        if (isFormRefreshedEventPayload(data.linksEvent)) {
+          const { form } = data.linksEvent;
+          return { form };
+        } else if (isSubscribersUpdatedEventPayload(data.linksEvent)) {
+          const { subscribers } = data.linksEvent;
+          return { subscribers };
+        } else if (isWidgetSubscriptionsUpdatedEventPayload(data.linksEvent)) {
+          const { widgetSubscriptions } = data.linksEvent;
+          return { widgetSubscriptions };
+        }
+        return {};
+      }),
+      setMessage: assign((_, event) => {
+        const { message } = event as ShowToastEvent;
+        return { message };
+      }),
+      clearMessage: assign((_) => {
+        return { message: null };
+      }),
+    },
+  }
+);

--- a/frontend/src/properties/propertysections/LinkPropertySection.tsx
+++ b/frontend/src/properties/propertysections/LinkPropertySection.tsx
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+import IconButton from '@material-ui/core/IconButton';
+import Link from '@material-ui/core/Link';
+import Snackbar from '@material-ui/core/Snackbar';
+import CloseIcon from '@material-ui/icons/Close';
+import { useMachine } from '@xstate/react';
+import { LinkPropertySectionProps } from 'properties/propertysections/LinkPropertySection.types';
+import {
+  LinkPropertySectionContext,
+  LinkPropertySectionEvent,
+  LinkPropertySectionMachine,
+  SchemaValue,
+} from 'properties/propertysections/LinkPropertySectionMachine';
+import React from 'react';
+
+/**
+ * Defines the content of a Link property section.
+ */
+export const LinkPropertySection = ({ editingContextId, formId, widget, subscribers }: LinkPropertySectionProps) => {
+  const [{ value: schemaValue, context }, dispatch] = useMachine<LinkPropertySectionContext, LinkPropertySectionEvent>(
+    LinkPropertySectionMachine
+  );
+  const { toast } = schemaValue as SchemaValue;
+  const { message } = context;
+
+  return (
+    <div>
+      <Link id={widget.id} href={widget.url} rel="no-referrer" target="_blank">
+        {widget.label}
+      </Link>
+      <Snackbar
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'right',
+        }}
+        open={toast === 'visible'}
+        autoHideDuration={3000}
+        onClose={() => dispatch({ type: 'HIDE_TOAST' })}
+        message={message}
+        action={
+          <IconButton size="small" aria-label="close" color="inherit" onClick={() => dispatch({ type: 'HIDE_TOAST' })}>
+            <CloseIcon fontSize="small" />
+          </IconButton>
+        }
+        data-testid="error"
+      />
+    </div>
+  );
+};

--- a/frontend/src/properties/propertysections/LinkPropertySection.types.ts
+++ b/frontend/src/properties/propertysections/LinkPropertySection.types.ts
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+import { Link, Subscriber } from 'form/Form.types';
+
+export interface LinkPropertySectionProps {
+  editingContextId: string;
+  formId: string;
+  widget: Link;
+  subscribers: Subscriber[];
+}

--- a/frontend/src/properties/propertysections/LinkPropertySectionMachine.ts
+++ b/frontend/src/properties/propertysections/LinkPropertySectionMachine.ts
@@ -1,0 +1,88 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+import { assign, Machine } from 'xstate';
+
+export interface LinkPropertySectionStateSchema {
+  states: {
+    toast: {
+      states: {
+        visible: {};
+        hidden: {};
+      };
+    };
+    LinkPropertySection: {};
+  };
+}
+
+export type SchemaValue = {
+  toast: 'visible' | 'hidden';
+};
+
+export interface LinkPropertySectionContext {
+  value: string;
+  message: string | null;
+}
+
+export type ShowToastEvent = { type: 'SHOW_TOAST'; message: string };
+export type HideToastEvent = { type: 'HIDE_TOAST' };
+
+export type LinkPropertySectionEvent = ShowToastEvent | HideToastEvent;
+
+export const LinkPropertySectionMachine = Machine<
+  LinkPropertySectionContext,
+  LinkPropertySectionStateSchema,
+  LinkPropertySectionEvent
+>(
+  {
+    type: 'parallel',
+    context: {
+      value: '',
+      message: null,
+    },
+    states: {
+      toast: {
+        initial: 'hidden',
+        states: {
+          hidden: {
+            on: {
+              SHOW_TOAST: {
+                target: 'visible',
+                actions: 'setMessage',
+              },
+            },
+          },
+          visible: {
+            on: {
+              HIDE_TOAST: {
+                target: 'hidden',
+                actions: 'clearMessage',
+              },
+            },
+          },
+        },
+      },
+      LinkPropertySection: {},
+    },
+  },
+  {
+    actions: {
+      setMessage: assign((_, event) => {
+        const { message } = event as ShowToastEvent;
+        return { message };
+      }),
+      clearMessage: assign((_) => {
+        return { message: null };
+      }),
+    },
+  }
+);

--- a/frontend/src/workbench/RightSite.tsx
+++ b/frontend/src/workbench/RightSite.tsx
@@ -16,6 +16,8 @@ import AccordionDetails from '@material-ui/core/AccordionDetails';
 import MuiAccordionSummary from '@material-ui/core/AccordionSummary';
 import MuiCollapse from '@material-ui/core/Collapse';
 import { makeStyles, withStyles } from '@material-ui/core/styles';
+import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import { LinksWebSocketContainer } from 'properties/LinksWebSocketContainer';
 import { PropertiesWebSocketContainer } from 'properties/PropertiesWebSocketContainer';
 import React from 'react';
 import { RightSiteProps } from './RightSite.types';
@@ -76,12 +78,29 @@ const CustomCollapse = withStyles({
 export const RightSite = ({ editingContextId, selection, readOnly }: RightSiteProps) => {
   const classes = useSiteStyles();
 
+  const [propertiesExpanded, setPropertiesExpanded] = React.useState<boolean>(true);
+  const [externalLinksExpanded, setExternalLinksExpanded] = React.useState<boolean>(true);
+
   return (
     <div className={classes.site}>
-      <Accordion square expanded={true} TransitionComponent={CustomCollapse as any}>
-        <AccordionSummary>Details</AccordionSummary>
+      <Accordion
+        square
+        expanded={propertiesExpanded}
+        onChange={(event, isExpanded) => setPropertiesExpanded(isExpanded)}
+        TransitionComponent={CustomCollapse as any}>
+        <AccordionSummary expandIcon={<ExpandMoreIcon />}>Details</AccordionSummary>
         <AccordionDetails className={classes.accordionDetailsRoot} data-testid={'Details AccordionDetails'}>
           <PropertiesWebSocketContainer editingContextId={editingContextId} selection={selection} readOnly={readOnly} />
+        </AccordionDetails>
+      </Accordion>
+      <Accordion
+        square
+        expanded={externalLinksExpanded}
+        onChange={(event, isExpanded) => setExternalLinksExpanded(isExpanded)}
+        TransitionComponent={CustomCollapse as any}>
+        <AccordionSummary expandIcon={<ExpandMoreIcon />}>External Links</AccordionSummary>
+        <AccordionDetails className={classes.accordionDetailsRoot} data-testid={'External Links AccordionDetails'}>
+          <LinksWebSocketContainer editingContextId={editingContextId} selection={selection} />
         </AccordionDetails>
       </Accordion>
     </div>


### PR DESCRIPTION
### Type of this PR 

- [ ] Bug fix
- [x] New feature or improvement
- [ ] Documentation
- [ ] Cleanup
- [ ] Test
- [ ] Build/Releng

### Issue(s)

#695
#696

### What does this PR do?

* Add a Link widget to be able to display hyperlinks as widgets in properties views.
* Add a Links Representation to be able to describe a representation dedicated to links.

### Screenshot/screencast of this PR

...
 

### Potential side effects

- Automated tests may be impacted in cypress because of the reuse of the Properties component, that has a hard-coded 'data-testid'. I'll change that in a future commit when cypress is reactivated.

### How to test this PR?

- [ ] Frontend Unit tests
- [ ] Backend Unit tests
- [ ] Cypress : please specify
  - Cypress is in progress, but I need some PRs to me merged first because currently utilities to delete & create projects & documents don't work.
- [ ] Manual Test : please specify

### Checklist

- [x] I have read CONTRIBUTING carefully.
- [x] I have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All my commits are signed-off (`-s`) with my mail address of my Eclipse Account.
- [x] I have covered my changes by unit tests or integration tests or manual tests.
   - Manual tests only, cypress in progress
- [x] All tests pass.
- [x] I have updated the documentation accordingly (ADR 030)
