### PR TITLE
Improve warnings for Java extension loading errors

### DIFF
--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/AQLInterpreterFactory.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/AQLInterpreterFactory.java
@@ -85,11 +85,18 @@ public class AQLInterpreterFactory implements IAQLInterpreterFactory {
         // @formatter:on
 
         for (String qualifiedName : qualifiedNames) {
+            if (qualifiedName.contains("::")) { //$NON-NLS-1$
+                this.logger.warn("Sirius Web does not support Acceleo-style :: references"); //$NON-NLS-1$
+                continue;
+            }
             try {
                 Class<?> aClass = Class.forName(qualifiedName);
                 classes.add(aClass);
             } catch (ClassNotFoundException exception) {
-                this.logger.warn(exception.getMessage(), exception);
+                this.logger.warn("Could not load class '{}'", qualifiedName); //$NON-NLS-1$
+            } catch (NoClassDefFoundError exception) {
+                this.logger.error("Could not load class '{}'; not all dependencies could be " //$NON-NLS-1$
+                        + "instantiated by the JVM: {}", qualifiedName, exception.getMessage()); //$NON-NLS-1$
             }
         }
 


### PR DESCRIPTION
### Type of this PR 

- [x] Bug fix
- [ ] New feature or improvement
- [ ] Documentation
- [x] Cleanup
- [ ] Test
- [ ] Build/Releng

### Issue(s)

...

### What does this PR do?

- Use a plain warning message when a class cannot be loaded instead of a stacktrace.
- Do not try to load a class when the extension uses ::-style reference (@pcdavid told me that there is no plan to support such references in SiriusW)
- Handle `NoClassDefFoundError`. In case extension classes reference Eclipse platform classes and crash
the startup process.


### Screenshot/screencast of this PR

...
 

### Potential side effects

...


### How to test this PR?

- [ ] Frontend Unit tests
- [ ] Backend Unit tests
- [ ] Cypress : please specify
- [x] Manual Test : log messages don't need automated tests?

### Checklist

- [x] I have read CONTRIBUTING carefully.
- [x] I have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All my commits are signed-off (`-s`) with my mail address of my Eclipse Account.
- [ ] I have covered my changes by unit tests or integration tests or manual tests.
- [x] All tests pass.
- [ ] I have updated the documentation accordingly
- [ ] New React components are availables in storybook
