### PR TITLE
[747] Fix bounding box computation for images with wide labels

### DIFF
--- a/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/LayoutConfiguratorRegistry.java
+++ b/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/LayoutConfiguratorRegistry.java
@@ -100,7 +100,7 @@ public class LayoutConfiguratorRegistry {
                 .setProperty(CoreOptions.NODE_LABELS_PADDING, new ElkPadding(0d, 12d, 0d, 6d));
 
         configurator.configureByType(NodeType.NODE_IMAGE)
-                .setProperty(CoreOptions.NODE_SIZE_CONSTRAINTS, SizeConstraint.free())
+                .setProperty(CoreOptions.NODE_SIZE_CONSTRAINTS, EnumSet.of(SizeConstraint.MINIMUM_SIZE, SizeConstraint.PORT_LABELS, SizeConstraint.PORTS))
                 .setProperty(CoreOptions.NODE_LABELS_PLACEMENT, NodeLabelPlacement.outsideTopCenter());
 
         // This image type does not match any diagram item. We add it to define the image size as constraint for the node image parent.


### PR DESCRIPTION
Image nodes have their labels on the outside, so the label width should not be considered by ELK when computing the width of the node itself, or it could lead to bounding boxes larger than needed with ugly side effects.
