### PR TITLE
[746] Delay form event processor disposal to avoid lost events

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -47,6 +47,7 @@ Currently it is not possible to compute different values for width and height.
 - [view] Fix the canonical domain-based edge creation tool
 - https://github.com/eclipse-sirius/sirius-components/issues/377[#377] [workbench] Restore the real time feedback on representation renaming
 - https://github.com/eclipse-sirius/sirius-components/issues/868[#868] [diagram] Fix a layout issue with the label of the newly created edges
+- https://github.com/eclipse-sirius/sirius-components/issues/746[#746] [core] Keep representations in memory for 5 more seconds when they should be disposed in order to have the time to receive some input before their disposal
 
 
 == v2021.12.0

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -15,7 +15,7 @@
 
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-components</artifactId>
-	<version>2021.12.4</version>
+	<version>2021.12.5</version>
 
 	<name>sirius-components</name>
 	<description>Sirius Components</description>

--- a/backend/sirius-web-annotations-spring/pom.xml
+++ b/backend/sirius-web-annotations-spring/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-annotations-spring</artifactId>
-	<version>2021.12.4</version>
+	<version>2021.12.5</version>
 	<name>sirius-web-annotations-spring</name>
 	<description>Sirius Web Annotations Spring</description>
 

--- a/backend/sirius-web-annotations/pom.xml
+++ b/backend/sirius-web-annotations/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-annotations</artifactId>
-	<version>2021.12.4</version>
+	<version>2021.12.5</version>
 	<name>sirius-web-annotations</name>
 	<description>Sirius Web Annotations</description>
 

--- a/backend/sirius-web-api/pom.xml
+++ b/backend/sirius-web-api/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-api</artifactId>
-	<version>2021.12.4</version>
+	<version>2021.12.5</version>
 	<name>sirius-web-api</name>
 	<description>Sirius Web API</description>
 
@@ -47,17 +47,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-annotations</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-representations</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-forms</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 		<dependency>
 			<groupId>io.projectreactor</groupId>
@@ -66,7 +66,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend/sirius-web-compatibility/pom.xml
+++ b/backend/sirius-web-compatibility/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-compatibility</artifactId>
-	<version>2021.12.4</version>
+	<version>2021.12.5</version>
 	<name>sirius-web-compatibility</name>
 	<description>Sirius Web Compatibility</description>
 
@@ -72,7 +72,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -82,43 +82,43 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-tests</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-api</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-core-api</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-collaborative-diagrams</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-forms</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-selection</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-trees</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-interpreter</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.emf</groupId>

--- a/backend/sirius-web-components/pom.xml
+++ b/backend/sirius-web-components/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-components</artifactId>
-	<version>2021.12.4</version>
+	<version>2021.12.5</version>
 	<name>sirius-web-components</name>
 	<description>Sirius Web Components</description>
 
@@ -52,7 +52,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend/sirius-web-core-api/pom.xml
+++ b/backend/sirius-web-core-api/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-core-api</artifactId>
-	<version>2021.12.4</version>
+	<version>2021.12.5</version>
 	<name>sirius-web-core-api</name>
 	<description>Sirius Web Core API</description>
 
@@ -47,17 +47,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-annotations</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-representations</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend/sirius-web-diagrams-layout-api/pom.xml
+++ b/backend/sirius-web-diagrams-layout-api/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-diagrams-layout-api</artifactId>
-	<version>2021.12.4</version>
+	<version>2021.12.5</version>
 	<name>sirius-web-diagrams-layout-api</name>
 	<description>Sirius Web Diagrams Layout API</description>
 
@@ -42,12 +42,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-diagrams</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-core-api</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 	</dependencies>
 

--- a/backend/sirius-web-diagrams-layout/pom.xml
+++ b/backend/sirius-web-diagrams-layout/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-diagrams-layout</artifactId>
-	<version>2021.12.4</version>
+	<version>2021.12.5</version>
 	<name>sirius-web-diagrams-layout</name>
 	<description>Sirius Web Diagrams layout</description>
 
@@ -65,17 +65,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-annotations</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-core-api</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-diagrams-layout-api</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.elk</groupId>
@@ -112,7 +112,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -127,12 +127,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-diagrams</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-diagrams-tests</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/backend/sirius-web-diagrams-tests/pom.xml
+++ b/backend/sirius-web-diagrams-tests/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-diagrams-tests</artifactId>
-	<version>2021.12.4</version>
+	<version>2021.12.5</version>
 	<name>sirius-web-diagrams-tests</name>
 	<description>Sirius Web Diagrams Tests</description>
 
@@ -42,7 +42,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-diagrams</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.assertj</groupId>

--- a/backend/sirius-web-diagrams/pom.xml
+++ b/backend/sirius-web-diagrams/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-diagrams</artifactId>
-	<version>2021.12.4</version>
+	<version>2021.12.5</version>
 	<name>sirius-web-diagrams</name>
 	<description>Sirius Web Diagrams</description>
 
@@ -42,12 +42,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-components</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-representations</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -57,7 +57,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend/sirius-web-domain-design/pom.xml
+++ b/backend/sirius-web-domain-design/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-domain-design</artifactId>
-	<version>2021.12.4</version>
+	<version>2021.12.5</version>
 	<name>sirius-web-domain-design</name>
 	<description>Sirius Web Domain Definition DSL - Graphical Modeler Definition</description>
 
@@ -64,7 +64,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-domain</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 	</dependencies>
 	

--- a/backend/sirius-web-domain-edit/pom.xml
+++ b/backend/sirius-web-domain-edit/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-domain-edit</artifactId>
-	<version>2021.12.4</version>
+	<version>2021.12.5</version>
 	<name>sirius-web-domain-edit</name>
 	<description>Sirius Web Domain Definition DSL - Edit Support</description>
 
@@ -64,7 +64,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-domain</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 	</dependencies>
 	

--- a/backend/sirius-web-domain/pom.xml
+++ b/backend/sirius-web-domain/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-domain</artifactId>
-	<version>2021.12.4</version>
+	<version>2021.12.5</version>
 	<name>sirius-web-domain</name>
 	<description>Sirius Web Domain Definition DSL</description>
 

--- a/backend/sirius-web-emf/pom.xml
+++ b/backend/sirius-web-emf/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-emf</artifactId>
-	<version>2021.12.4</version>
+	<version>2021.12.5</version>
 	<name>sirius-web-emf</name>
 	<description>Sirius Web EMF</description>
 
@@ -66,52 +66,52 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-graphql-api</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-collaborative</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-collaborative-diagrams</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-collaborative-forms</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-collaborative-trees</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-collaborative-validation</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-compatibility</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-interpreter</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-domain</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-view</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.emf</groupId>
@@ -160,13 +160,13 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-tests</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend/sirius-web-forms-tests/pom.xml
+++ b/backend/sirius-web-forms-tests/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-forms-tests</artifactId>
-	<version>2021.12.4</version>
+	<version>2021.12.5</version>
 	<name>sirius-web-forms-tests</name>
 	<description>Sirius Web Forms Tests</description>
 
@@ -42,7 +42,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-forms</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.assertj</groupId>

--- a/backend/sirius-web-forms/pom.xml
+++ b/backend/sirius-web-forms/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-forms</artifactId>
-	<version>2021.12.4</version>
+	<version>2021.12.5</version>
 	<name>sirius-web-forms</name>
 	<description>Sirius Web Forms</description>
 
@@ -46,17 +46,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-annotations</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-components</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-representations</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -66,7 +66,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/backend/sirius-web-graphiql/pom.xml
+++ b/backend/sirius-web-graphiql/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-graphiql</artifactId>
-	<version>2021.12.4</version>
+	<version>2021.12.5</version>
 	<name>sirius-web-graphiql</name>
 	<description>Sirius Web Graphiql support. This project contribute a GraphQL query tool on the /graphiql/index.html URI.</description>
 

--- a/backend/sirius-web-graphql-utils/pom.xml
+++ b/backend/sirius-web-graphql-utils/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-graphql-utils</artifactId>
-	<version>2021.12.4</version>
+	<version>2021.12.5</version>
 	<name>sirius-web-graphql-utils</name>
 	<description>Sirius Web GraphQL Utils</description>
 
@@ -43,7 +43,7 @@
 		<dependency>
         	<groupId>org.eclipse.sirius.web</groupId>
         	<artifactId>sirius-web-annotations</artifactId>
-        	<version>2021.12.4</version>
+        	<version>2021.12.5</version>
     	</dependency>
 		<dependency>
         	<groupId>com.graphql-java</groupId>
@@ -53,7 +53,7 @@
     	<dependency>
    			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 			<scope>test</scope>
     	</dependency>
     	<dependency>

--- a/backend/sirius-web-graphql-voyager/pom.xml
+++ b/backend/sirius-web-graphql-voyager/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-graphql-voyager</artifactId>
-	<version>2021.12.4</version>
+	<version>2021.12.5</version>
 	<name>sirius-web-graphql-voyager</name>
 	<description>Sirius Web Graph Voyager. This project contribute a GraphQL API UX thanks to the https://github.com/APIs-guru/graphql-voyager project.</description>
 

--- a/backend/sirius-web-interpreter/pom.xml
+++ b/backend/sirius-web-interpreter/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-interpreter</artifactId>
-	<version>2021.12.4</version>
+	<version>2021.12.5</version>
 	<name>sirius-web-interpreter</name>
 	<description>Sirius Web Intepreter</description>
 

--- a/backend/sirius-web-representations/pom.xml
+++ b/backend/sirius-web-representations/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-representations</artifactId>
-	<version>2021.12.4</version>
+	<version>2021.12.5</version>
 	<name>sirius-web-representations</name>
 	<description>Sirius Web Representations</description>
 
@@ -42,7 +42,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-annotations</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 	</dependencies>
 

--- a/backend/sirius-web-selection/pom.xml
+++ b/backend/sirius-web-selection/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-selection</artifactId>
-	<version>2021.12.4</version>
+	<version>2021.12.5</version>
 	<name>sirius-web-selection</name>
 	<description>Sirius Web Selection</description>
 
@@ -42,17 +42,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-annotations</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-representations</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend/sirius-web-spring-collaborative-diagrams/pom.xml
+++ b/backend/sirius-web-spring-collaborative-diagrams/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-spring-collaborative-diagrams</artifactId>
-	<version>2021.12.4</version>
+	<version>2021.12.5</version>
 	<name>sirius-web-spring-collaborative-diagrams</name>
 	<description>Sirius Web Spring Collaborative Diagrams</description>
 
@@ -50,39 +50,39 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-api</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-diagrams</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-collaborative</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-diagrams-layout</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 		<dependency>
     		<groupId>org.eclipse.sirius.web</groupId>
     		<artifactId>sirius-web-tests</artifactId>
-    		<version>2021.12.4</version>
+    		<version>2021.12.5</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius.web</groupId>
     		<artifactId>sirius-web-spring-tests</artifactId>
-    		<version>2021.12.4</version>
+    		<version>2021.12.5</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-diagrams-tests</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/backend/sirius-web-spring-collaborative-forms/pom.xml
+++ b/backend/sirius-web-spring-collaborative-forms/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-spring-collaborative-forms</artifactId>
-	<version>2021.12.4</version>
+	<version>2021.12.5</version>
 	<name>sirius-web-spring-collaborative-forms</name>
 	<description>Sirius Web Spring Collaborative Forms</description>
 
@@ -50,28 +50,28 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-api</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-forms</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-collaborative</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 		<dependency>
     		<groupId>org.eclipse.sirius.web</groupId>
     		<artifactId>sirius-web-tests</artifactId>
-    		<version>2021.12.4</version>
+    		<version>2021.12.5</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius.web</groupId>
     		<artifactId>sirius-web-spring-tests</artifactId>
-    		<version>2021.12.4</version>
+    		<version>2021.12.5</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>

--- a/backend/sirius-web-spring-collaborative-selection/pom.xml
+++ b/backend/sirius-web-spring-collaborative-selection/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-spring-collaborative-selection</artifactId>
-	<version>2021.12.4</version>
+	<version>2021.12.5</version>
 	<name>sirius-web-spring-collaborative-selection</name>
 	<description>Sirius Web Spring Collaborative Selection</description>
 
@@ -43,7 +43,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-selection</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>
@@ -56,23 +56,23 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-api</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-collaborative</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-tests</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/backend/sirius-web-spring-collaborative-trees/pom.xml
+++ b/backend/sirius-web-spring-collaborative-trees/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-spring-collaborative-trees</artifactId>
-	<version>2021.12.4</version>
+	<version>2021.12.5</version>
 	<name>sirius-web-spring-collaborative-trees</name>
 	<description>Sirius Web Spring Collaborative Trees</description>
 
@@ -42,12 +42,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-collaborative</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-trees</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>
@@ -68,13 +68,13 @@
 		<dependency>
     		<groupId>org.eclipse.sirius.web</groupId>
     		<artifactId>sirius-web-tests</artifactId>
-    		<version>2021.12.4</version>
+    		<version>2021.12.5</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius.web</groupId>
     		<artifactId>sirius-web-spring-tests</artifactId>
-    		<version>2021.12.4</version>
+    		<version>2021.12.5</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>

--- a/backend/sirius-web-spring-collaborative-validation/pom.xml
+++ b/backend/sirius-web-spring-collaborative-validation/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-spring-collaborative-validation</artifactId>
-	<version>2021.12.4</version>
+	<version>2021.12.5</version>
 	<name>sirius-web-spring-collaborative-validation</name>
 	<description>Sirius Web Spring Collaborative Validation</description>
 	
@@ -46,17 +46,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-api</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-collaborative</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-validation</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -66,13 +66,13 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 			<scope>test</scope>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius.web</groupId>
     		<artifactId>sirius-web-spring-tests</artifactId>
-    		<version>2021.12.4</version>
+    		<version>2021.12.5</version>
     		<scope>test</scope>
     	</dependency>
 	</dependencies>

--- a/backend/sirius-web-spring-collaborative/pom.xml
+++ b/backend/sirius-web-spring-collaborative/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-spring-collaborative</artifactId>
-	<version>2021.12.4</version>
+	<version>2021.12.5</version>
 	<name>sirius-web-spring-collaborative</name>
 	<description>Sirius Web Spring Collaborative</description>
 
@@ -70,23 +70,23 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-core-api</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-representations</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 		<dependency>
     		<groupId>org.eclipse.sirius.web</groupId>
     		<artifactId>sirius-web-tests</artifactId>
-    		<version>2021.12.4</version>
+    		<version>2021.12.5</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius.web</groupId>
     		<artifactId>sirius-web-spring-tests</artifactId>
-    		<version>2021.12.4</version>
+    		<version>2021.12.5</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>

--- a/backend/sirius-web-spring-collaborative/src/main/java/org/eclipse/sirius/web/spring/collaborative/api/ISubscriptionManager.java
+++ b/backend/sirius-web-spring-collaborative/src/main/java/org/eclipse/sirius/web/spring/collaborative/api/ISubscriptionManager.java
@@ -28,6 +28,8 @@ public interface ISubscriptionManager {
 
     Flux<Boolean> canBeDisposed();
 
+    boolean isEmpty();
+
     void dispose();
 
     /**
@@ -45,6 +47,11 @@ public interface ISubscriptionManager {
         @Override
         public Flux<Boolean> canBeDisposed() {
             return Flux.empty();
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return true;
         }
 
         @Override

--- a/backend/sirius-web-spring-collaborative/src/main/java/org/eclipse/sirius/web/spring/collaborative/representations/SubscriptionManager.java
+++ b/backend/sirius-web-spring-collaborative/src/main/java/org/eclipse/sirius/web/spring/collaborative/representations/SubscriptionManager.java
@@ -65,6 +65,11 @@ public class SubscriptionManager implements ISubscriptionManager {
     }
 
     @Override
+    public boolean isEmpty() {
+        return this.subscriptionCount.get() > 0;
+    }
+
+    @Override
     public void dispose() {
         EmitResult emitResult = this.sink.tryEmitComplete();
         if (emitResult.isFailure()) {

--- a/backend/sirius-web-spring-graphql-api/pom.xml
+++ b/backend/sirius-web-spring-graphql-api/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-spring-graphql-api</artifactId>
-	<version>2021.12.4</version>
+	<version>2021.12.5</version>
 	<name>sirius-web-spring-graphql-api</name>
 	<description>Sirius Web Spring GraphQL API</description>
 
@@ -48,7 +48,7 @@
     	<dependency>
         	<groupId>org.eclipse.sirius.web</groupId>
         	<artifactId>sirius-web-annotations-spring</artifactId>
-        	<version>2021.12.4</version>
+        	<version>2021.12.5</version>
     	</dependency>
 	</dependencies>
 

--- a/backend/sirius-web-spring-graphql/pom.xml
+++ b/backend/sirius-web-spring-graphql/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-spring-graphql</artifactId>
-	<version>2021.12.4</version>
+	<version>2021.12.5</version>
 	<name>sirius-web-spring-graphql</name>
 	<description>Sirius Web Spring GraphQL</description>
 
@@ -68,28 +68,28 @@
     	<dependency>
     		<groupId>org.eclipse.sirius.web</groupId>
     		<artifactId>sirius-web-annotations</artifactId>
-    		<version>2021.12.4</version>
+    		<version>2021.12.5</version>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius.web</groupId>
     		<artifactId>sirius-web-graphql-utils</artifactId>
-    		<version>2021.12.4</version>
+    		<version>2021.12.5</version>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius.web</groupId>
     		<artifactId>sirius-web-spring-graphql-api</artifactId>
-    		<version>2021.12.4</version>
+    		<version>2021.12.5</version>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius.web</groupId>
     		<artifactId>sirius-web-tests</artifactId>
-    		<version>2021.12.4</version>
+    		<version>2021.12.5</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius.web</groupId>
     		<artifactId>sirius-web-spring-tests</artifactId>
-    		<version>2021.12.4</version>
+    		<version>2021.12.5</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>

--- a/backend/sirius-web-spring-starter/pom.xml
+++ b/backend/sirius-web-spring-starter/pom.xml
@@ -15,7 +15,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-spring-starter</artifactId>
-	<version>2021.12.4</version>
+	<version>2021.12.5</version>
 	<name>sirius-web-spring-starter</name>
 	<description>Sirius Web Spring Starter</description>
 
@@ -55,52 +55,52 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-graphql</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-diagrams-layout</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-collaborative</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-collaborative-diagrams</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-collaborative-forms</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-collaborative-selection</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-collaborative-trees</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-collaborative-validation</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-emf</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-compatibility</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 	</dependencies>
 

--- a/backend/sirius-web-spring-tests/pom.xml
+++ b/backend/sirius-web-spring-tests/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-spring-tests</artifactId>
-	<version>2021.12.4</version>
+	<version>2021.12.5</version>
 	<name>sirius-web-spring-tests</name>
 	<description>Sirius Web Spring Tests</description>
 
@@ -46,7 +46,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-annotations</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>

--- a/backend/sirius-web-tests/pom.xml
+++ b/backend/sirius-web-tests/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-tests</artifactId>
-	<version>2021.12.4</version>
+	<version>2021.12.5</version>
 	<name>sirius-web-tests</name>
 	<description>Sirius Web Tests</description>
 
@@ -51,7 +51,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-annotations</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 	</dependencies>
 

--- a/backend/sirius-web-trees/pom.xml
+++ b/backend/sirius-web-trees/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-trees</artifactId>
-	<version>2021.12.4</version>
+	<version>2021.12.5</version>
 	<name>sirius-web-trees</name>
 	<description>Sirius Web Trees</description>
 
@@ -42,17 +42,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-annotations</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-representations</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/backend/sirius-web-validation/pom.xml
+++ b/backend/sirius-web-validation/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-validation</artifactId>
-	<version>2021.12.4</version>
+	<version>2021.12.5</version>
 	<name>sirius-web-validation</name>
 	<description>Sirius Web Validation</description>
 	
@@ -47,17 +47,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-components</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-representations</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend/sirius-web-view-edit/pom.xml
+++ b/backend/sirius-web-view-edit/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-view-edit</artifactId>
-	<version>2021.12.4</version>
+	<version>2021.12.5</version>
 	<name>sirius-web-view-edit</name>
 	<description>Sirius Web View Definition DSL - Edit Support</description>
 
@@ -64,7 +64,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-view</artifactId>
-			<version>2021.12.4</version>
+			<version>2021.12.5</version>
 		</dependency>
 	</dependencies>
 	

--- a/backend/sirius-web-view/pom.xml
+++ b/backend/sirius-web-view/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-view</artifactId>
-	<version>2021.12.4</version>
+	<version>2021.12.5</version>
 	<name>sirius-web-view</name>
 	<description>Sirius Web View Definition DSL</description>
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@eclipse-sirius/sirius-components",
-  "version": "2021.12.4",
+  "version": "2021.12.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@eclipse-sirius/sirius-components",
-      "version": "2021.12.4",
+      "version": "2021.12.5",
       "license": "EPL-2.0",
       "dependencies": {
         "uuid": "8.3.2"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-sirius/sirius-components",
-  "version": "2021.12.4",
+  "version": "2021.12.5",
   "author": "Eclipse Sirius",
   "license": "EPL-2.0",
   "description": "Reusable components used to build the Sirius Web frontend",


### PR DESCRIPTION
Just a draft for now so that the existing workaround can be discussed.
* The delay is hard coded, and the choice of 5 seconds is arbitrary.
* The change only is only applied to Forms, but if we want to to apply more globally it should be move up into the stack.