### PR TITLE
[fix] Fix erroneous error status when unsetting a mono-valued reference

### DIFF
--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/properties/MonoValuedNonContainmentReferenceIfDescriptionProvider.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/properties/MonoValuedNonContainmentReferenceIfDescriptionProvider.java
@@ -102,12 +102,18 @@ public class MonoValuedNonContainmentReferenceIfDescriptionProvider {
             var optionalEReference = variableManager.get(PropertiesDefaultDescriptionProvider.ESTRUCTURAL_FEATURE, EReference.class);
             var optionalEditingContext = variableManager.get(IEditingContext.EDITING_CONTEXT, IEditingContext.class);
 
+            Status result = Status.ERROR;
             if (optionalEObject.isPresent() && optionalEReference.isPresent()) {
                 EObject eObject = optionalEObject.get();
                 EReference eReference = optionalEReference.get();
 
                 if (newValue == null || newValue.isBlank()) {
-                    eObject.eUnset(eReference);
+                    try {
+                        eObject.eUnset(eReference);
+                        result = Status.OK;
+                    } catch (IllegalArgumentException | ClassCastException | ArrayStoreException exception) {
+                        this.logger.warn(exception.getMessage(), exception);
+                    }
                 } else {
                     // @formatter:off
                     var optionalNewValueToSet = optionalEditingContext.flatMap(context -> this.objectService.getObject(context, newValue))
@@ -118,14 +124,14 @@ public class MonoValuedNonContainmentReferenceIfDescriptionProvider {
                         EObject newValueToSet = optionalNewValueToSet.get();
                         try {
                             eObject.eSet(eReference, newValueToSet);
-                            return Status.OK;
+                            result = Status.OK;
                         } catch (IllegalArgumentException | ClassCastException | ArrayStoreException exception) {
                             this.logger.warn(exception.getMessage(), exception);
                         }
                     }
                 }
             }
-            return Status.ERROR;
+            return result;
         };
     }
 


### PR DESCRIPTION
Signed-off-by: Pierre-Charles David <pierre-charles.david@obeo.fr>

### Type of this PR 

- [ ] Bug fix
- [ ] New feature or improvement
- [ ] Documentation
- [ ] Cleanup
- [ ] Test
- [ ] Build/Releng

### Issue(s)

...

### What does this PR do?

...

### Screenshot/screencast of this PR

...
 

### Potential side effects

...

### How to test this PR?

- [ ] Frontend Unit tests
- [ ] Backend Unit tests
- [ ] Cypress : please specify
- [ ] Manual Test : please specify

### Checklist

- [ ] I have read CONTRIBUTING carefully.
- [ ] I have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [ ] All my commits are signed-off (`-s`) with my mail address of my Eclipse Account.
- [ ] I have covered my changes by unit tests or integration tests or manual tests.
- [ ] All tests pass.
- [ ] I have updated the documentation accordingly
- [ ] New React components are availables in storybook
