### PR TITLE
[735] Generic edge tool should not be added when a custom is provided

### DIFF
--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/view/ViewConverter.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/view/ViewConverter.java
@@ -290,18 +290,20 @@ public class ViewConverter {
                 nodeCreationTools.add(customTool);
             }
             // If there are no custom tools defined, add a canonical creation tool
-            // @formatter:off
-            CreateEdgeTool tool = CreateEdgeTool.newCreateEdgeTool(this.idProvider.apply(edgeDescription) + "_creationTool") //$NON-NLS-1$
-                    .label("New edge" + edgeDescription.getDomainType()) //$NON-NLS-1$
-                    .imageURL(EDGE_CREATION_TOOL_ICON)
-                    .edgeCandidates(List.of(EdgeCandidate.newEdgeCandidate()
-                            .sources(List.of(this.convert(edgeDescription.getSourceNodeDescription(), interpreter)))
-                            .targets(List.of(this.convert(edgeDescription.getTargetNodeDescription(), interpreter)))
-                            .build()))
-                    .handler(variableManager -> this.canonicalBehaviors.createNewEdge(variableManager, edgeDescription))
-                    .build();
-            // @formatter:on
-            edgeCreationTools.add(tool);
+            if (i == 0) {
+                // @formatter:off
+                CreateEdgeTool tool = CreateEdgeTool.newCreateEdgeTool(this.idProvider.apply(edgeDescription) + "_creationTool") //$NON-NLS-1$
+                        .label("New edge" + edgeDescription.getDomainType()) //$NON-NLS-1$
+                        .imageURL(EDGE_CREATION_TOOL_ICON)
+                        .edgeCandidates(List.of(EdgeCandidate.newEdgeCandidate()
+                                .sources(List.of(this.convert(edgeDescription.getSourceNodeDescription(), interpreter)))
+                                .targets(List.of(this.convert(edgeDescription.getTargetNodeDescription(), interpreter)))
+                                .build()))
+                        .handler(variableManager -> this.canonicalBehaviors.createNewEdge(variableManager, edgeDescription))
+                        .build();
+                // @formatter:on
+                edgeCreationTools.add(tool);
+            }
         }
 
         // @formatter:off


### PR DESCRIPTION
Signed-off-by: Arthur Daussy <arthur.daussy@obeo.fr>
Bug: https://github.com/eclipse-sirius/sirius-components/issues/735

### Type of this PR 

- [x] Bug fix
- [ ] New feature or improvement
- [ ] Documentation
- [ ] Cleanup
- [ ] Test
- [ ] Build/Releng

### Issue(s)

...

### What does this PR do?

...

### Screenshot/screencast of this PR

...
 

### Potential side effects

...

### How to test this PR?

- [ ] Frontend Unit tests
- [ ] Backend Unit tests
- [ ] Cypress : please specify
- [ ] Manual Test : please specify

### Checklist

- [x] I have read CONTRIBUTING carefully.
- [x] I have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All my commits are signed-off (`-s`) with my mail address of my Eclipse Account.
- [ ] I have covered my changes by unit tests or integration tests or manual tests.
- [ ] All tests pass.
- [ ] I have updated the documentation accordingly
- [ ] New React components are availables in storybook
