### PR TITLE
[729] Improve ResourceSet creation to be a IEditingDomainProvider

### DIFF
--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/services/EditService.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/services/EditService.java
@@ -35,7 +35,6 @@ import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecore.impl.EPackageRegistryImpl;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.ResourceSet;
-import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.emf.edit.command.AddCommand;
 import org.eclipse.emf.edit.command.CommandParameter;
@@ -109,9 +108,9 @@ public class EditService implements IEditService {
 
         EPackage.Registry ePackageRegistry = this.getPackageRegistry(editingContextId);
 
-        ResourceSet resourceSet = new ResourceSetImpl();
+        AdapterFactoryEditingDomain editingDomain = new AdapterFactoryEditingDomain(this.composedAdapterFactory, new BasicCommandStack());
+        ResourceSet resourceSet = editingDomain.getResourceSet();
         resourceSet.setPackageRegistry(ePackageRegistry);
-        AdapterFactoryEditingDomain editingDomain = new AdapterFactoryEditingDomain(this.composedAdapterFactory, new BasicCommandStack(), resourceSet);
         Resource resource = new JsonResourceImpl(URI.createURI("inmemory"), Map.of()); //$NON-NLS-1$
         resourceSet.getResources().add(resource);
 

--- a/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/services/EditingDomainFactory.java
+++ b/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/services/EditingDomainFactory.java
@@ -18,7 +18,6 @@ import org.eclipse.emf.ecore.EcorePackage;
 import org.eclipse.emf.ecore.impl.EPackageRegistryImpl;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.ResourceSet;
-import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
 import org.eclipse.emf.ecore.util.ECrossReferenceAdapter;
 import org.eclipse.emf.ecore.util.EcoreAdapterFactory;
 import org.eclipse.emf.edit.domain.AdapterFactoryEditingDomain;
@@ -39,14 +38,15 @@ public class EditingDomainFactory {
         EPackage.Registry ePackageRegistry = new EPackageRegistryImpl();
         ePackageRegistry.put(EcorePackage.eINSTANCE.getNsURI(), EcorePackage.eINSTANCE);
 
-        ResourceSet resourceSet = new ResourceSetImpl();
+        AdapterFactoryEditingDomain editingDomain = new AdapterFactoryEditingDomain(composedAdapterFactory, new BasicCommandStack());
+
+        ResourceSet resourceSet = editingDomain.getResourceSet();
         for (Resource resource : resources) {
             resourceSet.getResources().add(resource);
         }
         resourceSet.setPackageRegistry(ePackageRegistry);
         resourceSet.eAdapters().add(new ECrossReferenceAdapter());
 
-        AdapterFactoryEditingDomain editingDomain = new AdapterFactoryEditingDomain(composedAdapterFactory, new BasicCommandStack(), resourceSet);
         return editingDomain;
     }
 


### PR DESCRIPTION
Bug: https://github.com/eclipse-sirius/sirius-components/issues/729
Signed-off-by: Arthur Daussy <arthur.daussy@obeo.fr>

### Type of this PR 

- [ ] Bug fix
- [ ] New feature or improvement
- [ ] Documentation
- [ ] Cleanup
- [ ] Test
- [ ] Build/Releng

### Issue(s)

...

### What does this PR do?

...

### Screenshot/screencast of this PR

...
 

### Potential side effects

...

### How to test this PR?

- [ ] Frontend Unit tests
- [ ] Backend Unit tests
- [ ] Cypress : please specify
- [ ] Manual Test : please specify

### Checklist

- [ ] I have read CONTRIBUTING carefully.
- [ ] I have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [ ] All my commits are signed-off (`-s`) with my mail address of my Eclipse Account.
- [ ] I have covered my changes by unit tests or integration tests or manual tests.
- [ ] All tests pass.
- [ ] I have updated the documentation accordingly
- [ ] New React components are availables in storybook
