### PR TITLE
[cleanup] Remove the principal from the GraphQL context

### DIFF
--- a/backend/sirius-web-spring-graphql-api/src/main/java/org/eclipse/sirius/web/spring/graphql/api/GraphQLConstants.java
+++ b/backend/sirius-web-spring-graphql-api/src/main/java/org/eclipse/sirius/web/spring/graphql/api/GraphQLConstants.java
@@ -21,8 +21,6 @@ public final class GraphQLConstants {
 
     public static final String GRAPHQL_BASE_PATH = "/api/graphql"; //$NON-NLS-1$
 
-    public static final String PRINCIPAL = "principal"; //$NON-NLS-1$
-
     public static final String SUBSCRIPTION_ID = "userId"; //$NON-NLS-1$
 
     private GraphQLConstants() {

--- a/backend/sirius-web-spring-graphql/src/main/java/org/eclipse/sirius/web/spring/graphql/configuration/WebSocketConfiguration.java
+++ b/backend/sirius-web-spring-graphql/src/main/java/org/eclipse/sirius/web/spring/graphql/configuration/WebSocketConfiguration.java
@@ -50,7 +50,7 @@ public class WebSocketConfiguration implements WebSocketConfigurer {
 
     private final MeterRegistry meterRegistry;
 
-    public WebSocketConfiguration(@Value("${sirius.web.graphql.websocket.allowed.origins}") String[] allowedOrigins, GraphQL graphQL, ObjectMapper objectMapper, MeterRegistry meterRegistry) {
+    public WebSocketConfiguration(@Value("${sirius.web.graphql.websocket.allowed.origins:*}") String[] allowedOrigins, GraphQL graphQL, ObjectMapper objectMapper, MeterRegistry meterRegistry) {
         this.allowedOrigins = Objects.requireNonNull(allowedOrigins);
         this.graphQL = Objects.requireNonNull(graphQL);
         this.objectMapper = Objects.requireNonNull(objectMapper);

--- a/backend/sirius-web-spring-graphql/src/main/java/org/eclipse/sirius/web/spring/graphql/ws/handlers/StartMessageHandler.java
+++ b/backend/sirius-web-spring-graphql/src/main/java/org/eclipse/sirius/web/spring/graphql/ws/handlers/StartMessageHandler.java
@@ -22,7 +22,6 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
-import org.eclipse.sirius.web.spring.graphql.api.GraphQLConstants;
 import org.eclipse.sirius.web.spring.graphql.controllers.GraphQLPayload;
 import org.eclipse.sirius.web.spring.graphql.ws.SubscriptionEntry;
 import org.eclipse.sirius.web.spring.graphql.ws.dto.input.StartMessage;
@@ -37,7 +36,6 @@ import org.springframework.web.socket.WebSocketSession;
 import graphql.ExecutionInput;
 import graphql.ExecutionResult;
 import graphql.GraphQL;
-import graphql.GraphQLContext;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import reactor.core.Disposable;
@@ -85,15 +83,10 @@ public class StartMessageHandler implements IWebSocketMessageHandler {
         String operationName = graphQLPayload.getOperationName();
 
         // @formatter:off
-        GraphQLContext graphQLContext = GraphQLContext.newContext()
-                .of(GraphQLConstants.PRINCIPAL, this.session.getPrincipal())
-                .build();
-
         ExecutionInput executionInput = ExecutionInput.newExecutionInput()
                 .query(query)
                 .variables(variables)
                 .operationName(operationName)
-                .context(graphQLContext)
                 .build();
         // @formatter:on
 

--- a/backend/sirius-web-spring-graphql/src/test/java/org/eclipse/sirius/web/spring/graphql/controllers/GraphQLControllerTests.java
+++ b/backend/sirius-web-spring-graphql/src/test/java/org/eclipse/sirius/web/spring/graphql/controllers/GraphQLControllerTests.java
@@ -23,7 +23,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.web.multipart.MultipartFile;
 
 import graphql.GraphQL;
@@ -116,28 +115,28 @@ public class GraphQLControllerTests {
     @Test
     public void testInvalidOperation() {
         GraphQLController graphQLController = new GraphQLController(new ObjectMapper(), this.getGraphQL(), new SimpleMeterRegistry());
-        ResponseEntity<Map<String, Object>> responseEntity = graphQLController.uploadDocument(null, MAPPING, FILE, new UsernamePasswordAuthenticationToken(new Object(), new Object()));
+        ResponseEntity<Map<String, Object>> responseEntity = graphQLController.uploadDocument(null, MAPPING, FILE);
         assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
     }
 
     @Test
     public void testInvalidMapping() {
         GraphQLController graphQLController = new GraphQLController(new ObjectMapper(), this.getGraphQL(), new SimpleMeterRegistry());
-        ResponseEntity<Map<String, Object>> responseEntity = graphQLController.uploadDocument(QUERY, null, FILE, new UsernamePasswordAuthenticationToken(new Object(), new Object()));
+        ResponseEntity<Map<String, Object>> responseEntity = graphQLController.uploadDocument(QUERY, null, FILE);
         assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
     }
 
     @Test
     public void testInvalidMultipartFile() {
         GraphQLController graphQLController = new GraphQLController(new ObjectMapper(), this.getGraphQL(), new SimpleMeterRegistry());
-        ResponseEntity<Map<String, Object>> responseEntity = graphQLController.uploadDocument(QUERY, MAPPING, null, new UsernamePasswordAuthenticationToken(new Object(), new Object()));
+        ResponseEntity<Map<String, Object>> responseEntity = graphQLController.uploadDocument(QUERY, MAPPING, null);
         assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
     }
 
     @Test
     public void testValidUpload() {
         GraphQLController graphQLController = new GraphQLController(new ObjectMapper(), this.getGraphQL(), new SimpleMeterRegistry());
-        ResponseEntity<Map<String, Object>> responseEntity = graphQLController.uploadDocument(QUERY, MAPPING, FILE, new UsernamePasswordAuthenticationToken(new Object(), new Object()));
+        ResponseEntity<Map<String, Object>> responseEntity = graphQLController.uploadDocument(QUERY, MAPPING, FILE);
         assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.CREATED);
         assertThat(responseEntity.getBody().toString()).isEqualTo("{data={uploadDocument=DOCUMENT_CREATED}}"); //$NON-NLS-1$
     }


### PR DESCRIPTION
Those who which to secure the GraphQL endpoint should do so in their Spring
configuration and the principal can be retrieve using the SecurityContext
from Spring Security. No need to keep using the GraphQL context for that.

Signed-off-by: Stéphane Bégaudeau <stephane.begaudeau@obeo.fr>