### PR TITLE
Add the ability to provide a status error message

### DIFF
--- a/backend/sirius-web-compatibility/src/main/java/org/eclipse/sirius/web/compat/diagrams/ToolConverter.java
+++ b/backend/sirius-web-compatibility/src/main/java/org/eclipse/sirius/web/compat/diagrams/ToolConverter.java
@@ -24,7 +24,9 @@ import org.eclipse.sirius.viewpoint.description.tool.InitialOperation;
 import org.eclipse.sirius.web.compat.api.IModelOperationHandlerSwitchProvider;
 import org.eclipse.sirius.web.core.api.IEditService;
 import org.eclipse.sirius.web.interpreter.AQLInterpreter;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.Failure;
+import org.eclipse.sirius.web.representations.IStatus;
+import org.eclipse.sirius.web.representations.Success;
 import org.eclipse.sirius.web.representations.VariableManager;
 
 /**
@@ -46,7 +48,7 @@ public class ToolConverter {
         this.modelOperationHandlerSwitchProvider = Objects.requireNonNull(modelOperationHandlerSwitchProvider);
     }
 
-    public BiFunction<VariableManager, String, Status> createDirectEditToolHandler(DirectEditLabel labelEditDescription) {
+    public BiFunction<VariableManager, String, IStatus> createDirectEditToolHandler(DirectEditLabel labelEditDescription) {
         var optionalInitialOperation = Optional.ofNullable(labelEditDescription).map(DirectEditLabel::getInitialOperation);
         if (optionalInitialOperation.isPresent()) {
             InitialOperation initialOperation = optionalInitialOperation.get();
@@ -56,15 +58,15 @@ public class ToolConverter {
                 var modelOperationHandlerSwitch = this.modelOperationHandlerSwitchProvider.getModelOperationHandlerSwitch(this.interpreter);
                 return modelOperationHandlerSwitch.apply(initialOperation.getFirstModelOperations()).map(handler -> {
                     return handler.handle(variables);
-                }).orElse(Status.ERROR);
+                }).orElse(new Failure("")); //$NON-NLS-1$
             };
         } else {
             // If no direct edit tool is defined, nothing to do but consider this OK.
-            return (variableManager, newText) -> Status.OK;
+            return (variableManager, newText) -> new Success();
         }
     }
 
-    public Function<VariableManager, Status> createDeleteToolHandler(DeleteElementDescription deleteDescription) {
+    public Function<VariableManager, IStatus> createDeleteToolHandler(DeleteElementDescription deleteDescription) {
         var optionalInitialOperation = Optional.ofNullable(deleteDescription).map(DeleteElementDescription::getInitialOperation);
         if (optionalInitialOperation.isPresent()) {
             InitialOperation initialOperation = optionalInitialOperation.get();
@@ -76,13 +78,13 @@ public class ToolConverter {
                 var modelOperationHandlerSwitch = this.modelOperationHandlerSwitchProvider.getModelOperationHandlerSwitch(this.interpreter);
                 return modelOperationHandlerSwitch.apply(initialOperation.getFirstModelOperations()).map(handler -> {
                     return handler.handle(variables);
-                }).orElse(Status.ERROR);
+                }).orElse(new Failure("")); //$NON-NLS-1$
             };
         } else {
             // If no delete tool is defined, execute the default behavior: delete the underlying semantic element.
             return variableManager -> {
                 Optional.of(variableManager.getVariables().get(VariableManager.SELF)).ifPresent(this.editService::delete);
-                return Status.OK;
+                return new Success();
             };
         }
     }

--- a/backend/sirius-web-compatibility/src/main/java/org/eclipse/sirius/web/compat/forms/WidgetDescriptionConverter.java
+++ b/backend/sirius-web-compatibility/src/main/java/org/eclipse/sirius/web/compat/forms/WidgetDescriptionConverter.java
@@ -40,7 +40,8 @@ import org.eclipse.sirius.web.forms.description.SelectDescription;
 import org.eclipse.sirius.web.forms.description.TextareaDescription;
 import org.eclipse.sirius.web.forms.description.TextfieldDescription;
 import org.eclipse.sirius.web.interpreter.AQLInterpreter;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.Failure;
+import org.eclipse.sirius.web.representations.IStatus;
 import org.eclipse.sirius.web.representations.VariableManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -97,7 +98,7 @@ public class WidgetDescriptionConverter {
         String valueExpression = Optional.ofNullable(textDescription.getValueExpression()).orElse(""); //$NON-NLS-1$
         StringValueProvider valueProvider = new StringValueProvider(this.interpreter, valueExpression);
 
-        BiFunction<VariableManager, String, Status> newValueHandler = this.getNewValueHandler(textDescription.getInitialOperation());
+        BiFunction<VariableManager, String, IStatus> newValueHandler = this.getNewValueHandler(textDescription.getInitialOperation());
 
         // @formatter:off
         return TextfieldDescription.newTextfieldDescription(this.identifierProvider.getIdentifier(textDescription))
@@ -126,7 +127,7 @@ public class WidgetDescriptionConverter {
         String valueExpression = Optional.ofNullable(textAreaDescription.getValueExpression()).orElse(""); //$NON-NLS-1$
         StringValueProvider valueProvider = new StringValueProvider(this.interpreter, valueExpression);
 
-        BiFunction<VariableManager, String, Status> newValueHandler = this.getNewValueHandler(textAreaDescription.getInitialOperation());
+        BiFunction<VariableManager, String, IStatus> newValueHandler = this.getNewValueHandler(textAreaDescription.getInitialOperation());
 
         // @formatter:off
         return TextareaDescription.newTextareaDescription(this.identifierProvider.getIdentifier(textAreaDescription))
@@ -142,8 +143,8 @@ public class WidgetDescriptionConverter {
 
     }
 
-    private BiFunction<VariableManager, String, Status> getNewValueHandler(InitialOperation initialOperation) {
-        BiFunction<VariableManager, String, Status> newValueHandler = (variableManager, newValue) -> {
+    private BiFunction<VariableManager, String, IStatus> getNewValueHandler(InitialOperation initialOperation) {
+        BiFunction<VariableManager, String, IStatus> newValueHandler = (variableManager, newValue) -> {
             VariableManager childVariableManager = variableManager.createChild();
             childVariableManager.put(NEW_VALUE, newValue);
 
@@ -151,7 +152,7 @@ public class WidgetDescriptionConverter {
 
             var modelOperationHandlerSwitch = this.modelOperationHandlerSwitchProvider.getModelOperationHandlerSwitch(this.interpreter);
             Optional<IModelOperationHandler> optionalModelOperationHandler = modelOperationHandlerSwitch.apply(modelOperation);
-            return optionalModelOperationHandler.map(handler -> handler.handle(childVariableManager.getVariables())).orElse(Status.ERROR);
+            return optionalModelOperationHandler.map(handler -> handler.handle(childVariableManager.getVariables())).orElse(new Failure("")); //$NON-NLS-1$
         };
         return newValueHandler;
     }
@@ -180,7 +181,7 @@ public class WidgetDescriptionConverter {
         String candidateDisplayExpression = Optional.ofNullable(radioDescription.getCandidateDisplayExpression()).orElse(""); //$NON-NLS-1$
         StringValueProvider optionLabelProvider = new StringValueProvider(this.interpreter, candidateDisplayExpression);
 
-        BiFunction<VariableManager, String, Status> newValueHandler = (variableManager, newValue) -> {
+        BiFunction<VariableManager, String, IStatus> newValueHandler = (variableManager, newValue) -> {
             VariableManager childVariableManager = variableManager.createChild();
             var optionalEditingContext = variableManager.get(IEditingContext.EDITING_CONTEXT, IEditingContext.class);
 
@@ -198,7 +199,7 @@ public class WidgetDescriptionConverter {
             Optional<IModelOperationHandler> optionalModelOperationHandler = modelOperationHandlerSwitch.apply(modelOperation);
             return optionalModelOperationHandler.map(handler -> {
                 return handler.handle(childVariableManager.getVariables());
-            }).orElse(Status.ERROR);
+            }).orElse(new Failure("")); //$NON-NLS-1$
         };
 
         // @formatter:off
@@ -240,7 +241,7 @@ public class WidgetDescriptionConverter {
             return this.objectService.getId(candidate);
         };
 
-        BiFunction<VariableManager, String, Status> newValueHandler = (variableManager, newValue) -> {
+        BiFunction<VariableManager, String, IStatus> newValueHandler = (variableManager, newValue) -> {
             Map<String, Object> variables = variableManager.getVariables();
             variables.put(NEW_VALUE, newValue);
 
@@ -251,7 +252,7 @@ public class WidgetDescriptionConverter {
             Optional<IModelOperationHandler> optionalModelOperationHandler = modelOperationHandlerSwitch.apply(modelOperation);
             return optionalModelOperationHandler.map(handler -> {
                 return handler.handle(variables);
-            }).orElse(Status.ERROR);
+            }).orElse(new Failure("")); //$NON-NLS-1$
         };
 
         // @formatter:off
@@ -274,7 +275,7 @@ public class WidgetDescriptionConverter {
     private CheckboxDescription convertCheckbox(org.eclipse.sirius.properties.CheckboxDescription checkboxDescription) {
         StringValueProvider labelProvider = new StringValueProvider(this.interpreter, checkboxDescription.getLabelExpression());
 
-        BiFunction<VariableManager, Boolean, Status> newValueHandler = (variableManager, newValue) -> {
+        BiFunction<VariableManager, Boolean, IStatus> newValueHandler = (variableManager, newValue) -> {
             Map<String, Object> variables = variableManager.getVariables();
             variables.put(NEW_VALUE, newValue);
 
@@ -285,7 +286,7 @@ public class WidgetDescriptionConverter {
             Optional<IModelOperationHandler> optionalModelOperationHandler = modelOperationHandlerSwitch.apply(modelOperation);
             return optionalModelOperationHandler.map(handler -> {
                 return handler.handle(variables);
-            }).orElse(Status.ERROR);
+            }).orElse(new Failure("")); //$NON-NLS-1$
         };
 
         String valueExpression = Optional.ofNullable(checkboxDescription.getValueExpression()).orElse(""); //$NON-NLS-1$

--- a/backend/sirius-web-compatibility/src/main/java/org/eclipse/sirius/web/compat/services/diagrams/ToolProvider.java
+++ b/backend/sirius-web-compatibility/src/main/java/org/eclipse/sirius/web/compat/services/diagrams/ToolProvider.java
@@ -54,7 +54,9 @@ import org.eclipse.sirius.web.diagrams.tools.EdgeCandidate;
 import org.eclipse.sirius.web.diagrams.tools.ITool;
 import org.eclipse.sirius.web.diagrams.tools.ToolSection;
 import org.eclipse.sirius.web.interpreter.AQLInterpreter;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.Failure;
+import org.eclipse.sirius.web.representations.IStatus;
+import org.eclipse.sirius.web.representations.Success;
 import org.eclipse.sirius.web.representations.VariableManager;
 import org.springframework.stereotype.Service;
 
@@ -339,7 +341,7 @@ public class ToolProvider implements IToolProvider {
         // @formatter:on
     }
 
-    private Function<VariableManager, Status> createContainerCreationHandler(AQLInterpreter interpreter, ContainerCreationDescription toolDescription) {
+    private Function<VariableManager, IStatus> createContainerCreationHandler(AQLInterpreter interpreter, ContainerCreationDescription toolDescription) {
         if (toolDescription != null) {
             InitialNodeCreationOperation initialOperation = toolDescription.getInitialOperation();
             return variableManager -> {
@@ -353,14 +355,14 @@ public class ToolProvider implements IToolProvider {
                 var modelOperationHandlerSwitch = this.modelOperationHandlerSwitchProvider.getModelOperationHandlerSwitch(interpreter);
                 return modelOperationHandlerSwitch.apply(initialOperation.getFirstModelOperations()).map(handler -> {
                     return handler.handle(variables);
-                }).orElse(Status.ERROR);
+                }).orElse(new Failure("")); //$NON-NLS-1$
             };
         } else {
-            return variableManager -> Status.OK;
+            return variableManager -> new Success();
         }
     }
 
-    private Function<VariableManager, Status> createNodeCreationHandler(AQLInterpreter interpreter, NodeCreationDescription toolDescription) {
+    private Function<VariableManager, IStatus> createNodeCreationHandler(AQLInterpreter interpreter, NodeCreationDescription toolDescription) {
         if (toolDescription != null) {
             InitialNodeCreationOperation initialOperation = toolDescription.getInitialOperation();
             return variableManager -> {
@@ -374,14 +376,14 @@ public class ToolProvider implements IToolProvider {
                 var modelOperationHandlerSwitch = this.modelOperationHandlerSwitchProvider.getModelOperationHandlerSwitch(interpreter);
                 return modelOperationHandlerSwitch.apply(initialOperation.getFirstModelOperations()).map(handler -> {
                     return handler.handle(variables);
-                }).orElse(Status.ERROR);
+                }).orElse(new Failure("")); //$NON-NLS-1$
             };
         } else {
-            return variableManager -> Status.OK;
+            return variableManager -> new Success();
         }
     }
 
-    private Function<VariableManager, Status> createGenericToolHandler(AQLInterpreter interpreter, org.eclipse.sirius.viewpoint.description.tool.ToolDescription toolDescription) {
+    private Function<VariableManager, IStatus> createGenericToolHandler(AQLInterpreter interpreter, org.eclipse.sirius.viewpoint.description.tool.ToolDescription toolDescription) {
         if (toolDescription != null) {
             InitialOperation initialOperation = toolDescription.getInitialOperation();
             return variableManager -> {
@@ -391,14 +393,14 @@ public class ToolProvider implements IToolProvider {
                 var modelOperationHandlerSwitch = this.modelOperationHandlerSwitchProvider.getModelOperationHandlerSwitch(interpreter);
                 return modelOperationHandlerSwitch.apply(initialOperation.getFirstModelOperations()).map(handler -> {
                     return handler.handle(variables);
-                }).orElse(Status.ERROR);
+                }).orElse(new Failure("")); //$NON-NLS-1$
             };
         } else {
-            return variableManager -> Status.OK;
+            return variableManager -> new Success();
         }
     }
 
-    private Function<VariableManager, Status> createEdgeCreationHandler(AQLInterpreter interpreter, EdgeCreationDescription edgeCreationDescription) {
+    private Function<VariableManager, IStatus> createEdgeCreationHandler(AQLInterpreter interpreter, EdgeCreationDescription edgeCreationDescription) {
         if (edgeCreationDescription != null) {
             InitEdgeCreationOperation initialOperation = edgeCreationDescription.getInitialOperation();
             return variableManager -> {
@@ -410,10 +412,10 @@ public class ToolProvider implements IToolProvider {
                 var modelOperationHandlerSwitch = this.modelOperationHandlerSwitchProvider.getModelOperationHandlerSwitch(interpreter);
                 return modelOperationHandlerSwitch.apply(initialOperation.getFirstModelOperations()).map(handler -> {
                     return handler.handle(variables);
-                }).orElse(Status.ERROR);
+                }).orElse(new Failure("")); //$NON-NLS-1$
             };
         } else {
-            return variableManager -> Status.OK;
+            return variableManager -> new Success();
         }
     }
 

--- a/backend/sirius-web-diagrams-tests/src/main/java/org/eclipse/sirius/web/diagrams/tests/TestDiagramBuilder.java
+++ b/backend/sirius-web-diagrams-tests/src/main/java/org/eclipse/sirius/web/diagrams/tests/TestDiagramBuilder.java
@@ -29,7 +29,7 @@ import org.eclipse.sirius.web.diagrams.Position;
 import org.eclipse.sirius.web.diagrams.RectangularNodeStyle;
 import org.eclipse.sirius.web.diagrams.Size;
 import org.eclipse.sirius.web.diagrams.tools.CreateNodeTool;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.Success;
 
 /**
  * Utility class used to help build diagrams for unit tests.
@@ -139,7 +139,7 @@ public class TestDiagramBuilder {
         return CreateNodeTool.newCreateNodeTool(id)
                 .label(TOOL_LABEL)
                 .imageURL(TOOL_IMAGE_URL)
-                .handler(variableManager -> Status.OK)
+                .handler(variableManager -> new Success())
                 .targetDescriptions(List.of())
                 .build();
         // @formatter:on

--- a/backend/sirius-web-diagrams-tests/src/main/java/org/eclipse/sirius/web/diagrams/tests/TestDiagramDescriptionBuilder.java
+++ b/backend/sirius-web-diagrams-tests/src/main/java/org/eclipse/sirius/web/diagrams/tests/TestDiagramDescriptionBuilder.java
@@ -30,7 +30,7 @@ import org.eclipse.sirius.web.diagrams.description.LabelDescription;
 import org.eclipse.sirius.web.diagrams.description.LabelStyleDescription;
 import org.eclipse.sirius.web.diagrams.description.NodeDescription;
 import org.eclipse.sirius.web.diagrams.tools.ToolSection;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.Success;
 import org.eclipse.sirius.web.representations.VariableManager;
 
 /**
@@ -133,8 +133,8 @@ public class TestDiagramDescriptionBuilder {
                 .sizeProvider(variableManager -> Size.UNDEFINED)
                 .borderNodeDescriptions(new ArrayList<>())
                 .childNodeDescriptions(new ArrayList<>())
-                .labelEditHandler((variableManager, newLabel) -> Status.OK)
-                .deleteHandler(variableManager -> Status.OK)
+                .labelEditHandler((variableManager, newLabel) -> new Success())
+                .deleteHandler(variableManager -> new Success())
                 .build();
         // @formatter:on
     }

--- a/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/description/EdgeDescription.java
+++ b/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/description/EdgeDescription.java
@@ -21,7 +21,7 @@ import java.util.function.Function;
 import org.eclipse.sirius.web.annotations.Immutable;
 import org.eclipse.sirius.web.components.Element;
 import org.eclipse.sirius.web.diagrams.EdgeStyle;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.IStatus;
 import org.eclipse.sirius.web.representations.VariableManager;
 
 /**
@@ -69,7 +69,7 @@ public final class EdgeDescription {
 
     private Function<VariableManager, EdgeStyle> styleProvider;
 
-    private Function<VariableManager, Status> deleteHandler;
+    private Function<VariableManager, IStatus> deleteHandler;
 
     private EdgeDescription() {
         // Prevent instantiation
@@ -131,7 +131,7 @@ public final class EdgeDescription {
         return this.styleProvider;
     }
 
-    public Function<VariableManager, Status> getDeleteHandler() {
+    public Function<VariableManager, IStatus> getDeleteHandler() {
         return this.deleteHandler;
     }
 
@@ -180,7 +180,7 @@ public final class EdgeDescription {
 
         private Function<VariableManager, EdgeStyle> styleProvider;
 
-        private Function<VariableManager, Status> deleteHandler;
+        private Function<VariableManager, IStatus> deleteHandler;
 
         private Builder(UUID id) {
             this.id = Objects.requireNonNull(id);
@@ -252,7 +252,7 @@ public final class EdgeDescription {
             return this;
         }
 
-        public Builder deleteHandler(Function<VariableManager, Status> deleteHandler) {
+        public Builder deleteHandler(Function<VariableManager, IStatus> deleteHandler) {
             this.deleteHandler = Objects.requireNonNull(deleteHandler);
             return this;
         }

--- a/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/description/NodeDescription.java
+++ b/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/description/NodeDescription.java
@@ -27,7 +27,7 @@ import org.eclipse.sirius.web.annotations.graphql.GraphQLNonNull;
 import org.eclipse.sirius.web.annotations.graphql.GraphQLObjectType;
 import org.eclipse.sirius.web.diagrams.INodeStyle;
 import org.eclipse.sirius.web.diagrams.Size;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.IStatus;
 import org.eclipse.sirius.web.representations.VariableManager;
 
 /**
@@ -62,9 +62,9 @@ public final class NodeDescription {
 
     private List<NodeDescription> childNodeDescriptions = new ArrayList<>();
 
-    private BiFunction<VariableManager, String, Status> labelEditHandler;
+    private BiFunction<VariableManager, String, IStatus> labelEditHandler;
 
-    private Function<VariableManager, Status> deleteHandler;
+    private Function<VariableManager, IStatus> deleteHandler;
 
     private NodeDescription() {
         // Prevent instantiation
@@ -121,11 +121,11 @@ public final class NodeDescription {
         return this.childNodeDescriptions;
     }
 
-    public Function<VariableManager, Status> getDeleteHandler() {
+    public Function<VariableManager, IStatus> getDeleteHandler() {
         return this.deleteHandler;
     }
 
-    public BiFunction<VariableManager, String, Status> getLabelEditHandler() {
+    public BiFunction<VariableManager, String, IStatus> getLabelEditHandler() {
         return this.labelEditHandler;
     }
 
@@ -170,9 +170,9 @@ public final class NodeDescription {
 
         private List<NodeDescription> childNodeDescriptions;
 
-        private BiFunction<VariableManager, String, Status> labelEditHandler;
+        private BiFunction<VariableManager, String, IStatus> labelEditHandler;
 
-        private Function<VariableManager, Status> deleteHandler;
+        private Function<VariableManager, IStatus> deleteHandler;
 
         public Builder(UUID id) {
             this.id = Objects.requireNonNull(id);
@@ -233,12 +233,12 @@ public final class NodeDescription {
             return this;
         }
 
-        public Builder deleteHandler(Function<VariableManager, Status> deleteHandler) {
+        public Builder deleteHandler(Function<VariableManager, IStatus> deleteHandler) {
             this.deleteHandler = Objects.requireNonNull(deleteHandler);
             return this;
         }
 
-        public Builder labelEditHandler(BiFunction<VariableManager, String, Status> labelEditHandler) {
+        public Builder labelEditHandler(BiFunction<VariableManager, String, IStatus> labelEditHandler) {
             this.labelEditHandler = Objects.requireNonNull(labelEditHandler);
             return this;
         }

--- a/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/tools/CreateEdgeTool.java
+++ b/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/tools/CreateEdgeTool.java
@@ -22,7 +22,7 @@ import org.eclipse.sirius.web.annotations.graphql.GraphQLField;
 import org.eclipse.sirius.web.annotations.graphql.GraphQLID;
 import org.eclipse.sirius.web.annotations.graphql.GraphQLNonNull;
 import org.eclipse.sirius.web.annotations.graphql.GraphQLObjectType;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.IStatus;
 import org.eclipse.sirius.web.representations.VariableManager;
 
 /**
@@ -41,7 +41,7 @@ public final class CreateEdgeTool implements ITool {
 
     private String label;
 
-    private Function<VariableManager, Status> handler;
+    private Function<VariableManager, IStatus> handler;
 
     private List<EdgeCandidate> edgeCandidates;
 
@@ -78,7 +78,7 @@ public final class CreateEdgeTool implements ITool {
     }
 
     @Override
-    public Function<VariableManager, Status> getHandler() {
+    public Function<VariableManager, IStatus> getHandler() {
         return this.handler;
     }
 
@@ -105,7 +105,7 @@ public final class CreateEdgeTool implements ITool {
 
         private String label;
 
-        private Function<VariableManager, Status> handler;
+        private Function<VariableManager, IStatus> handler;
 
         private List<EdgeCandidate> edgeCandidates;
 
@@ -128,7 +128,7 @@ public final class CreateEdgeTool implements ITool {
             return this;
         }
 
-        public Builder handler(Function<VariableManager, Status> handler) {
+        public Builder handler(Function<VariableManager, IStatus> handler) {
             this.handler = Objects.requireNonNull(handler);
             return this;
         }

--- a/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/tools/CreateNodeTool.java
+++ b/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/tools/CreateNodeTool.java
@@ -23,7 +23,7 @@ import org.eclipse.sirius.web.annotations.graphql.GraphQLID;
 import org.eclipse.sirius.web.annotations.graphql.GraphQLNonNull;
 import org.eclipse.sirius.web.annotations.graphql.GraphQLObjectType;
 import org.eclipse.sirius.web.diagrams.description.NodeDescription;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.IStatus;
 import org.eclipse.sirius.web.representations.VariableManager;
 
 /**
@@ -44,7 +44,7 @@ public final class CreateNodeTool implements ITool {
 
     private String label;
 
-    private Function<VariableManager, Status> handler;
+    private Function<VariableManager, IStatus> handler;
 
     private List<NodeDescription> targetDescriptions;
 
@@ -97,7 +97,7 @@ public final class CreateNodeTool implements ITool {
     }
 
     @Override
-    public Function<VariableManager, Status> getHandler() {
+    public Function<VariableManager, IStatus> getHandler() {
         return this.handler;
     }
 
@@ -124,7 +124,7 @@ public final class CreateNodeTool implements ITool {
 
         private String label;
 
-        private Function<VariableManager, Status> handler;
+        private Function<VariableManager, IStatus> handler;
 
         private List<NodeDescription> targetDescriptions;
 
@@ -156,7 +156,7 @@ public final class CreateNodeTool implements ITool {
             return this;
         }
 
-        public Builder handler(Function<VariableManager, Status> handler) {
+        public Builder handler(Function<VariableManager, IStatus> handler) {
             this.handler = Objects.requireNonNull(handler);
             return this;
         }

--- a/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/tools/ITool.java
+++ b/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/tools/ITool.java
@@ -18,7 +18,7 @@ import org.eclipse.sirius.web.annotations.graphql.GraphQLField;
 import org.eclipse.sirius.web.annotations.graphql.GraphQLID;
 import org.eclipse.sirius.web.annotations.graphql.GraphQLInterfaceType;
 import org.eclipse.sirius.web.annotations.graphql.GraphQLNonNull;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.IStatus;
 import org.eclipse.sirius.web.representations.VariableManager;
 
 /**
@@ -38,7 +38,7 @@ public interface ITool {
     @GraphQLNonNull
     String getLabel();
 
-    Function<VariableManager, Status> getHandler();
+    Function<VariableManager, IStatus> getHandler();
 
     @GraphQLField
     @GraphQLNonNull

--- a/backend/sirius-web-diagrams/src/test/java/org/eclipse/sirius/web/diagrams/renderer/DiagramRendererEdgeTests.java
+++ b/backend/sirius-web-diagrams/src/test/java/org/eclipse/sirius/web/diagrams/renderer/DiagramRendererEdgeTests.java
@@ -42,7 +42,8 @@ import org.eclipse.sirius.web.diagrams.description.LabelDescription;
 import org.eclipse.sirius.web.diagrams.description.LabelStyleDescription;
 import org.eclipse.sirius.web.diagrams.description.NodeDescription;
 import org.eclipse.sirius.web.diagrams.elements.NodeElementProps;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.Failure;
+import org.eclipse.sirius.web.representations.Success;
 import org.eclipse.sirius.web.representations.VariableManager;
 import org.junit.jupiter.api.Test;
 
@@ -207,8 +208,8 @@ public class DiagramRendererEdgeTests {
                 .sizeProvider(variableManager -> Size.UNDEFINED)
                 .borderNodeDescriptions(new ArrayList<>())
                 .childNodeDescriptions(new ArrayList<>())
-                .labelEditHandler((variableManager, newLabel) -> Status.OK)
-                .deleteHandler(variableManager -> Status.OK)
+                .labelEditHandler((variableManager, newLabel) -> new Success())
+                .deleteHandler(variableManager -> new Success())
                 .build();
         // @formatter:on
     }
@@ -263,7 +264,7 @@ public class DiagramRendererEdgeTests {
                 .targetObjectKindProvider(variableManager -> "") //$NON-NLS-1$
                 .targetObjectLabelProvider(variableManager -> "")//$NON-NLS-1$
                 .styleProvider(edgeStyleProvider)
-                .deleteHandler(variableManager -> Status.ERROR)
+                .deleteHandler(variableManager -> new Failure("")) //$NON-NLS-1$
                 .build();
         // @formatter:on
     }

--- a/backend/sirius-web-diagrams/src/test/java/org/eclipse/sirius/web/diagrams/renderer/DiagramRendererNodeTests.java
+++ b/backend/sirius-web-diagrams/src/test/java/org/eclipse/sirius/web/diagrams/renderer/DiagramRendererNodeTests.java
@@ -38,7 +38,7 @@ import org.eclipse.sirius.web.diagrams.description.DiagramDescription;
 import org.eclipse.sirius.web.diagrams.description.LabelDescription;
 import org.eclipse.sirius.web.diagrams.description.LabelStyleDescription;
 import org.eclipse.sirius.web.diagrams.description.NodeDescription;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.Success;
 import org.eclipse.sirius.web.representations.VariableManager;
 import org.junit.jupiter.api.Test;
 
@@ -263,8 +263,8 @@ public class DiagramRendererNodeTests {
                 .sizeProvider(sizeProvider)
                 .borderNodeDescriptions(new ArrayList<>())
                 .childNodeDescriptions(new ArrayList<>())
-                .labelEditHandler((variableManager, newLabel) -> Status.OK)
-                .deleteHandler(variableManager -> Status.OK)
+                .labelEditHandler((variableManager, newLabel) -> new Success())
+                .deleteHandler(variableManager -> new Success())
                 .build();
 
         DiagramDescription diagramDescription = DiagramDescription.newDiagramDescription(UUID.randomUUID())

--- a/backend/sirius-web-diagrams/src/test/java/org/eclipse/sirius/web/diagrams/renderer/UnsynchronizedDiagramTests.java
+++ b/backend/sirius-web-diagrams/src/test/java/org/eclipse/sirius/web/diagrams/renderer/UnsynchronizedDiagramTests.java
@@ -36,7 +36,7 @@ import org.eclipse.sirius.web.diagrams.description.LabelDescription;
 import org.eclipse.sirius.web.diagrams.description.LabelStyleDescription;
 import org.eclipse.sirius.web.diagrams.description.NodeDescription;
 import org.eclipse.sirius.web.diagrams.description.SynchronizationPolicy;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.Success;
 import org.eclipse.sirius.web.representations.VariableManager;
 import org.junit.jupiter.api.Test;
 
@@ -293,8 +293,8 @@ public class UnsynchronizedDiagramTests {
                 .sizeProvider(variableManager -> Size.UNDEFINED)
                 .borderNodeDescriptions(new ArrayList<>())
                 .childNodeDescriptions(new ArrayList<>())
-                .labelEditHandler((variableManager, newLabel) -> Status.OK)
-                .deleteHandler(variableManager -> Status.OK)
+                .labelEditHandler((variableManager, newLabel) -> new Success())
+                .deleteHandler(variableManager -> new Success())
                 .build();
         NodeDescription unsynchronizedNodeDescription = NodeDescription.newNodeDescription(UUID.nameUUIDFromBytes("unsynchronized".getBytes())) //$NON-NLS-1$
                 .synchronizationPolicy(SynchronizationPolicy.UNSYNCHRONIZED)
@@ -308,8 +308,8 @@ public class UnsynchronizedDiagramTests {
                 .sizeProvider(variableManager -> Size.UNDEFINED)
                 .borderNodeDescriptions(new ArrayList<>())
                 .childNodeDescriptions(List.of(subUnsynchronizedNodeDescription))
-                .labelEditHandler((variableManager, newLabel) -> Status.OK)
-                .deleteHandler(variableManager -> Status.OK)
+                .labelEditHandler((variableManager, newLabel) -> new Success())
+                .deleteHandler(variableManager -> new Success())
                 .build();
 
         NodeDescription synchronizedNodeDescription = NodeDescription.newNodeDescription(UUID.nameUUIDFromBytes("synchronized".getBytes())) //$NON-NLS-1$
@@ -324,8 +324,8 @@ public class UnsynchronizedDiagramTests {
                 .sizeProvider(variableManager -> Size.UNDEFINED)
                 .borderNodeDescriptions(new ArrayList<>())
                 .childNodeDescriptions(new ArrayList<>())
-                .labelEditHandler((variableManager, newLabel) -> Status.OK)
-                .deleteHandler(variableManager -> Status.OK)
+                .labelEditHandler((variableManager, newLabel) -> new Success())
+                .deleteHandler(variableManager -> new Success())
                 .build();
 
         DiagramDescription diagramDescription = DiagramDescription.newDiagramDescription(UUID.nameUUIDFromBytes("diagram".getBytes())) //$NON-NLS-1$

--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/modeloperations/ChangeContextOperationHandler.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/modeloperations/ChangeContextOperationHandler.java
@@ -22,7 +22,7 @@ import org.eclipse.sirius.viewpoint.description.tool.ChangeContext;
 import org.eclipse.sirius.viewpoint.description.tool.ModelOperation;
 import org.eclipse.sirius.web.compat.api.IModelOperationHandler;
 import org.eclipse.sirius.web.interpreter.AQLInterpreter;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.IStatus;
 import org.eclipse.sirius.web.representations.VariableManager;
 
 /**
@@ -45,7 +45,7 @@ public class ChangeContextOperationHandler implements IModelOperationHandler {
     }
 
     @Override
-    public Status handle(Map<String, Object> variables) {
+    public IStatus handle(Map<String, Object> variables) {
         String browseExpression = this.changeContext.getBrowseExpression();
         Map<String, Object> childVariables = new HashMap<>(variables);
         if (browseExpression != null && !browseExpression.isBlank()) {

--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/modeloperations/ChildModelOperationHandler.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/modeloperations/ChildModelOperationHandler.java
@@ -19,7 +19,9 @@ import java.util.Optional;
 import org.eclipse.sirius.viewpoint.description.tool.ModelOperation;
 import org.eclipse.sirius.web.compat.api.IModelOperationHandler;
 import org.eclipse.sirius.web.interpreter.AQLInterpreter;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.Failure;
+import org.eclipse.sirius.web.representations.IStatus;
+import org.eclipse.sirius.web.representations.Success;
 
 /**
  * Used to execute some child model operations.
@@ -27,23 +29,23 @@ import org.eclipse.sirius.web.representations.Status;
  * @author sbegaudeau
  */
 public class ChildModelOperationHandler {
-    public Status handle(AQLInterpreter interpreter, Map<String, Object> variables, List<ModelOperation> modelOperations) {
+    public IStatus handle(AQLInterpreter interpreter, Map<String, Object> variables, List<ModelOperation> modelOperations) {
         boolean hasBeenSuccessfullyExecuted = true;
 
         ModelOperationHandlerSwitch modelOperationHandlerSwitch = new ModelOperationHandlerSwitch(interpreter);
         for (ModelOperation modelOperation : modelOperations) {
             Optional<IModelOperationHandler> optionalModelOperationHandler = modelOperationHandlerSwitch.apply(modelOperation);
 
-            Status status = optionalModelOperationHandler.map(handler -> {
+            IStatus status = optionalModelOperationHandler.map(handler -> {
                 return handler.handle(variables);
-            }).orElse(Status.ERROR);
+            }).orElse(new Failure("")); //$NON-NLS-1$
 
-            hasBeenSuccessfullyExecuted = hasBeenSuccessfullyExecuted && Status.OK.equals(status);
+            hasBeenSuccessfullyExecuted = hasBeenSuccessfullyExecuted && status instanceof Success;
         }
 
         if (hasBeenSuccessfullyExecuted) {
-            return Status.OK;
+            return new Success();
         }
-        return Status.ERROR;
+        return new Failure(""); //$NON-NLS-1$
     }
 }

--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/modeloperations/CreateInstanceOperationHandler.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/modeloperations/CreateInstanceOperationHandler.java
@@ -33,7 +33,7 @@ import org.eclipse.sirius.web.core.api.IEditingContext;
 import org.eclipse.sirius.web.emf.compatibility.EPackageService;
 import org.eclipse.sirius.web.emf.services.EditingContext;
 import org.eclipse.sirius.web.interpreter.AQLInterpreter;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.IStatus;
 import org.eclipse.sirius.web.representations.VariableManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -68,7 +68,7 @@ public class CreateInstanceOperationHandler implements IModelOperationHandler {
     }
 
     @Override
-    public Status handle(Map<String, Object> variables) {
+    public IStatus handle(Map<String, Object> variables) {
         String typeName = this.createInstance.getTypeName();
         String referenceName = this.createInstance.getReferenceName();
         String variableName = this.createInstance.getVariableName();

--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/modeloperations/ForOperationHandler.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/modeloperations/ForOperationHandler.java
@@ -22,7 +22,8 @@ import org.eclipse.sirius.viewpoint.description.tool.For;
 import org.eclipse.sirius.viewpoint.description.tool.ModelOperation;
 import org.eclipse.sirius.web.compat.api.IModelOperationHandler;
 import org.eclipse.sirius.web.interpreter.AQLInterpreter;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.IStatus;
+import org.eclipse.sirius.web.representations.Success;
 
 /**
  * Handle the {@link For} model operation.
@@ -44,7 +45,7 @@ public class ForOperationHandler implements IModelOperationHandler {
     }
 
     @Override
-    public Status handle(Map<String, Object> variables) {
+    public IStatus handle(Map<String, Object> variables) {
         String expression = this.forOperation.getExpression();
         String iteratedVariableName = this.forOperation.getIteratorName();
 
@@ -64,7 +65,7 @@ public class ForOperationHandler implements IModelOperationHandler {
             }
         }
 
-        return Status.OK;
+        return new Success();
     }
 
 }

--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/modeloperations/IfOperationHandler.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/modeloperations/IfOperationHandler.java
@@ -21,7 +21,8 @@ import org.eclipse.sirius.viewpoint.description.tool.If;
 import org.eclipse.sirius.viewpoint.description.tool.ModelOperation;
 import org.eclipse.sirius.web.compat.api.IModelOperationHandler;
 import org.eclipse.sirius.web.interpreter.AQLInterpreter;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.IStatus;
+import org.eclipse.sirius.web.representations.Success;
 
 /**
  * Handle the {@link If} model operation.
@@ -43,7 +44,7 @@ public class IfOperationHandler implements IModelOperationHandler {
     }
 
     @Override
-    public Status handle(Map<String, Object> variables) {
+    public IStatus handle(Map<String, Object> variables) {
         String conditionExpression = this.ifOperation.getConditionExpression();
         if (conditionExpression != null && !conditionExpression.isBlank()) {
             Optional<Boolean> optionalValueObject = this.interpreter.evaluateExpression(variables, conditionExpression).asBoolean();
@@ -54,7 +55,7 @@ public class IfOperationHandler implements IModelOperationHandler {
             }
         }
 
-        return Status.OK;
+        return new Success();
     }
 
 }

--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/modeloperations/LetOperationHandler.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/modeloperations/LetOperationHandler.java
@@ -22,7 +22,7 @@ import org.eclipse.sirius.viewpoint.description.tool.Let;
 import org.eclipse.sirius.viewpoint.description.tool.ModelOperation;
 import org.eclipse.sirius.web.compat.api.IModelOperationHandler;
 import org.eclipse.sirius.web.interpreter.AQLInterpreter;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.IStatus;
 
 /**
  * Handle the {@link Let} model operation.
@@ -44,7 +44,7 @@ public class LetOperationHandler implements IModelOperationHandler {
     }
 
     @Override
-    public Status handle(Map<String, Object> variables) {
+    public IStatus handle(Map<String, Object> variables) {
         String valueExpression = this.letOperation.getValueExpression();
         String variableName = this.letOperation.getVariableName();
         Map<String, Object> childVariables = new HashMap<>(variables);

--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/modeloperations/MoveElementOperationHandler.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/modeloperations/MoveElementOperationHandler.java
@@ -24,7 +24,7 @@ import org.eclipse.sirius.viewpoint.description.tool.ModelOperation;
 import org.eclipse.sirius.viewpoint.description.tool.MoveElement;
 import org.eclipse.sirius.web.compat.api.IModelOperationHandler;
 import org.eclipse.sirius.web.interpreter.AQLInterpreter;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.IStatus;
 import org.eclipse.sirius.web.representations.VariableManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,7 +50,7 @@ public class MoveElementOperationHandler implements IModelOperationHandler {
     }
 
     @Override
-    public Status handle(Map<String, Object> variables) {
+    public IStatus handle(Map<String, Object> variables) {
         String newContainerExpression = this.moveElementOperation.getNewContainerExpression();
         String featureName = this.moveElementOperation.getFeatureName();
         if (featureName != null && !featureName.isBlank() && newContainerExpression != null && !newContainerExpression.isBlank()) {

--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/modeloperations/RemoveElementOperationHandler.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/modeloperations/RemoveElementOperationHandler.java
@@ -24,7 +24,7 @@ import org.eclipse.sirius.viewpoint.description.tool.ModelOperation;
 import org.eclipse.sirius.viewpoint.description.tool.RemoveElement;
 import org.eclipse.sirius.web.compat.api.IModelOperationHandler;
 import org.eclipse.sirius.web.interpreter.AQLInterpreter;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.IStatus;
 import org.eclipse.sirius.web.representations.VariableManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,7 +51,7 @@ public class RemoveElementOperationHandler implements IModelOperationHandler {
     }
 
     @Override
-    public Status handle(Map<String, Object> variables) {
+    public IStatus handle(Map<String, Object> variables) {
         // @formatter:off
         Optional<EObject> optionalObjectToRemove = Optional.ofNullable(variables.get(VariableManager.SELF))
              .filter(EObject.class::isInstance)

--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/modeloperations/SetValueOperationHandler.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/modeloperations/SetValueOperationHandler.java
@@ -24,7 +24,7 @@ import org.eclipse.sirius.viewpoint.description.tool.ModelOperation;
 import org.eclipse.sirius.viewpoint.description.tool.SetValue;
 import org.eclipse.sirius.web.compat.api.IModelOperationHandler;
 import org.eclipse.sirius.web.interpreter.AQLInterpreter;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.IStatus;
 import org.eclipse.sirius.web.representations.VariableManager;
 
 /**
@@ -47,7 +47,7 @@ public class SetValueOperationHandler implements IModelOperationHandler {
     }
 
     @Override
-    public Status handle(Map<String, Object> variables) {
+    public IStatus handle(Map<String, Object> variables) {
         String featureName = this.setValue.getFeatureName();
         if (featureName != null && !featureName.isBlank()) {
             String valueExpression = this.setValue.getValueExpression();

--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/modeloperations/SwitchOperationHandler.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/modeloperations/SwitchOperationHandler.java
@@ -25,7 +25,8 @@ import org.eclipse.sirius.viewpoint.description.tool.ModelOperation;
 import org.eclipse.sirius.viewpoint.description.tool.Switch;
 import org.eclipse.sirius.web.compat.api.IModelOperationHandler;
 import org.eclipse.sirius.web.interpreter.AQLInterpreter;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.IStatus;
+import org.eclipse.sirius.web.representations.Success;
 
 /**
  * Handle the {@link Switch} model operation.
@@ -47,11 +48,11 @@ public class SwitchOperationHandler implements IModelOperationHandler {
     }
 
     @Override
-    public Status handle(Map<String, Object> variables) {
+    public IStatus handle(Map<String, Object> variables) {
         EList<Case> switchCases = this.switchOperation.getCases();
         Map<String, Object> childVariables = new HashMap<>(variables);
 
-        Status status = Status.OK;
+        IStatus status = new Success();
         boolean oneCaseHasBeenExecuted = false;
         for (Case switchCase : switchCases) {
             String conditionExpression = switchCase.getConditionExpression();

--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/modeloperations/UnsetOperationHandler.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/modeloperations/UnsetOperationHandler.java
@@ -27,7 +27,7 @@ import org.eclipse.sirius.viewpoint.description.tool.ModelOperation;
 import org.eclipse.sirius.viewpoint.description.tool.Unset;
 import org.eclipse.sirius.web.compat.api.IModelOperationHandler;
 import org.eclipse.sirius.web.interpreter.AQLInterpreter;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.IStatus;
 import org.eclipse.sirius.web.representations.VariableManager;
 
 /**
@@ -50,7 +50,7 @@ public class UnsetOperationHandler implements IModelOperationHandler {
     }
 
     @Override
-    public Status handle(Map<String, Object> variables) {
+    public IStatus handle(Map<String, Object> variables) {
         var optionalContext = this.getContext(variables);
         var optionalFeature = optionalContext.flatMap(context -> this.computeFeature(context, variables));
         if (optionalContext.isPresent() && optionalFeature.isPresent()) {
@@ -109,7 +109,7 @@ public class UnsetOperationHandler implements IModelOperationHandler {
         }
     }
 
-    private Status executeChildrenOperations(Map<String, Object> variables) {
+    private IStatus executeChildrenOperations(Map<String, Object> variables) {
         Map<String, Object> childVariables = new HashMap<>(variables);
         List<ModelOperation> subModelOperations = this.unsetOperation.getSubModelOperations();
         return this.childModelOperationHandler.handle(this.interpreter, childVariables, subModelOperations);

--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/properties/EBooleanIfDescriptionProvider.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/properties/EBooleanIfDescriptionProvider.java
@@ -24,7 +24,9 @@ import org.eclipse.sirius.web.compat.forms.WidgetIdProvider;
 import org.eclipse.sirius.web.emf.compatibility.properties.api.IPropertiesValidationProvider;
 import org.eclipse.sirius.web.forms.description.CheckboxDescription;
 import org.eclipse.sirius.web.forms.description.IfDescription;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.Failure;
+import org.eclipse.sirius.web.representations.IStatus;
+import org.eclipse.sirius.web.representations.Success;
 import org.eclipse.sirius.web.representations.VariableManager;
 
 /**
@@ -96,7 +98,7 @@ public class EBooleanIfDescriptionProvider {
         };
     }
 
-    private BiFunction<VariableManager, Boolean, Status> getNewValueHandler() {
+    private BiFunction<VariableManager, Boolean, IStatus> getNewValueHandler() {
         return (variableManager, newValue) -> {
             var optionalEObject = variableManager.get(VariableManager.SELF, EObject.class);
             var optionalEAttribute = variableManager.get(PropertiesDefaultDescriptionProvider.ESTRUCTURAL_FEATURE, EAttribute.class);
@@ -105,9 +107,9 @@ public class EBooleanIfDescriptionProvider {
                 EAttribute eAttribute = optionalEAttribute.get();
 
                 eObject.eSet(eAttribute, newValue);
-                return Status.OK;
+                return new Success();
             }
-            return Status.ERROR;
+            return new Failure(""); //$NON-NLS-1$
         };
     }
 

--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/properties/EEnumIfDescriptionProvider.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/properties/EEnumIfDescriptionProvider.java
@@ -34,7 +34,9 @@ import org.eclipse.sirius.web.emf.compatibility.properties.api.IPropertiesValida
 import org.eclipse.sirius.web.forms.components.SelectComponent;
 import org.eclipse.sirius.web.forms.description.IfDescription;
 import org.eclipse.sirius.web.forms.description.RadioDescription;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.Failure;
+import org.eclipse.sirius.web.representations.IStatus;
+import org.eclipse.sirius.web.representations.Success;
 import org.eclipse.sirius.web.representations.VariableManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -163,7 +165,7 @@ public class EEnumIfDescriptionProvider {
         };
     }
 
-    private BiFunction<VariableManager, String, Status> getNewValueHandler() {
+    private BiFunction<VariableManager, String, IStatus> getNewValueHandler() {
         return (variableManager, newValue) -> {
             var optionalEObject = variableManager.get(VariableManager.SELF, EObject.class);
             var optionalEAttribute = variableManager.get(PropertiesDefaultDescriptionProvider.ESTRUCTURAL_FEATURE, EAttribute.class);
@@ -185,9 +187,9 @@ public class EEnumIfDescriptionProvider {
                 }
             } catch (NumberFormatException exception) {
                 this.logger.warn(exception.getMessage(), exception);
-                return Status.ERROR;
+                return new Failure(""); //$NON-NLS-1$
             }
-            return Status.OK;
+            return new Success();
         };
     }
 

--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/properties/EStringIfDescriptionProvider.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/properties/EStringIfDescriptionProvider.java
@@ -26,7 +26,9 @@ import org.eclipse.sirius.web.compat.forms.WidgetIdProvider;
 import org.eclipse.sirius.web.emf.compatibility.properties.api.IPropertiesValidationProvider;
 import org.eclipse.sirius.web.forms.description.IfDescription;
 import org.eclipse.sirius.web.forms.description.TextfieldDescription;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.Failure;
+import org.eclipse.sirius.web.representations.IStatus;
+import org.eclipse.sirius.web.representations.Success;
 import org.eclipse.sirius.web.representations.VariableManager;
 
 /**
@@ -104,7 +106,7 @@ public class EStringIfDescriptionProvider {
         };
     }
 
-    private BiFunction<VariableManager, String, Status> getNewValueHandler() {
+    private BiFunction<VariableManager, String, IStatus> getNewValueHandler() {
         return (variableManager, newValue) -> {
             var optionalEObject = variableManager.get(VariableManager.SELF, EObject.class);
             var optionalEAttribute = variableManager.get(PropertiesDefaultDescriptionProvider.ESTRUCTURAL_FEATURE, EAttribute.class);
@@ -115,9 +117,9 @@ public class EStringIfDescriptionProvider {
                 String value = EcoreUtil.createFromString(EcorePackage.Literals.ESTRING, newValue).toString();
                 eObject.eSet(eAttribute, value);
 
-                return Status.OK;
+                return new Success();
             }
-            return Status.ERROR;
+            return new Failure(""); //$NON-NLS-1$
         };
     }
 }

--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/properties/MonoValuedNonContainmentReferenceIfDescriptionProvider.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/properties/MonoValuedNonContainmentReferenceIfDescriptionProvider.java
@@ -27,7 +27,9 @@ import org.eclipse.sirius.web.emf.compatibility.properties.api.IPropertiesValida
 import org.eclipse.sirius.web.forms.components.SelectComponent;
 import org.eclipse.sirius.web.forms.description.IfDescription;
 import org.eclipse.sirius.web.forms.description.SelectDescription;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.Failure;
+import org.eclipse.sirius.web.representations.IStatus;
+import org.eclipse.sirius.web.representations.Success;
 import org.eclipse.sirius.web.representations.VariableManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -96,13 +98,13 @@ public class MonoValuedNonContainmentReferenceIfDescriptionProvider {
         // @formatter:on
     }
 
-    private BiFunction<VariableManager, String, Status> getNewValueHandler() {
+    private BiFunction<VariableManager, String, IStatus> getNewValueHandler() {
         return (variableManager, newValue) -> {
             var optionalEObject = variableManager.get(VariableManager.SELF, EObject.class);
             var optionalEReference = variableManager.get(PropertiesDefaultDescriptionProvider.ESTRUCTURAL_FEATURE, EReference.class);
             var optionalEditingContext = variableManager.get(IEditingContext.EDITING_CONTEXT, IEditingContext.class);
 
-            Status result = Status.ERROR;
+            IStatus result = new Failure(""); //$NON-NLS-1$
             if (optionalEObject.isPresent() && optionalEReference.isPresent()) {
                 EObject eObject = optionalEObject.get();
                 EReference eReference = optionalEReference.get();
@@ -110,7 +112,7 @@ public class MonoValuedNonContainmentReferenceIfDescriptionProvider {
                 if (newValue == null || newValue.isBlank()) {
                     try {
                         eObject.eUnset(eReference);
-                        result = Status.OK;
+                        result = new Success();
                     } catch (IllegalArgumentException | ClassCastException | ArrayStoreException exception) {
                         this.logger.warn(exception.getMessage(), exception);
                     }
@@ -124,7 +126,7 @@ public class MonoValuedNonContainmentReferenceIfDescriptionProvider {
                         EObject newValueToSet = optionalNewValueToSet.get();
                         try {
                             eObject.eSet(eReference, newValueToSet);
-                            result = Status.OK;
+                            result = new Success();
                         } catch (IllegalArgumentException | ClassCastException | ArrayStoreException exception) {
                             this.logger.warn(exception.getMessage(), exception);
                         }

--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/properties/MultiValuedNonContainmentReferenceIfDescriptionProvider.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/properties/MultiValuedNonContainmentReferenceIfDescriptionProvider.java
@@ -30,7 +30,9 @@ import org.eclipse.sirius.web.emf.compatibility.properties.api.IPropertiesValida
 import org.eclipse.sirius.web.forms.components.SelectComponent;
 import org.eclipse.sirius.web.forms.description.IfDescription;
 import org.eclipse.sirius.web.forms.description.MultiSelectDescription;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.Failure;
+import org.eclipse.sirius.web.representations.IStatus;
+import org.eclipse.sirius.web.representations.Success;
 import org.eclipse.sirius.web.representations.VariableManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -99,9 +101,9 @@ public class MultiValuedNonContainmentReferenceIfDescriptionProvider {
         // @formatter:on
     }
 
-    private BiFunction<VariableManager, List<String>, Status> getNewValuesHandler() {
+    private BiFunction<VariableManager, List<String>, IStatus> getNewValuesHandler() {
         return (variableManager, newValues) -> {
-            var status = Status.ERROR;
+            IStatus status = new Failure(""); //$NON-NLS-1$
             var optionalEObject = variableManager.get(VariableManager.SELF, EObject.class);
             var optionalEReference = variableManager.get(PropertiesDefaultDescriptionProvider.ESTRUCTURAL_FEATURE, EReference.class);
             var optionalEditingContext = variableManager.get(IEditingContext.EDITING_CONTEXT, IEditingContext.class);
@@ -135,7 +137,7 @@ public class MultiValuedNonContainmentReferenceIfDescriptionProvider {
 
                 refElements.removeIf(refElt -> !newValuesToSet.contains(refElt));
 
-                status = Status.OK;
+                status = new Success();
             }
             return status;
         };

--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/properties/NumberIfDescriptionProvider.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/properties/NumberIfDescriptionProvider.java
@@ -25,7 +25,9 @@ import org.eclipse.emf.edit.provider.ComposedAdapterFactory;
 import org.eclipse.sirius.web.emf.compatibility.properties.api.IPropertiesValidationProvider;
 import org.eclipse.sirius.web.forms.description.IfDescription;
 import org.eclipse.sirius.web.forms.description.TextfieldDescription;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.Failure;
+import org.eclipse.sirius.web.representations.IStatus;
+import org.eclipse.sirius.web.representations.Success;
 import org.eclipse.sirius.web.representations.VariableManager;
 
 /**
@@ -115,7 +117,7 @@ public class NumberIfDescriptionProvider {
         };
     }
 
-    private BiFunction<VariableManager, String, Status> getNewValueHandler() {
+    private BiFunction<VariableManager, String, IStatus> getNewValueHandler() {
         return (variableManager, newValue) -> {
             var optionalEObject = variableManager.get(VariableManager.SELF, EObject.class);
             var optionalEAttribute = variableManager.get(PropertiesDefaultDescriptionProvider.ESTRUCTURAL_FEATURE, EAttribute.class);
@@ -126,9 +128,9 @@ public class NumberIfDescriptionProvider {
                 EAttribute eAttribute = optionalEAttribute.get();
 
                 eObject.eSet(eAttribute, value);
-                return Status.OK;
+                return new Success();
             }
-            return Status.ERROR;
+            return new Failure(""); //$NON-NLS-1$
         };
     }
 

--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/view/CanonicalBehaviors.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/view/CanonicalBehaviors.java
@@ -21,7 +21,8 @@ import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EPackage;
 import org.eclipse.sirius.web.core.api.IEditService;
 import org.eclipse.sirius.web.core.api.IObjectService;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.IStatus;
+import org.eclipse.sirius.web.representations.Success;
 import org.eclipse.sirius.web.representations.VariableManager;
 import org.eclipse.sirius.web.view.EdgeDescription;
 
@@ -42,14 +43,14 @@ public class CanonicalBehaviors {
         this.editService = Objects.requireNonNull(editService);
     }
 
-    public Status createNewNode(org.eclipse.sirius.web.view.NodeDescription nodeDescription, VariableManager variableManager) {
+    public IStatus createNewNode(org.eclipse.sirius.web.view.NodeDescription nodeDescription, VariableManager variableManager) {
         EObject self = variableManager.get(VariableManager.SELF, EObject.class).orElse(null);
         String domainType = nodeDescription.getDomainType();
         this.createSemanticInstance(self, domainType).ifPresent(instance -> this.addInParent(self, instance));
-        return Status.OK;
+        return new Success();
     }
 
-    public Status createNewEdge(VariableManager variableManager, EdgeDescription edgeDescription) {
+    public IStatus createNewEdge(VariableManager variableManager, EdgeDescription edgeDescription) {
         EObject semanticSource = variableManager.get(org.eclipse.sirius.web.diagrams.description.EdgeDescription.SEMANTIC_EDGE_SOURCE, EObject.class).get();
         EObject semanticTarget = variableManager.get(org.eclipse.sirius.web.diagrams.description.EdgeDescription.SEMANTIC_EDGE_TARGET, EObject.class).get();
         if (edgeDescription.isIsDomainBasedEdge()) {
@@ -61,22 +62,22 @@ public class CanonicalBehaviors {
         } else {
             this.addReferenceTo(semanticSource, semanticTarget);
         }
-        return Status.OK;
+        return new Success();
     }
 
-    public Status editLabel(VariableManager variableManager, String newLabel) {
+    public IStatus editLabel(VariableManager variableManager, String newLabel) {
         this.self(variableManager).ifPresent(self -> {
             Optional<String> optionalLabelField = this.objectService.getLabelField(self);
             if (optionalLabelField.isPresent()) {
                 this.editService.editLabel(self, optionalLabelField.get(), newLabel);
             }
         });
-        return Status.OK;
+        return new Success();
     }
 
-    public Status deleteElement(VariableManager variableManager) {
+    public IStatus deleteElement(VariableManager variableManager) {
         this.self(variableManager).ifPresent(this.editService::delete);
-        return Status.OK;
+        return new Success();
     }
 
     private Optional<Object> self(VariableManager variableManager) {

--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/view/ToolInterpreter.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/view/ToolInterpreter.java
@@ -28,7 +28,9 @@ import org.eclipse.sirius.ecore.extender.business.internal.accessor.ecore.EcoreI
 import org.eclipse.sirius.web.core.api.IEditService;
 import org.eclipse.sirius.web.interpreter.AQLInterpreter;
 import org.eclipse.sirius.web.interpreter.Result;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.Failure;
+import org.eclipse.sirius.web.representations.IStatus;
+import org.eclipse.sirius.web.representations.Success;
 import org.eclipse.sirius.web.representations.VariableManager;
 import org.eclipse.sirius.web.view.ChangeContext;
 import org.eclipse.sirius.web.view.CreateInstance;
@@ -58,12 +60,12 @@ public class ToolInterpreter {
         this.ecore = new EcoreIntrinsicExtender();
     }
 
-    public Status executeTool(Tool tool, VariableManager variableManager) {
+    public IStatus executeTool(Tool tool, VariableManager variableManager) {
         Optional<VariableManager> result = this.executeOperations(tool.getBody(), variableManager);
         if (result.isPresent()) {
-            return Status.OK;
+            return new Success();
         } else {
-            return Status.ERROR;
+            return new Failure(""); //$NON-NLS-1$
         }
     }
 

--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/view/ViewConverter.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/view/ViewConverter.java
@@ -52,7 +52,7 @@ import org.eclipse.sirius.web.emf.compatibility.DomainClassPredicate;
 import org.eclipse.sirius.web.interpreter.AQLInterpreter;
 import org.eclipse.sirius.web.interpreter.Result;
 import org.eclipse.sirius.web.representations.IRepresentationDescription;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.IStatus;
 import org.eclipse.sirius.web.representations.VariableManager;
 import org.eclipse.sirius.web.view.DeleteTool;
 import org.eclipse.sirius.web.view.DiagramElementDescription;
@@ -465,7 +465,7 @@ public class ViewConverter {
         // @formatter:on
     }
 
-    private Function<VariableManager, Status> createDeleteHandler(DiagramElementDescription diagramElementDescription, AQLInterpreter interpreter) {
+    private Function<VariableManager, IStatus> createDeleteHandler(DiagramElementDescription diagramElementDescription, AQLInterpreter interpreter) {
         DeleteTool tool = diagramElementDescription.getDeleteTool();
         if (tool != null) {
             return variableManager -> {
@@ -476,7 +476,7 @@ public class ViewConverter {
         }
     }
 
-    private BiFunction<VariableManager, String, Status> createLabelEditHandler(DiagramElementDescription diagramElementDescription, AQLInterpreter interpreter) {
+    private BiFunction<VariableManager, String, IStatus> createLabelEditHandler(DiagramElementDescription diagramElementDescription, AQLInterpreter interpreter) {
         LabelEditTool tool = diagramElementDescription.getLabelEditTool();
         if (tool != null) {
             return (variableManager, newLabel) -> {

--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/view/ViewPropertiesConfigurer.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/view/ViewPropertiesConfigurer.java
@@ -37,9 +37,11 @@ import org.eclipse.sirius.web.forms.description.GroupDescription;
 import org.eclipse.sirius.web.forms.description.PageDescription;
 import org.eclipse.sirius.web.forms.description.SelectDescription;
 import org.eclipse.sirius.web.forms.description.TextfieldDescription;
+import org.eclipse.sirius.web.representations.Failure;
 import org.eclipse.sirius.web.representations.GetOrCreateRandomIdProvider;
 import org.eclipse.sirius.web.representations.IRepresentationDescription;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.IStatus;
+import org.eclipse.sirius.web.representations.Success;
 import org.eclipse.sirius.web.representations.VariableManager;
 import org.eclipse.sirius.web.spring.collaborative.validation.api.IValidationService;
 import org.eclipse.sirius.web.view.ConditionalNodeStyle;
@@ -289,13 +291,13 @@ public class ViewPropertiesConfigurer implements IPropertiesDescriptionRegistryC
 
     private TextfieldDescription createTextField(String id, String title, Function<Object, String> reader, BiConsumer<Object, String> writer, Object feature) {
         Function<VariableManager, String> valueProvider = variableManager -> variableManager.get(VariableManager.SELF, Object.class).map(reader).orElse(EMPTY);
-        BiFunction<VariableManager, String, Status> newValueHandler = (variableManager, newValue) -> {
+        BiFunction<VariableManager, String, IStatus> newValueHandler = (variableManager, newValue) -> {
             var optionalDiagramMapping = variableManager.get(VariableManager.SELF, Object.class);
             if (optionalDiagramMapping.isPresent()) {
                 writer.accept(optionalDiagramMapping.get(), newValue);
-                return Status.OK;
+                return new Success();
             } else {
-                return Status.ERROR;
+                return new Failure(""); //$NON-NLS-1$
             }
         };
 
@@ -314,13 +316,13 @@ public class ViewPropertiesConfigurer implements IPropertiesDescriptionRegistryC
 
     private CheckboxDescription createCheckbox(String id, String title, Function<Object, Boolean> reader, BiConsumer<Object, Boolean> writer, Object feature) {
         Function<VariableManager, Boolean> valueProvider = variableManager -> variableManager.get(VariableManager.SELF, Object.class).map(reader).orElse(Boolean.FALSE);
-        BiFunction<VariableManager, Boolean, Status> newValueHandler = (variableManager, newValue) -> {
+        BiFunction<VariableManager, Boolean, IStatus> newValueHandler = (variableManager, newValue) -> {
             var optionalDiagramMapping = variableManager.get(VariableManager.SELF, Object.class);
             if (optionalDiagramMapping.isPresent()) {
                 writer.accept(optionalDiagramMapping.get(), newValue);
-                return Status.OK;
+                return new Success();
             } else {
-                return Status.ERROR;
+                return new Failure(""); //$NON-NLS-1$
             }
         };
         // @formatter:off
@@ -360,7 +362,7 @@ public class ViewPropertiesConfigurer implements IPropertiesDescriptionRegistryC
         // @formatter:on
     }
 
-    private BiFunction<VariableManager, String, Status> getNewShapeValueHandler() {
+    private BiFunction<VariableManager, String, IStatus> getNewShapeValueHandler() {
         return (variableManager, newValue) -> {
             var optionalNodeStyle = variableManager.get(VariableManager.SELF, NodeStyle.class);
             if (optionalNodeStyle.isPresent()) {
@@ -368,9 +370,9 @@ public class ViewPropertiesConfigurer implements IPropertiesDescriptionRegistryC
                     newValue = null;
                 }
                 optionalNodeStyle.get().setShape(newValue);
-                return Status.OK;
+                return new Success();
             }
-            return Status.ERROR;
+            return new Failure(""); //$NON-NLS-1$
         };
     }
 

--- a/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/compatibility/diagrams/EdgeMappingConverterTests.java
+++ b/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/compatibility/diagrams/EdgeMappingConverterTests.java
@@ -36,7 +36,7 @@ import org.eclipse.sirius.web.diagrams.description.NodeDescription;
 import org.eclipse.sirius.web.emf.compatibility.SemanticCandidatesProvider;
 import org.eclipse.sirius.web.emf.compatibility.modeloperations.ModelOperationHandlerSwitch;
 import org.eclipse.sirius.web.interpreter.AQLInterpreter;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.Success;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -109,8 +109,8 @@ public class EdgeMappingConverterTests {
                 .sizeProvider(variableManager -> Size.UNDEFINED)
                 .borderNodeDescriptions(List.of())
                 .childNodeDescriptions(List.of())
-                .labelEditHandler((variableManager, newLabel) -> Status.OK)
-                .deleteHandler(variableManager -> Status.OK)
+                .labelEditHandler((variableManager, newLabel) -> new Success())
+                .deleteHandler(variableManager -> new Success())
                 .build();
         // @formatter:on
     }

--- a/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/compatibility/operations/ChangeContextOperationHandlerTests.java
+++ b/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/compatibility/operations/ChangeContextOperationHandlerTests.java
@@ -13,6 +13,7 @@
 package org.eclipse.sirius.web.emf.compatibility.operations;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.text.MessageFormat;
 import java.util.UUID;
@@ -22,7 +23,8 @@ import org.eclipse.sirius.viewpoint.description.tool.ChangeContext;
 import org.eclipse.sirius.viewpoint.description.tool.ToolFactory;
 import org.eclipse.sirius.web.emf.compatibility.modeloperations.ChangeContextOperationHandler;
 import org.eclipse.sirius.web.emf.compatibility.modeloperations.ChildModelOperationHandler;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.IStatus;
+import org.eclipse.sirius.web.representations.Success;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -53,9 +55,9 @@ public class ChangeContextOperationHandlerTests {
         String newName = "newName"; //$NON-NLS-1$
         this.changeContext.setBrowseExpression("aql:self.renameENamedElementService('" + newName + "')"); //$NON-NLS-1$//$NON-NLS-2$
 
-        Status handleResult = this.changeContextOperationHandler.handle(this.operationTestContext.getVariables());
+        IStatus handleResult = this.changeContextOperationHandler.handle(this.operationTestContext.getVariables());
 
-        assertEquals(Status.OK, handleResult);
+        assertTrue(handleResult instanceof Success);
         assertEquals(newName, this.operationTestContext.getRootPackage().getName());
 
         // check the ChangeContextOperation correctly change the context
@@ -99,10 +101,10 @@ public class ChangeContextOperationHandlerTests {
 
         // execute
         this.changeContext.setBrowseExpression(browseExpression);
-        Status handleResult = this.changeContextOperationHandler.handle(this.operationTestContext.getVariables());
+        IStatus handleResult = this.changeContextOperationHandler.handle(this.operationTestContext.getVariables());
 
         // check
-        assertEquals(Status.OK, handleResult);
+        assertTrue(handleResult instanceof Success);
         assertEquals(newName, renamedElement.getName());
     }
 }

--- a/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/compatibility/operations/CreateInstanceOperationHandlerTests.java
+++ b/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/compatibility/operations/CreateInstanceOperationHandlerTests.java
@@ -13,6 +13,7 @@
 package org.eclipse.sirius.web.emf.compatibility.operations;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.text.MessageFormat;
 import java.util.UUID;
@@ -36,7 +37,8 @@ import org.eclipse.sirius.web.emf.compatibility.EPackageService;
 import org.eclipse.sirius.web.emf.compatibility.modeloperations.ChildModelOperationHandler;
 import org.eclipse.sirius.web.emf.compatibility.modeloperations.CreateInstanceOperationHandler;
 import org.eclipse.sirius.web.emf.services.EditingContext;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.IStatus;
+import org.eclipse.sirius.web.representations.Success;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -94,9 +96,9 @@ public class CreateInstanceOperationHandlerTests {
         this.createInstanceOperation.setTypeName(TYPE_NAME);
         this.createInstanceOperation.setVariableName(VARIABLE_NAME);
 
-        Status handleResult = this.createInstanceOperationHandler.handle(this.operationTestContext.getVariables());
+        IStatus handleResult = this.createInstanceOperationHandler.handle(this.operationTestContext.getVariables());
 
-        assertEquals(Status.OK, handleResult);
+        assertTrue(handleResult instanceof Success);
         assertEquals(2, this.operationTestContext.getRootPackage().getEClassifiers().size());
         assertEquals(className, this.operationTestContext.getRootPackage().getEClassifiers().get(1).getName());
 
@@ -105,7 +107,7 @@ public class CreateInstanceOperationHandlerTests {
 
         handleResult = this.createInstanceOperationHandler.handle(this.operationTestContext.getVariables());
 
-        assertEquals(Status.OK, handleResult);
+        assertTrue(handleResult instanceof Success);
         assertEquals(3, this.operationTestContext.getRootPackage().getEClassifiers().size());
         assertEquals(null, this.operationTestContext.getRootPackage().getEClassifiers().get(2).getName());
     }
@@ -123,9 +125,9 @@ public class CreateInstanceOperationHandlerTests {
         this.createInstanceOperation.setTypeName(TYPE_NAME);
         this.createInstanceOperation.setVariableName(VARIABLE_NAME);
 
-        Status handleResult = this.createInstanceOperationHandler.handle(this.operationTestContext.getVariables());
+        IStatus handleResult = this.createInstanceOperationHandler.handle(this.operationTestContext.getVariables());
 
-        assertEquals(Status.OK, handleResult);
+        assertTrue(handleResult instanceof Success);
         assertEquals(2, this.operationTestContext.getRootPackage().getEClassifiers().size());
         assertEquals(className, this.operationTestContext.getRootPackage().getEClassifiers().get(1).getName());
 
@@ -134,7 +136,7 @@ public class CreateInstanceOperationHandlerTests {
 
         handleResult = this.createInstanceOperationHandler.handle(this.operationTestContext.getVariables());
 
-        assertEquals(Status.OK, handleResult);
+        assertTrue(handleResult instanceof Success);
         assertEquals(3, this.operationTestContext.getRootPackage().getEClassifiers().size());
         assertEquals(className, this.operationTestContext.getRootPackage().getEClassifiers().get(2).getName());
     }
@@ -170,10 +172,10 @@ public class CreateInstanceOperationHandlerTests {
         this.createInstanceOperation.setTypeName(typeName);
         this.createInstanceOperation.setVariableName(variableName);
 
-        Status handleResult = this.createInstanceOperationHandler.handle(this.operationTestContext.getVariables());
+        IStatus handleResult = this.createInstanceOperationHandler.handle(this.operationTestContext.getVariables());
 
         // check
-        assertEquals(Status.OK, handleResult);
+        assertTrue(handleResult instanceof Success);
         assertEquals(newName, renamedElement.getName());
     }
 

--- a/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/compatibility/operations/ForOperationHandlerTests.java
+++ b/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/compatibility/operations/ForOperationHandlerTests.java
@@ -13,6 +13,7 @@
 package org.eclipse.sirius.web.emf.compatibility.operations;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.text.MessageFormat;
 import java.util.UUID;
@@ -23,7 +24,8 @@ import org.eclipse.sirius.viewpoint.description.tool.For;
 import org.eclipse.sirius.viewpoint.description.tool.ToolFactory;
 import org.eclipse.sirius.web.emf.compatibility.modeloperations.ChildModelOperationHandler;
 import org.eclipse.sirius.web.emf.compatibility.modeloperations.ForOperationHandler;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.IStatus;
+import org.eclipse.sirius.web.representations.Success;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -62,9 +64,9 @@ public class ForOperationHandlerTests {
         subChangeContext.setBrowseExpression("aql:self.renameENamedElementService(self.name+" + ITERATOR_VARIABLE_NAME + "))"); //$NON-NLS-1$//$NON-NLS-2$
         this.forOperation.getSubModelOperations().add(subChangeContext);
 
-        Status handleResult = this.forOperationHandler.handle(this.operationTestContext.getVariables());
+        IStatus handleResult = this.forOperationHandler.handle(this.operationTestContext.getVariables());
 
-        assertEquals(Status.OK, handleResult);
+        assertTrue(handleResult instanceof Success);
         assertEquals(OperationTestContext.ROOT_PACKAGE_NAME + "abc", this.operationTestContext.getRootPackage().getName()); //$NON-NLS-1$
 
     }
@@ -103,10 +105,10 @@ public class ForOperationHandlerTests {
         this.forOperation.setIteratorName(iteratorVariableName);
         this.forOperation.setExpression(expression);
 
-        Status handleResult = this.forOperationHandler.handle(this.operationTestContext.getVariables());
+        IStatus handleResult = this.forOperationHandler.handle(this.operationTestContext.getVariables());
 
         // check
-        assertEquals(Status.OK, handleResult);
+        assertTrue(handleResult instanceof Success);
         assertEquals(OperationTestContext.ROOT_PACKAGE_NAME, renamedElement.getName());
     }
 

--- a/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/compatibility/operations/IfOperationHandlerTests.java
+++ b/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/compatibility/operations/IfOperationHandlerTests.java
@@ -13,6 +13,7 @@
 package org.eclipse.sirius.web.emf.compatibility.operations;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.text.MessageFormat;
 import java.util.UUID;
@@ -23,7 +24,8 @@ import org.eclipse.sirius.viewpoint.description.tool.If;
 import org.eclipse.sirius.viewpoint.description.tool.ToolFactory;
 import org.eclipse.sirius.web.emf.compatibility.modeloperations.ChildModelOperationHandler;
 import org.eclipse.sirius.web.emf.compatibility.modeloperations.IfOperationHandler;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.IStatus;
+import org.eclipse.sirius.web.representations.Success;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -60,9 +62,9 @@ public class IfOperationHandlerTests {
         // check the nominal case
         this.ifOperation.setConditionExpression(AQL_TRUE);
 
-        Status handleResult = this.ifOperationHandler.handle(this.operationTestContext.getVariables());
+        IStatus handleResult = this.ifOperationHandler.handle(this.operationTestContext.getVariables());
 
-        assertEquals(Status.OK, handleResult);
+        assertTrue(handleResult instanceof Success);
         assertEquals(newName, this.operationTestContext.getRootPackage().getName());
 
     }
@@ -98,10 +100,10 @@ public class IfOperationHandlerTests {
         // execute
         this.ifOperation.setConditionExpression(conditionExpression);
 
-        Status handleResult = this.ifOperationHandler.handle(this.operationTestContext.getVariables());
+        IStatus handleResult = this.ifOperationHandler.handle(this.operationTestContext.getVariables());
 
         // check
-        assertEquals(Status.OK, handleResult);
+        assertTrue(handleResult instanceof Success);
         assertEquals(OperationTestContext.ROOT_PACKAGE_NAME, renamedElement.getName());
     }
 

--- a/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/compatibility/operations/LetOperationHandlerTests.java
+++ b/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/compatibility/operations/LetOperationHandlerTests.java
@@ -13,6 +13,7 @@
 package org.eclipse.sirius.web.emf.compatibility.operations;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.text.MessageFormat;
 import java.util.UUID;
@@ -23,7 +24,8 @@ import org.eclipse.sirius.viewpoint.description.tool.Let;
 import org.eclipse.sirius.viewpoint.description.tool.ToolFactory;
 import org.eclipse.sirius.web.emf.compatibility.modeloperations.ChildModelOperationHandler;
 import org.eclipse.sirius.web.emf.compatibility.modeloperations.LetOperationHandler;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.IStatus;
+import org.eclipse.sirius.web.representations.Success;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -61,9 +63,9 @@ public class LetOperationHandlerTests {
         this.letOperation.setVariableName(VARIABLE_NAME);
         this.letOperation.setValueExpression("aql:self"); //$NON-NLS-1$
 
-        Status handleResult = this.letOperationHandler.handle(this.operationTestContext.getVariables());
+        IStatus handleResult = this.letOperationHandler.handle(this.operationTestContext.getVariables());
 
-        assertEquals(Status.OK, handleResult);
+        assertTrue(handleResult instanceof Success);
         assertEquals(newName, this.operationTestContext.getRootPackage().getName());
 
     }
@@ -100,10 +102,10 @@ public class LetOperationHandlerTests {
         this.letOperation.setVariableName(variableName);
         this.letOperation.setValueExpression(setValueExpression);
 
-        Status handleResult = this.letOperationHandler.handle(this.operationTestContext.getVariables());
+        IStatus handleResult = this.letOperationHandler.handle(this.operationTestContext.getVariables());
 
         // check
-        assertEquals(Status.OK, handleResult);
+        assertTrue(handleResult instanceof Success);
         assertEquals(newName, renamedElement.getName());
     }
 }

--- a/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/compatibility/operations/MoveElementOperationHandlerTests.java
+++ b/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/compatibility/operations/MoveElementOperationHandlerTests.java
@@ -13,6 +13,7 @@
 package org.eclipse.sirius.web.emf.compatibility.operations;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.text.MessageFormat;
 import java.util.UUID;
@@ -25,7 +26,8 @@ import org.eclipse.sirius.viewpoint.description.tool.MoveElement;
 import org.eclipse.sirius.viewpoint.description.tool.ToolFactory;
 import org.eclipse.sirius.web.emf.compatibility.modeloperations.ChildModelOperationHandler;
 import org.eclipse.sirius.web.emf.compatibility.modeloperations.MoveElementOperationHandler;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.IStatus;
+import org.eclipse.sirius.web.representations.Success;
 import org.eclipse.sirius.web.representations.VariableManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -71,9 +73,9 @@ public class MoveElementOperationHandlerTests {
         this.moveElementOperation.setFeatureName(NAME_FEATURE);
         this.moveElementOperation.setNewContainerExpression(AQL_NEWCONTAINER_EXPRESSION);
 
-        Status handleResult = this.moveElementOperationHandler.handle(this.operationTestContext.getVariables());
+        IStatus handleResult = this.moveElementOperationHandler.handle(this.operationTestContext.getVariables());
 
-        assertEquals(Status.OK, handleResult);
+        assertTrue(handleResult instanceof Success);
         assertEquals(0, this.operationTestContext.getRootPackage().getEClassifiers().size());
         assertEquals(this.operationTestContext.getClass1(), this.subPackage1.getEClassifiers().get(0));
     }
@@ -112,10 +114,10 @@ public class MoveElementOperationHandlerTests {
         this.moveElementOperation.setFeatureName(featureName);
         this.moveElementOperation.setNewContainerExpression(newContainerExpression);
 
-        Status handleResult = this.moveElementOperationHandler.handle(this.operationTestContext.getVariables());
+        IStatus handleResult = this.moveElementOperationHandler.handle(this.operationTestContext.getVariables());
 
         // check
-        assertEquals(Status.OK, handleResult);
+        assertTrue(handleResult instanceof Success);
         assertEquals(newName, renamedElement.getName());
     }
 

--- a/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/compatibility/operations/RemoveElementOperationHandlerTests.java
+++ b/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/compatibility/operations/RemoveElementOperationHandlerTests.java
@@ -13,12 +13,14 @@
 package org.eclipse.sirius.web.emf.compatibility.operations;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.sirius.viewpoint.description.tool.RemoveElement;
 import org.eclipse.sirius.viewpoint.description.tool.ToolFactory;
 import org.eclipse.sirius.web.emf.compatibility.modeloperations.ChildModelOperationHandler;
 import org.eclipse.sirius.web.emf.compatibility.modeloperations.RemoveElementOperationHandler;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.IStatus;
+import org.eclipse.sirius.web.representations.Success;
 import org.eclipse.sirius.web.representations.VariableManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -48,9 +50,9 @@ public class RemoveElementOperationHandlerTests {
     @Test
     public void removeElementOperationHandlerNominalCaseTest() {
         // check the nominal case
-        Status handleResult = this.removeElementOperationHandler.handle(this.operationTestContext.getVariables());
+        IStatus handleResult = this.removeElementOperationHandler.handle(this.operationTestContext.getVariables());
 
-        assertEquals(Status.OK, handleResult);
+        assertTrue(handleResult instanceof Success);
         // the class1 under root package has been removed
         assertEquals(0, this.operationTestContext.getRootPackage().getEClassifiers().size());
 

--- a/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/compatibility/operations/SetValueOperationHandlerTests.java
+++ b/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/compatibility/operations/SetValueOperationHandlerTests.java
@@ -13,6 +13,7 @@
 package org.eclipse.sirius.web.emf.compatibility.operations;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.text.MessageFormat;
 import java.util.UUID;
@@ -23,7 +24,8 @@ import org.eclipse.sirius.viewpoint.description.tool.SetValue;
 import org.eclipse.sirius.viewpoint.description.tool.ToolFactory;
 import org.eclipse.sirius.web.emf.compatibility.modeloperations.ChildModelOperationHandler;
 import org.eclipse.sirius.web.emf.compatibility.modeloperations.SetValueOperationHandler;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.IStatus;
+import org.eclipse.sirius.web.representations.Success;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -56,9 +58,9 @@ public class SetValueOperationHandlerTests {
         this.setValue.setFeatureName(NAME_FEATURE);
         this.setValue.setValueExpression("aql:'" + newName + "'"); //$NON-NLS-1$//$NON-NLS-2$
 
-        Status handleResult = this.setValueOperationHandler.handle(this.operationTestContext.getVariables());
+        IStatus handleResult = this.setValueOperationHandler.handle(this.operationTestContext.getVariables());
 
-        assertEquals(Status.OK, handleResult);
+        assertTrue(handleResult instanceof Success);
         assertEquals(newName, this.operationTestContext.getRootPackage().getName());
     }
 
@@ -97,10 +99,10 @@ public class SetValueOperationHandlerTests {
         this.setValue.setFeatureName(featureName);
         this.setValue.setValueExpression(setValueExpression);
 
-        Status handleResult = this.setValueOperationHandler.handle(this.operationTestContext.getVariables());
+        IStatus handleResult = this.setValueOperationHandler.handle(this.operationTestContext.getVariables());
 
         // check
-        assertEquals(Status.OK, handleResult);
+        assertTrue(handleResult instanceof Success);
         assertEquals(newName, renamedElement.getName());
     }
 }

--- a/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/compatibility/operations/SwitchOperationHandlerTests.java
+++ b/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/compatibility/operations/SwitchOperationHandlerTests.java
@@ -13,6 +13,7 @@
 package org.eclipse.sirius.web.emf.compatibility.operations;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.text.MessageFormat;
 
@@ -23,7 +24,8 @@ import org.eclipse.sirius.viewpoint.description.tool.Switch;
 import org.eclipse.sirius.viewpoint.description.tool.ToolFactory;
 import org.eclipse.sirius.web.emf.compatibility.modeloperations.ChildModelOperationHandler;
 import org.eclipse.sirius.web.emf.compatibility.modeloperations.SwitchOperationHandler;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.IStatus;
+import org.eclipse.sirius.web.representations.Success;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -89,8 +91,8 @@ public class SwitchOperationHandlerTests {
         this.case1.setConditionExpression(expressionCase1);
         this.case2.setConditionExpression(expressionCase2);
 
-        Status handleResult = this.switchOperationHandler.handle(this.operationTestContext.getVariables());
-        assertEquals(Status.OK, handleResult);
+        IStatus handleResult = this.switchOperationHandler.handle(this.operationTestContext.getVariables());
+        assertTrue(handleResult instanceof Success);
         assertEquals(expectedRootName, this.operationTestContext.getRootPackage().getName());
     }
 

--- a/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/compatibility/operations/UnsetOperationHandlerTests.java
+++ b/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/compatibility/operations/UnsetOperationHandlerTests.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.sirius.web.emf.compatibility.operations;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.text.MessageFormat;
@@ -26,7 +27,8 @@ import org.eclipse.sirius.viewpoint.description.tool.ToolFactory;
 import org.eclipse.sirius.viewpoint.description.tool.Unset;
 import org.eclipse.sirius.web.emf.compatibility.modeloperations.ChildModelOperationHandler;
 import org.eclipse.sirius.web.emf.compatibility.modeloperations.UnsetOperationHandler;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.IStatus;
+import org.eclipse.sirius.web.representations.Success;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -70,9 +72,9 @@ public class UnsetOperationHandlerTests {
         this.unset.setFeatureName(NAME_FEATURE);
         this.unset.setElementExpression(null);
 
-        Status handleResult = this.unsetOperationHandler.handle(this.operationTestContext.getVariables());
+        IStatus handleResult = this.unsetOperationHandler.handle(this.operationTestContext.getVariables());
 
-        assertEquals(Status.OK, handleResult);
+        assertThat(handleResult).isInstanceOf(Success.class);
         assertEquals(null, this.operationTestContext.getRootPackage().getName());
 
         // check unset on mono value EStrucuralFeature
@@ -81,7 +83,7 @@ public class UnsetOperationHandlerTests {
 
         handleResult = this.unsetOperationHandler.handle(this.operationTestContext.getVariables());
 
-        assertEquals(Status.OK, handleResult);
+        assertThat(handleResult).isInstanceOf(Success.class);
         assertEquals(null, this.operationTestContext.getRootPackage().getEFactoryInstance());
     }
 
@@ -91,9 +93,9 @@ public class UnsetOperationHandlerTests {
         this.unset.setFeatureName(ECLASSIFIERS_FEATURE);
         this.unset.setElementExpression("aql:self.eClassifiers->first()"); //$NON-NLS-1$
         EClassifier secondClass = this.operationTestContext.getRootPackage().getEClassifiers().get(1);
-        Status handleResult = this.unsetOperationHandler.handle(this.operationTestContext.getVariables());
+        IStatus handleResult = this.unsetOperationHandler.handle(this.operationTestContext.getVariables());
 
-        assertEquals(Status.OK, handleResult);
+        assertThat(handleResult).isInstanceOf(Success.class);
         assertEquals(1, this.operationTestContext.getRootPackage().getEClassifiers().size());
         assertEquals(secondClass, this.operationTestContext.getRootPackage().getEClassifiers().get(0));
 
@@ -103,7 +105,7 @@ public class UnsetOperationHandlerTests {
 
         handleResult = this.unsetOperationHandler.handle(this.operationTestContext.getVariables());
 
-        assertEquals(Status.OK, handleResult);
+        assertThat(handleResult).isInstanceOf(Success.class);
         // This result is functionally unexpected but is the one in Sirius
         // The expected size is 0
         assertEquals(0, this.operationTestContext.getRootPackage().getEClassifiers().size());
@@ -137,9 +139,9 @@ public class UnsetOperationHandlerTests {
         this.unset.setFeatureName("aql:'na' + 'me'"); //$NON-NLS-1$
         this.unset.setElementExpression(null);
 
-        Status handleResult = this.unsetOperationHandler.handle(this.operationTestContext.getVariables());
+        IStatus handleResult = this.unsetOperationHandler.handle(this.operationTestContext.getVariables());
 
-        assertEquals(Status.OK, handleResult);
+        assertThat(handleResult).isInstanceOf(Success.class);
         assertEquals(null, this.operationTestContext.getRootPackage().getName());
     }
 
@@ -155,10 +157,10 @@ public class UnsetOperationHandlerTests {
         this.unset.setFeatureName(featureName);
         this.unset.setElementExpression(elementExpression);
 
-        Status handleResult = this.unsetOperationHandler.handle(this.operationTestContext.getVariables());
+        IStatus handleResult = this.unsetOperationHandler.handle(this.operationTestContext.getVariables());
 
         // check
-        assertEquals(Status.OK, handleResult);
+        assertThat(handleResult).isInstanceOf(Success.class);
         assertEquals(newName, renamedElement.getName());
     }
 

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/Checkbox.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/Checkbox.java
@@ -22,7 +22,7 @@ import org.eclipse.sirius.web.annotations.graphql.GraphQLField;
 import org.eclipse.sirius.web.annotations.graphql.GraphQLNonNull;
 import org.eclipse.sirius.web.annotations.graphql.GraphQLObjectType;
 import org.eclipse.sirius.web.forms.validation.Diagnostic;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.IStatus;
 
 /**
  * The checkbox widget.
@@ -36,7 +36,7 @@ public final class Checkbox extends AbstractWidget {
 
     private boolean value;
 
-    private Function<Boolean, Status> newValueHandler;
+    private Function<Boolean, IStatus> newValueHandler;
 
     private Checkbox() {
         // Prevent instantiation
@@ -54,7 +54,7 @@ public final class Checkbox extends AbstractWidget {
         return this.value;
     }
 
-    public Function<Boolean, Status> getNewValueHandler() {
+    public Function<Boolean, IStatus> getNewValueHandler() {
         return this.newValueHandler;
     }
 
@@ -81,7 +81,7 @@ public final class Checkbox extends AbstractWidget {
 
         private boolean value;
 
-        private Function<Boolean, Status> newValueHandler;
+        private Function<Boolean, IStatus> newValueHandler;
 
         private List<Diagnostic> diagnostics;
 
@@ -99,7 +99,7 @@ public final class Checkbox extends AbstractWidget {
             return this;
         }
 
-        public Builder newValueHandler(Function<Boolean, Status> handler) {
+        public Builder newValueHandler(Function<Boolean, IStatus> handler) {
             this.newValueHandler = Objects.requireNonNull(handler);
             return this;
         }

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/MultiSelect.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/MultiSelect.java
@@ -22,7 +22,7 @@ import org.eclipse.sirius.web.annotations.graphql.GraphQLField;
 import org.eclipse.sirius.web.annotations.graphql.GraphQLNonNull;
 import org.eclipse.sirius.web.annotations.graphql.GraphQLObjectType;
 import org.eclipse.sirius.web.forms.validation.Diagnostic;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.IStatus;
 
 /**
  * The select widget.
@@ -39,7 +39,7 @@ public final class MultiSelect extends AbstractWidget {
 
     private List<String> values;
 
-    private Function<List<String>, Status> newValuesHandler;
+    private Function<List<String>, IStatus> newValuesHandler;
 
     private MultiSelect() {
         // Prevent instantiation
@@ -62,7 +62,7 @@ public final class MultiSelect extends AbstractWidget {
         return this.values;
     }
 
-    public Function<List<String>, Status> getNewValuesHandler() {
+    public Function<List<String>, IStatus> getNewValuesHandler() {
         return this.newValuesHandler;
     }
 
@@ -91,7 +91,7 @@ public final class MultiSelect extends AbstractWidget {
 
         private List<String> values;
 
-        private Function<List<String>, Status> newValuesHandler;
+        private Function<List<String>, IStatus> newValuesHandler;
 
         private List<Diagnostic> diagnostics;
 
@@ -114,7 +114,7 @@ public final class MultiSelect extends AbstractWidget {
             return this;
         }
 
-        public Builder newValuesHandler(Function<List<String>, Status> newValuesHandler) {
+        public Builder newValuesHandler(Function<List<String>, IStatus> newValuesHandler) {
             this.newValuesHandler = Objects.requireNonNull(newValuesHandler);
             return this;
         }

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/Radio.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/Radio.java
@@ -22,7 +22,7 @@ import org.eclipse.sirius.web.annotations.graphql.GraphQLField;
 import org.eclipse.sirius.web.annotations.graphql.GraphQLNonNull;
 import org.eclipse.sirius.web.annotations.graphql.GraphQLObjectType;
 import org.eclipse.sirius.web.forms.validation.Diagnostic;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.IStatus;
 
 /**
  * The radio widget.
@@ -36,7 +36,7 @@ public final class Radio extends AbstractWidget {
 
     private List<RadioOption> options;
 
-    private Function<String, Status> newValueHandler;
+    private Function<String, IStatus> newValueHandler;
 
     private Radio() {
         // Prevent instantiation
@@ -54,7 +54,7 @@ public final class Radio extends AbstractWidget {
         return this.options;
     }
 
-    public Function<String, Status> getNewValueHandler() {
+    public Function<String, IStatus> getNewValueHandler() {
         return this.newValueHandler;
     }
 
@@ -81,7 +81,7 @@ public final class Radio extends AbstractWidget {
 
         private List<RadioOption> options;
 
-        private Function<String, Status> newValueHandler;
+        private Function<String, IStatus> newValueHandler;
 
         private List<Diagnostic> diagnostics;
 
@@ -99,7 +99,7 @@ public final class Radio extends AbstractWidget {
             return this;
         }
 
-        public Builder newValueHandler(Function<String, Status> newValueHandler) {
+        public Builder newValueHandler(Function<String, IStatus> newValueHandler) {
             this.newValueHandler = Objects.requireNonNull(newValueHandler);
             return this;
         }

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/Select.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/Select.java
@@ -22,7 +22,7 @@ import org.eclipse.sirius.web.annotations.graphql.GraphQLField;
 import org.eclipse.sirius.web.annotations.graphql.GraphQLNonNull;
 import org.eclipse.sirius.web.annotations.graphql.GraphQLObjectType;
 import org.eclipse.sirius.web.forms.validation.Diagnostic;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.IStatus;
 
 /**
  * The select widget.
@@ -38,7 +38,7 @@ public final class Select extends AbstractWidget {
 
     private String value;
 
-    private Function<String, Status> newValueHandler;
+    private Function<String, IStatus> newValueHandler;
 
     private Select() {
         // Prevent instantiation
@@ -61,7 +61,7 @@ public final class Select extends AbstractWidget {
         return this.value;
     }
 
-    public Function<String, Status> getNewValueHandler() {
+    public Function<String, IStatus> getNewValueHandler() {
         return this.newValueHandler;
     }
 
@@ -90,7 +90,7 @@ public final class Select extends AbstractWidget {
 
         private String value;
 
-        private Function<String, Status> newValueHandler;
+        private Function<String, IStatus> newValueHandler;
 
         private List<Diagnostic> diagnostics;
 
@@ -113,7 +113,7 @@ public final class Select extends AbstractWidget {
             return this;
         }
 
-        public Builder newValueHandler(Function<String, Status> newValueHandler) {
+        public Builder newValueHandler(Function<String, IStatus> newValueHandler) {
             this.newValueHandler = Objects.requireNonNull(newValueHandler);
             return this;
         }

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/Textfield.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/Textfield.java
@@ -22,7 +22,7 @@ import org.eclipse.sirius.web.annotations.graphql.GraphQLField;
 import org.eclipse.sirius.web.annotations.graphql.GraphQLNonNull;
 import org.eclipse.sirius.web.annotations.graphql.GraphQLObjectType;
 import org.eclipse.sirius.web.forms.validation.Diagnostic;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.IStatus;
 
 /**
  * The textfield widget.
@@ -36,7 +36,7 @@ public final class Textfield extends AbstractWidget {
 
     private String value;
 
-    private Function<String, Status> newValueHandler;
+    private Function<String, IStatus> newValueHandler;
 
     private Textfield() {
         // Prevent instantiation
@@ -54,7 +54,7 @@ public final class Textfield extends AbstractWidget {
         return this.value;
     }
 
-    public Function<String, Status> getNewValueHandler() {
+    public Function<String, IStatus> getNewValueHandler() {
         return this.newValueHandler;
     }
 
@@ -81,7 +81,7 @@ public final class Textfield extends AbstractWidget {
 
         private String value;
 
-        private Function<String, Status> newValueHandler;
+        private Function<String, IStatus> newValueHandler;
 
         private List<Diagnostic> diagnostics;
 
@@ -99,7 +99,7 @@ public final class Textfield extends AbstractWidget {
             return this;
         }
 
-        public Builder newValueHandler(Function<String, Status> newValueHandler) {
+        public Builder newValueHandler(Function<String, IStatus> newValueHandler) {
             this.newValueHandler = Objects.requireNonNull(newValueHandler);
             return this;
         }

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/components/CheckboxComponent.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/components/CheckboxComponent.java
@@ -23,7 +23,7 @@ import org.eclipse.sirius.web.forms.description.CheckboxDescription;
 import org.eclipse.sirius.web.forms.elements.CheckboxElementProps;
 import org.eclipse.sirius.web.forms.validation.DiagnosticComponent;
 import org.eclipse.sirius.web.forms.validation.DiagnosticComponentProps;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.IStatus;
 import org.eclipse.sirius.web.representations.VariableManager;
 
 /**
@@ -47,8 +47,8 @@ public class CheckboxComponent implements IComponent {
         String id = checkboxDescription.getIdProvider().apply(variableManager);
         String label = checkboxDescription.getLabelProvider().apply(variableManager);
         Boolean value = checkboxDescription.getValueProvider().apply(variableManager);
-        BiFunction<VariableManager, Boolean, Status> genericHandler = checkboxDescription.getNewValueHandler();
-        Function<Boolean, Status> specializedHandler = newValue -> genericHandler.apply(variableManager, newValue);
+        BiFunction<VariableManager, Boolean, IStatus> genericHandler = checkboxDescription.getNewValueHandler();
+        Function<Boolean, IStatus> specializedHandler = newValue -> genericHandler.apply(variableManager, newValue);
 
         List<Element> children = List.of(new Element(DiagnosticComponent.class, new DiagnosticComponentProps(checkboxDescription, variableManager)));
 

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/components/MultiSelectComponent.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/components/MultiSelectComponent.java
@@ -24,7 +24,7 @@ import org.eclipse.sirius.web.forms.description.MultiSelectDescription;
 import org.eclipse.sirius.web.forms.elements.MultiSelectElementProps;
 import org.eclipse.sirius.web.forms.validation.DiagnosticComponent;
 import org.eclipse.sirius.web.forms.validation.DiagnosticComponentProps;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.IStatus;
 import org.eclipse.sirius.web.representations.VariableManager;
 
 /**
@@ -71,7 +71,7 @@ public class MultiSelectComponent implements IComponent {
 
             options.add(option);
         }
-        Function<List<String>, Status> newValuesHandler = newValues -> {
+        Function<List<String>, IStatus> newValuesHandler = newValues -> {
             return multiSelectDescription.getNewValuesHandler().apply(variableManager, newValues);
         };
 

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/components/RadioComponent.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/components/RadioComponent.java
@@ -25,7 +25,7 @@ import org.eclipse.sirius.web.forms.description.RadioDescription;
 import org.eclipse.sirius.web.forms.elements.RadioElementProps;
 import org.eclipse.sirius.web.forms.validation.DiagnosticComponent;
 import org.eclipse.sirius.web.forms.validation.DiagnosticComponentProps;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.IStatus;
 import org.eclipse.sirius.web.representations.VariableManager;
 
 /**
@@ -73,8 +73,8 @@ public class RadioComponent implements IComponent {
             options.add(option);
         }
 
-        BiFunction<VariableManager, String, Status> genericHandler = radioDescription.getNewValueHandler();
-        Function<String, Status> specializedHandler = newValue -> {
+        BiFunction<VariableManager, String, IStatus> genericHandler = radioDescription.getNewValueHandler();
+        Function<String, IStatus> specializedHandler = newValue -> {
             return genericHandler.apply(variableManager, newValue);
         };
 

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/components/SelectComponent.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/components/SelectComponent.java
@@ -24,7 +24,7 @@ import org.eclipse.sirius.web.forms.description.SelectDescription;
 import org.eclipse.sirius.web.forms.elements.SelectElementProps;
 import org.eclipse.sirius.web.forms.validation.DiagnosticComponent;
 import org.eclipse.sirius.web.forms.validation.DiagnosticComponentProps;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.IStatus;
 import org.eclipse.sirius.web.representations.VariableManager;
 
 /**
@@ -70,7 +70,7 @@ public class SelectComponent implements IComponent {
 
             options.add(option);
         }
-        Function<String, Status> specializedHandler = newValue -> {
+        Function<String, IStatus> specializedHandler = newValue -> {
             return selectDescription.getNewValueHandler().apply(variableManager, newValue);
         };
 

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/components/TextareaComponent.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/components/TextareaComponent.java
@@ -22,7 +22,7 @@ import org.eclipse.sirius.web.forms.description.TextareaDescription;
 import org.eclipse.sirius.web.forms.elements.TextareaElementProps;
 import org.eclipse.sirius.web.forms.validation.DiagnosticComponent;
 import org.eclipse.sirius.web.forms.validation.DiagnosticComponentProps;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.IStatus;
 import org.eclipse.sirius.web.representations.VariableManager;
 
 /**
@@ -46,7 +46,7 @@ public class TextareaComponent implements IComponent {
         String id = textareaDescription.getIdProvider().apply(variableManager);
         String label = textareaDescription.getLabelProvider().apply(variableManager);
         String value = textareaDescription.getValueProvider().apply(variableManager);
-        Function<String, Status> specializedHandler = newValue -> {
+        Function<String, IStatus> specializedHandler = newValue -> {
             return textareaDescription.getNewValueHandler().apply(variableManager, newValue);
         };
 

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/components/TextfieldComponent.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/components/TextfieldComponent.java
@@ -23,7 +23,7 @@ import org.eclipse.sirius.web.forms.description.TextfieldDescription;
 import org.eclipse.sirius.web.forms.elements.TextfieldElementProps;
 import org.eclipse.sirius.web.forms.validation.DiagnosticComponent;
 import org.eclipse.sirius.web.forms.validation.DiagnosticComponentProps;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.IStatus;
 import org.eclipse.sirius.web.representations.VariableManager;
 
 /**
@@ -47,8 +47,8 @@ public class TextfieldComponent implements IComponent {
         String id = textfieldDescription.getIdProvider().apply(variableManager);
         String label = textfieldDescription.getLabelProvider().apply(variableManager);
         String value = textfieldDescription.getValueProvider().apply(variableManager);
-        BiFunction<VariableManager, String, Status> genericHandler = textfieldDescription.getNewValueHandler();
-        Function<String, Status> specializedHandler = newValue -> {
+        BiFunction<VariableManager, String, IStatus> genericHandler = textfieldDescription.getNewValueHandler();
+        Function<String, IStatus> specializedHandler = newValue -> {
             return genericHandler.apply(variableManager, newValue);
         };
         List<Element> children = List.of(new Element(DiagnosticComponent.class, new DiagnosticComponentProps(textfieldDescription, variableManager)));

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/description/CheckboxDescription.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/description/CheckboxDescription.java
@@ -19,7 +19,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import org.eclipse.sirius.web.annotations.Immutable;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.IStatus;
 import org.eclipse.sirius.web.representations.VariableManager;
 
 /**
@@ -36,7 +36,7 @@ public final class CheckboxDescription extends AbstractWidgetDescription {
 
     private Function<VariableManager, Boolean> valueProvider;
 
-    private BiFunction<VariableManager, Boolean, Status> newValueHandler;
+    private BiFunction<VariableManager, Boolean, IStatus> newValueHandler;
 
     private CheckboxDescription() {
         // Prevent instantiation
@@ -54,7 +54,7 @@ public final class CheckboxDescription extends AbstractWidgetDescription {
         return this.valueProvider;
     }
 
-    public BiFunction<VariableManager, Boolean, Status> getNewValueHandler() {
+    public BiFunction<VariableManager, Boolean, IStatus> getNewValueHandler() {
         return this.newValueHandler;
     }
 
@@ -83,7 +83,7 @@ public final class CheckboxDescription extends AbstractWidgetDescription {
 
         private Function<VariableManager, Boolean> valueProvider;
 
-        private BiFunction<VariableManager, Boolean, Status> newValueHandler;
+        private BiFunction<VariableManager, Boolean, IStatus> newValueHandler;
 
         private Function<VariableManager, List<Object>> diagnosticsProvider;
 
@@ -110,7 +110,7 @@ public final class CheckboxDescription extends AbstractWidgetDescription {
             return this;
         }
 
-        public Builder newValueHandler(BiFunction<VariableManager, Boolean, Status> newValueHandler) {
+        public Builder newValueHandler(BiFunction<VariableManager, Boolean, IStatus> newValueHandler) {
             this.newValueHandler = Objects.requireNonNull(newValueHandler);
             return this;
         }

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/description/MultiSelectDescription.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/description/MultiSelectDescription.java
@@ -19,7 +19,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import org.eclipse.sirius.web.annotations.Immutable;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.IStatus;
 import org.eclipse.sirius.web.representations.VariableManager;
 
 /**
@@ -43,7 +43,7 @@ public final class MultiSelectDescription extends AbstractWidgetDescription {
 
     private Function<VariableManager, List<String>> valuesProvider;
 
-    private BiFunction<VariableManager, List<String>, Status> newValuesHandler;
+    private BiFunction<VariableManager, List<String>, IStatus> newValuesHandler;
 
     private MultiSelectDescription() {
         // Prevent instantiation
@@ -73,7 +73,7 @@ public final class MultiSelectDescription extends AbstractWidgetDescription {
         return this.valuesProvider;
     }
 
-    public BiFunction<VariableManager, List<String>, Status> getNewValuesHandler() {
+    public BiFunction<VariableManager, List<String>, IStatus> getNewValuesHandler() {
         return this.newValuesHandler;
     }
 
@@ -109,7 +109,7 @@ public final class MultiSelectDescription extends AbstractWidgetDescription {
 
         private Function<VariableManager, List<String>> valuesProvider;
 
-        private BiFunction<VariableManager, List<String>, Status> newValuesHandler;
+        private BiFunction<VariableManager, List<String>, IStatus> newValuesHandler;
 
         private Function<VariableManager, List<Object>> diagnosticsProvider;
 
@@ -151,7 +151,7 @@ public final class MultiSelectDescription extends AbstractWidgetDescription {
             return this;
         }
 
-        public Builder newValuesHandler(BiFunction<VariableManager, List<String>, Status> newValuesHandler) {
+        public Builder newValuesHandler(BiFunction<VariableManager, List<String>, IStatus> newValuesHandler) {
             this.newValuesHandler = Objects.requireNonNull(newValuesHandler);
             return this;
         }

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/description/RadioDescription.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/description/RadioDescription.java
@@ -19,7 +19,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import org.eclipse.sirius.web.annotations.Immutable;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.IStatus;
 import org.eclipse.sirius.web.representations.VariableManager;
 
 /**
@@ -42,7 +42,7 @@ public final class RadioDescription extends AbstractWidgetDescription {
 
     private Function<VariableManager, Boolean> optionSelectedProvider;
 
-    private BiFunction<VariableManager, String, Status> newValueHandler;
+    private BiFunction<VariableManager, String, IStatus> newValueHandler;
 
     private RadioDescription() {
         // Prevent instantiation
@@ -72,7 +72,7 @@ public final class RadioDescription extends AbstractWidgetDescription {
         return this.optionSelectedProvider;
     }
 
-    public BiFunction<VariableManager, String, Status> getNewValueHandler() {
+    public BiFunction<VariableManager, String, IStatus> getNewValueHandler() {
         return this.newValueHandler;
     }
 
@@ -107,7 +107,7 @@ public final class RadioDescription extends AbstractWidgetDescription {
 
         private Function<VariableManager, Boolean> optionSelectedProvider;
 
-        private BiFunction<VariableManager, String, Status> newValueHandler;
+        private BiFunction<VariableManager, String, IStatus> newValueHandler;
 
         private Function<VariableManager, List<Object>> diagnosticsProvider;
 
@@ -149,7 +149,7 @@ public final class RadioDescription extends AbstractWidgetDescription {
             return this;
         }
 
-        public Builder newValueHandler(BiFunction<VariableManager, String, Status> newValueHandler) {
+        public Builder newValueHandler(BiFunction<VariableManager, String, IStatus> newValueHandler) {
             this.newValueHandler = Objects.requireNonNull(newValueHandler);
             return this;
         }

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/description/SelectDescription.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/description/SelectDescription.java
@@ -19,7 +19,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import org.eclipse.sirius.web.annotations.Immutable;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.IStatus;
 import org.eclipse.sirius.web.representations.VariableManager;
 
 /**
@@ -42,7 +42,7 @@ public final class SelectDescription extends AbstractWidgetDescription {
 
     private Function<VariableManager, String> valueProvider;
 
-    private BiFunction<VariableManager, String, Status> newValueHandler;
+    private BiFunction<VariableManager, String, IStatus> newValueHandler;
 
     private SelectDescription() {
         // Prevent instantiation
@@ -72,7 +72,7 @@ public final class SelectDescription extends AbstractWidgetDescription {
         return this.valueProvider;
     }
 
-    public BiFunction<VariableManager, String, Status> getNewValueHandler() {
+    public BiFunction<VariableManager, String, IStatus> getNewValueHandler() {
         return this.newValueHandler;
     }
 
@@ -107,7 +107,7 @@ public final class SelectDescription extends AbstractWidgetDescription {
 
         private Function<VariableManager, String> valueProvider;
 
-        private BiFunction<VariableManager, String, Status> newValueHandler;
+        private BiFunction<VariableManager, String, IStatus> newValueHandler;
 
         private Function<VariableManager, List<Object>> diagnosticsProvider;
 
@@ -149,7 +149,7 @@ public final class SelectDescription extends AbstractWidgetDescription {
             return this;
         }
 
-        public Builder newValueHandler(BiFunction<VariableManager, String, Status> newValueHandler) {
+        public Builder newValueHandler(BiFunction<VariableManager, String, IStatus> newValueHandler) {
             this.newValueHandler = Objects.requireNonNull(newValueHandler);
             return this;
         }

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/description/TextareaDescription.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/description/TextareaDescription.java
@@ -19,7 +19,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import org.eclipse.sirius.web.annotations.Immutable;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.IStatus;
 import org.eclipse.sirius.web.representations.VariableManager;
 
 /**
@@ -35,7 +35,7 @@ public final class TextareaDescription extends AbstractWidgetDescription {
 
     private Function<VariableManager, String> valueProvider;
 
-    private BiFunction<VariableManager, String, Status> newValueHandler;
+    private BiFunction<VariableManager, String, IStatus> newValueHandler;
 
     private TextareaDescription() {
         // Prevent instantiation
@@ -53,7 +53,7 @@ public final class TextareaDescription extends AbstractWidgetDescription {
         return this.valueProvider;
     }
 
-    public BiFunction<VariableManager, String, Status> getNewValueHandler() {
+    public BiFunction<VariableManager, String, IStatus> getNewValueHandler() {
         return this.newValueHandler;
     }
 
@@ -83,7 +83,7 @@ public final class TextareaDescription extends AbstractWidgetDescription {
 
         private Function<VariableManager, String> valueProvider;
 
-        private BiFunction<VariableManager, String, Status> newValueHandler;
+        private BiFunction<VariableManager, String, IStatus> newValueHandler;
 
         private Function<VariableManager, List<Object>> diagnosticsProvider;
 
@@ -110,7 +110,7 @@ public final class TextareaDescription extends AbstractWidgetDescription {
             return this;
         }
 
-        public Builder newValueHandler(BiFunction<VariableManager, String, Status> newValueHandler) {
+        public Builder newValueHandler(BiFunction<VariableManager, String, IStatus> newValueHandler) {
             this.newValueHandler = Objects.requireNonNull(newValueHandler);
             return this;
         }

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/description/TextfieldDescription.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/description/TextfieldDescription.java
@@ -19,7 +19,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import org.eclipse.sirius.web.annotations.Immutable;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.IStatus;
 import org.eclipse.sirius.web.representations.VariableManager;
 
 /**
@@ -35,7 +35,7 @@ public final class TextfieldDescription extends AbstractWidgetDescription {
 
     private Function<VariableManager, String> valueProvider;
 
-    private BiFunction<VariableManager, String, Status> newValueHandler;
+    private BiFunction<VariableManager, String, IStatus> newValueHandler;
 
     private TextfieldDescription() {
         // Prevent instantiation
@@ -53,7 +53,7 @@ public final class TextfieldDescription extends AbstractWidgetDescription {
         return this.valueProvider;
     }
 
-    public BiFunction<VariableManager, String, Status> getNewValueHandler() {
+    public BiFunction<VariableManager, String, IStatus> getNewValueHandler() {
         return this.newValueHandler;
     }
 
@@ -82,7 +82,7 @@ public final class TextfieldDescription extends AbstractWidgetDescription {
 
         private Function<VariableManager, String> valueProvider;
 
-        private BiFunction<VariableManager, String, Status> newValueHandler;
+        private BiFunction<VariableManager, String, IStatus> newValueHandler;
 
         private Function<VariableManager, List<Object>> diagnosticsProvider;
 
@@ -109,7 +109,7 @@ public final class TextfieldDescription extends AbstractWidgetDescription {
             return this;
         }
 
-        public Builder newValueHandler(BiFunction<VariableManager, String, Status> newValueHandler) {
+        public Builder newValueHandler(BiFunction<VariableManager, String, IStatus> newValueHandler) {
             this.newValueHandler = Objects.requireNonNull(newValueHandler);
             return this;
         }

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/elements/CheckboxElementProps.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/elements/CheckboxElementProps.java
@@ -20,7 +20,7 @@ import java.util.function.Function;
 import org.eclipse.sirius.web.annotations.Immutable;
 import org.eclipse.sirius.web.components.Element;
 import org.eclipse.sirius.web.components.IProps;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.IStatus;
 
 /**
  * The properties of the checkbox element.
@@ -37,7 +37,7 @@ public final class CheckboxElementProps implements IProps {
 
     private boolean value;
 
-    private Function<Boolean, Status> newValueHandler;
+    private Function<Boolean, IStatus> newValueHandler;
 
     private List<Element> children;
 
@@ -57,7 +57,7 @@ public final class CheckboxElementProps implements IProps {
         return this.value;
     }
 
-    public Function<Boolean, Status> getNewValueHandler() {
+    public Function<Boolean, IStatus> getNewValueHandler() {
         return this.newValueHandler;
     }
 
@@ -89,7 +89,7 @@ public final class CheckboxElementProps implements IProps {
 
         private boolean value;
 
-        private Function<Boolean, Status> newValueHandler;
+        private Function<Boolean, IStatus> newValueHandler;
 
         private List<Element> children;
 
@@ -107,7 +107,7 @@ public final class CheckboxElementProps implements IProps {
             return this;
         }
 
-        public Builder newValueHandler(Function<Boolean, Status> newValueHandler) {
+        public Builder newValueHandler(Function<Boolean, IStatus> newValueHandler) {
             this.newValueHandler = Objects.requireNonNull(newValueHandler);
             return this;
         }

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/elements/MultiSelectElementProps.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/elements/MultiSelectElementProps.java
@@ -21,7 +21,7 @@ import org.eclipse.sirius.web.annotations.Immutable;
 import org.eclipse.sirius.web.components.Element;
 import org.eclipse.sirius.web.components.IProps;
 import org.eclipse.sirius.web.forms.SelectOption;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.IStatus;
 
 /**
  * The properties of the multi-select element.
@@ -41,7 +41,7 @@ public final class MultiSelectElementProps implements IProps {
 
     private List<String> values;
 
-    private Function<List<String>, Status> newValuesHandler;
+    private Function<List<String>, IStatus> newValuesHandler;
 
     private List<Element> children;
 
@@ -65,7 +65,7 @@ public final class MultiSelectElementProps implements IProps {
         return this.values;
     }
 
-    public Function<List<String>, Status> getNewValuesHandler() {
+    public Function<List<String>, IStatus> getNewValuesHandler() {
         return this.newValuesHandler;
     }
 
@@ -100,7 +100,7 @@ public final class MultiSelectElementProps implements IProps {
 
         private List<String> values;
 
-        private Function<List<String>, Status> newValuesHandler;
+        private Function<List<String>, IStatus> newValuesHandler;
 
         private List<Element> children;
 
@@ -123,7 +123,7 @@ public final class MultiSelectElementProps implements IProps {
             return this;
         }
 
-        public Builder newValuesHandler(Function<List<String>, Status> newValuesHandler) {
+        public Builder newValuesHandler(Function<List<String>, IStatus> newValuesHandler) {
             this.newValuesHandler = Objects.requireNonNull(newValuesHandler);
             return this;
         }

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/elements/RadioElementProps.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/elements/RadioElementProps.java
@@ -21,7 +21,7 @@ import org.eclipse.sirius.web.annotations.Immutable;
 import org.eclipse.sirius.web.components.Element;
 import org.eclipse.sirius.web.components.IProps;
 import org.eclipse.sirius.web.forms.RadioOption;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.IStatus;
 
 /**
  * The properties of the radio element.
@@ -38,7 +38,7 @@ public final class RadioElementProps implements IProps {
 
     private List<RadioOption> options;
 
-    private Function<String, Status> newValueHandler;
+    private Function<String, IStatus> newValueHandler;
 
     private List<Element> children;
 
@@ -58,7 +58,7 @@ public final class RadioElementProps implements IProps {
         return this.options;
     }
 
-    public Function<String, Status> getNewValueHandler() {
+    public Function<String, IStatus> getNewValueHandler() {
         return this.newValueHandler;
     }
 
@@ -90,7 +90,7 @@ public final class RadioElementProps implements IProps {
 
         private List<RadioOption> options;
 
-        private Function<String, Status> newValueHandler;
+        private Function<String, IStatus> newValueHandler;
 
         private List<Element> children;
 
@@ -108,7 +108,7 @@ public final class RadioElementProps implements IProps {
             return this;
         }
 
-        public Builder newValueHandler(Function<String, Status> newValueHandler) {
+        public Builder newValueHandler(Function<String, IStatus> newValueHandler) {
             this.newValueHandler = Objects.requireNonNull(newValueHandler);
             return this;
         }

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/elements/SelectElementProps.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/elements/SelectElementProps.java
@@ -21,7 +21,7 @@ import org.eclipse.sirius.web.annotations.Immutable;
 import org.eclipse.sirius.web.components.Element;
 import org.eclipse.sirius.web.components.IProps;
 import org.eclipse.sirius.web.forms.SelectOption;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.IStatus;
 
 /**
  * The properties of the select element.
@@ -40,7 +40,7 @@ public final class SelectElementProps implements IProps {
 
     private String value;
 
-    private Function<String, Status> newValueHandler;
+    private Function<String, IStatus> newValueHandler;
 
     private List<Element> children;
 
@@ -64,7 +64,7 @@ public final class SelectElementProps implements IProps {
         return this.value;
     }
 
-    public Function<String, Status> getNewValueHandler() {
+    public Function<String, IStatus> getNewValueHandler() {
         return this.newValueHandler;
     }
 
@@ -99,7 +99,7 @@ public final class SelectElementProps implements IProps {
 
         private String value;
 
-        private Function<String, Status> newValueHandler;
+        private Function<String, IStatus> newValueHandler;
 
         private List<Element> children;
 
@@ -122,7 +122,7 @@ public final class SelectElementProps implements IProps {
             return this;
         }
 
-        public Builder newValueHandler(Function<String, Status> handler) {
+        public Builder newValueHandler(Function<String, IStatus> handler) {
             this.newValueHandler = Objects.requireNonNull(handler);
             return this;
         }

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/elements/TextareaElementProps.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/elements/TextareaElementProps.java
@@ -20,7 +20,7 @@ import java.util.function.Function;
 import org.eclipse.sirius.web.annotations.Immutable;
 import org.eclipse.sirius.web.components.Element;
 import org.eclipse.sirius.web.components.IProps;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.IStatus;
 
 /**
  * The properties of the textarea element.
@@ -37,7 +37,7 @@ public final class TextareaElementProps implements IProps {
 
     private String value;
 
-    private Function<String, Status> newValueHandler;
+    private Function<String, IStatus> newValueHandler;
 
     private List<Element> children;
 
@@ -57,7 +57,7 @@ public final class TextareaElementProps implements IProps {
         return this.value;
     }
 
-    public Function<String, Status> getNewValueHandler() {
+    public Function<String, IStatus> getNewValueHandler() {
         return this.newValueHandler;
     }
 
@@ -89,7 +89,7 @@ public final class TextareaElementProps implements IProps {
 
         private String value;
 
-        private Function<String, Status> newValueHandler;
+        private Function<String, IStatus> newValueHandler;
 
         private List<Element> children;
 
@@ -107,7 +107,7 @@ public final class TextareaElementProps implements IProps {
             return this;
         }
 
-        public Builder newValueHandler(Function<String, Status> handler) {
+        public Builder newValueHandler(Function<String, IStatus> handler) {
             this.newValueHandler = Objects.requireNonNull(handler);
             return this;
         }

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/elements/TextfieldElementProps.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/elements/TextfieldElementProps.java
@@ -20,7 +20,7 @@ import java.util.function.Function;
 import org.eclipse.sirius.web.annotations.Immutable;
 import org.eclipse.sirius.web.components.Element;
 import org.eclipse.sirius.web.components.IProps;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.IStatus;
 
 /**
  * The properties of the textfield element.
@@ -37,7 +37,7 @@ public final class TextfieldElementProps implements IProps {
 
     private String value;
 
-    private Function<String, Status> newValueHandler;
+    private Function<String, IStatus> newValueHandler;
 
     private List<Element> children;
 
@@ -62,7 +62,7 @@ public final class TextfieldElementProps implements IProps {
         return this.children;
     }
 
-    public Function<String, Status> getNewValueHandler() {
+    public Function<String, IStatus> getNewValueHandler() {
         return this.newValueHandler;
     }
 
@@ -89,7 +89,7 @@ public final class TextfieldElementProps implements IProps {
 
         private String value;
 
-        private Function<String, Status> newValueHandler;
+        private Function<String, IStatus> newValueHandler;
 
         private List<Element> children;
 
@@ -107,7 +107,7 @@ public final class TextfieldElementProps implements IProps {
             return this;
         }
 
-        public Builder newValueHandler(Function<String, Status> handler) {
+        public Builder newValueHandler(Function<String, IStatus> handler) {
             this.newValueHandler = Objects.requireNonNull(handler);
             return this;
         }

--- a/backend/sirius-web-representations/src/main/java/org/eclipse/sirius/web/representations/Failure.java
+++ b/backend/sirius-web-representations/src/main/java/org/eclipse/sirius/web/representations/Failure.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 Obeo.
+ * Copyright (c) 2021 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -10,17 +10,24 @@
  * Contributors:
  *     Obeo - initial API and implementation
  *******************************************************************************/
-package org.eclipse.sirius.web.compat.api;
+package org.eclipse.sirius.web.representations;
 
-import java.util.Map;
-
-import org.eclipse.sirius.web.representations.IStatus;
+import java.util.Objects;
 
 /**
- * Used to handle a Sirius model operation.
+ * The message when the representation description handler fails.
  *
- * @author sbegaudeau
+ * @author gcoutable
  */
-public interface IModelOperationHandler {
-    IStatus handle(Map<String, Object> variables);
+public class Failure implements IStatus {
+
+    private final String message;
+
+    public Failure(String message) {
+        this.message = Objects.requireNonNull(message);
+    }
+
+    public String getMessage() {
+        return this.message;
+    }
 }

--- a/backend/sirius-web-representations/src/main/java/org/eclipse/sirius/web/representations/IStatus.java
+++ b/backend/sirius-web-representations/src/main/java/org/eclipse/sirius/web/representations/IStatus.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Obeo.
+ * Copyright (c) 2021 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -13,10 +13,10 @@
 package org.eclipse.sirius.web.representations;
 
 /**
- * Status of the operation executed.
+ * The Status that should be return by representation description handlers.
  *
- * @author sbegaudeau
+ * @author gcoutable
  */
-public enum Status {
-    OK, ERROR
+public interface IStatus {
+
 }

--- a/backend/sirius-web-representations/src/main/java/org/eclipse/sirius/web/representations/Success.java
+++ b/backend/sirius-web-representations/src/main/java/org/eclipse/sirius/web/representations/Success.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 Obeo.
+ * Copyright (c) 2021 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -10,17 +10,13 @@
  * Contributors:
  *     Obeo - initial API and implementation
  *******************************************************************************/
-package org.eclipse.sirius.web.compat.api;
-
-import java.util.Map;
-
-import org.eclipse.sirius.web.representations.IStatus;
+package org.eclipse.sirius.web.representations;
 
 /**
- * Used to handle a Sirius model operation.
+ * The status to return when the representation description handler success.
  *
- * @author sbegaudeau
+ * @author gcoutable
  */
-public interface IModelOperationHandler {
-    IStatus handle(Map<String, Object> variables);
+public class Success implements IStatus {
+
 }

--- a/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/handlers/DeleteFromDiagramEventHandler.java
+++ b/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/handlers/DeleteFromDiagramEventHandler.java
@@ -29,7 +29,9 @@ import org.eclipse.sirius.web.diagrams.Node;
 import org.eclipse.sirius.web.diagrams.description.DiagramDescription;
 import org.eclipse.sirius.web.diagrams.description.EdgeDescription;
 import org.eclipse.sirius.web.diagrams.description.NodeDescription;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.Failure;
+import org.eclipse.sirius.web.representations.IStatus;
+import org.eclipse.sirius.web.representations.Success;
 import org.eclipse.sirius.web.representations.VariableManager;
 import org.eclipse.sirius.web.spring.collaborative.api.ChangeDescription;
 import org.eclipse.sirius.web.spring.collaborative.api.ChangeKind;
@@ -114,8 +116,8 @@ public class DeleteFromDiagramEventHandler implements IDiagramEventHandler {
         for (UUID edgeId : diagramInput.getEdgeIds()) {
             var optionalElement = this.diagramQueryService.findEdgeById(diagram, edgeId);
             if (optionalElement.isPresent()) {
-                Status status = this.invokeDeleteEdgeTool(optionalElement.get(), editingContext, diagramContext);
-                if (Status.OK == status) {
+                IStatus status = this.invokeDeleteEdgeTool(optionalElement.get(), editingContext, diagramContext);
+                if (status instanceof Success) {
                     atLeastOneOk = true;
                 }
             } else {
@@ -126,8 +128,8 @@ public class DeleteFromDiagramEventHandler implements IDiagramEventHandler {
         for (UUID nodeId : diagramInput.getNodeIds()) {
             var optionalElement = this.diagramQueryService.findNodeById(diagram, nodeId);
             if (optionalElement.isPresent()) {
-                Status status = this.invokeDeleteNodeTool(optionalElement.get(), editingContext, diagramContext);
-                if (Status.OK == status) {
+                IStatus status = this.invokeDeleteNodeTool(optionalElement.get(), editingContext, diagramContext);
+                if (status instanceof Success) {
                     atLeastOneOk = true;
                 }
             } else {
@@ -163,9 +165,10 @@ public class DeleteFromDiagramEventHandler implements IDiagramEventHandler {
         changeDescriptionSink.tryEmitNext(changeDescription);
     }
 
-    private Status invokeDeleteNodeTool(Node node, IEditingContext editingContext, IDiagramContext diagramContext) {
-        Status result = Status.ERROR;
+    private IStatus invokeDeleteNodeTool(Node node, IEditingContext editingContext, IDiagramContext diagramContext) {
+        IStatus result = new Failure(""); //$NON-NLS-1$
         var optionalNodeDescription = this.findNodeDescription(node, diagramContext.getDiagram(), editingContext);
+
         if (optionalNodeDescription.isPresent()) {
             var optionalSelf = this.objectService.getObject(editingContext, node.getTargetObjectId());
             if (optionalSelf.isPresent()) {
@@ -187,8 +190,8 @@ public class DeleteFromDiagramEventHandler implements IDiagramEventHandler {
         return result;
     }
 
-    private Status invokeDeleteEdgeTool(Edge edge, IEditingContext editingContext, IDiagramContext diagramContext) {
-        Status result = Status.ERROR;
+    private IStatus invokeDeleteEdgeTool(Edge edge, IEditingContext editingContext, IDiagramContext diagramContext) {
+        IStatus result = new Failure(""); //$NON-NLS-1$
         var optionalEdgeDescription = this.findEdgeDescription(edge, diagramContext.getDiagram(), editingContext);
         if (optionalEdgeDescription.isPresent()) {
             var optionalSelf = this.objectService.getObject(editingContext, edge.getTargetObjectId());

--- a/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/handlers/InvokeEdgeToolOnDiagramEventHandler.java
+++ b/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/handlers/InvokeEdgeToolOnDiagramEventHandler.java
@@ -24,7 +24,9 @@ import org.eclipse.sirius.web.diagrams.Diagram;
 import org.eclipse.sirius.web.diagrams.Node;
 import org.eclipse.sirius.web.diagrams.description.EdgeDescription;
 import org.eclipse.sirius.web.diagrams.tools.CreateEdgeTool;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.Failure;
+import org.eclipse.sirius.web.representations.IStatus;
+import org.eclipse.sirius.web.representations.Success;
 import org.eclipse.sirius.web.representations.VariableManager;
 import org.eclipse.sirius.web.spring.collaborative.api.ChangeDescription;
 import org.eclipse.sirius.web.spring.collaborative.api.ChangeKind;
@@ -99,8 +101,8 @@ public class InvokeEdgeToolOnDiagramEventHandler implements IDiagramEventHandler
                     .map(CreateEdgeTool.class::cast);
             // @formatter:on
             if (optionalTool.isPresent()) {
-                Status status = this.executeTool(editingContext, diagramContext, input.getDiagramSourceElementId(), input.getDiagramTargetElementId(), optionalTool.get());
-                if (Objects.equals(status, Status.OK)) {
+                IStatus status = this.executeTool(editingContext, diagramContext, input.getDiagramSourceElementId(), input.getDiagramTargetElementId(), optionalTool.get());
+                if (status instanceof Success) {
 
                     payload = new InvokeEdgeToolOnDiagramSuccessPayload(diagramInput.getId(), diagram);
                     changeDescription = new ChangeDescription(ChangeKind.SEMANTIC_CHANGE, diagramInput.getRepresentationId(), diagramInput);
@@ -112,8 +114,8 @@ public class InvokeEdgeToolOnDiagramEventHandler implements IDiagramEventHandler
         changeDescriptionSink.tryEmitNext(changeDescription);
     }
 
-    private Status executeTool(IEditingContext editingContext, IDiagramContext diagramContext, UUID sourceNodeId, UUID targetNodeId, CreateEdgeTool tool) {
-        Status result = Status.ERROR;
+    private IStatus executeTool(IEditingContext editingContext, IDiagramContext diagramContext, UUID sourceNodeId, UUID targetNodeId, CreateEdgeTool tool) {
+        IStatus result = new Failure(""); //$NON-NLS-1$
         Diagram diagram = diagramContext.getDiagram();
         Optional<Node> sourceNode = this.diagramQueryService.findNodeById(diagram, sourceNodeId);
         Optional<Node> targetNode = this.diagramQueryService.findNodeById(diagram, targetNodeId);

--- a/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/handlers/InvokeNodeToolOnDiagramEventHandler.java
+++ b/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/handlers/InvokeNodeToolOnDiagramEventHandler.java
@@ -26,7 +26,9 @@ import org.eclipse.sirius.web.diagrams.Node;
 import org.eclipse.sirius.web.diagrams.Position;
 import org.eclipse.sirius.web.diagrams.events.CreationEvent;
 import org.eclipse.sirius.web.diagrams.tools.CreateNodeTool;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.Failure;
+import org.eclipse.sirius.web.representations.IStatus;
+import org.eclipse.sirius.web.representations.Success;
 import org.eclipse.sirius.web.representations.VariableManager;
 import org.eclipse.sirius.web.spring.collaborative.api.ChangeDescription;
 import org.eclipse.sirius.web.spring.collaborative.api.ChangeKind;
@@ -104,9 +106,9 @@ public class InvokeNodeToolOnDiagramEventHandler implements IDiagramEventHandler
                     .map(CreateNodeTool.class::cast);
             // @formatter:on
             if (optionalTool.isPresent()) {
-                Status status = this.executeTool(editingContext, diagramContext, input.getDiagramElementId(), optionalTool.get(), input.getStartingPositionX(), input.getStartingPositionY(),
+                IStatus status = this.executeTool(editingContext, diagramContext, input.getDiagramElementId(), optionalTool.get(), input.getStartingPositionX(), input.getStartingPositionY(),
                         input.getSelectedObjectId());
-                if (Objects.equals(status, Status.OK)) {
+                if (status instanceof Success) {
 
                     payload = new InvokeNodeToolOnDiagramSuccessPayload(diagramInput.getId(), diagram);
                     changeDescription = new ChangeDescription(ChangeKind.SEMANTIC_CHANGE, diagramInput.getRepresentationId(), diagramInput);
@@ -118,9 +120,9 @@ public class InvokeNodeToolOnDiagramEventHandler implements IDiagramEventHandler
         changeDescriptionSink.tryEmitNext(changeDescription);
     }
 
-    private Status executeTool(IEditingContext editingContext, IDiagramContext diagramContext, UUID diagramElementId, CreateNodeTool tool, double startingPositionX, double startingPositionY,
+    private IStatus executeTool(IEditingContext editingContext, IDiagramContext diagramContext, UUID diagramElementId, CreateNodeTool tool, double startingPositionX, double startingPositionY,
             String selectedObjectId) {
-        Status result = Status.ERROR;
+        IStatus result = new Failure(""); //$NON-NLS-1$
         Diagram diagram = diagramContext.getDiagram();
         Optional<Node> node = this.diagramQueryService.findNodeById(diagram, diagramElementId);
         Optional<Object> self = Optional.empty();

--- a/backend/sirius-web-spring-collaborative-forms/src/main/java/org/eclipse/sirius/web/spring/collaborative/forms/handlers/EditCheckboxEventHandler.java
+++ b/backend/sirius-web-spring-collaborative-forms/src/main/java/org/eclipse/sirius/web/spring/collaborative/forms/handlers/EditCheckboxEventHandler.java
@@ -18,7 +18,9 @@ import org.eclipse.sirius.web.core.api.ErrorPayload;
 import org.eclipse.sirius.web.core.api.IPayload;
 import org.eclipse.sirius.web.forms.Checkbox;
 import org.eclipse.sirius.web.forms.Form;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.Failure;
+import org.eclipse.sirius.web.representations.IStatus;
+import org.eclipse.sirius.web.representations.Success;
 import org.eclipse.sirius.web.spring.collaborative.api.ChangeDescription;
 import org.eclipse.sirius.web.spring.collaborative.api.ChangeKind;
 import org.eclipse.sirius.web.spring.collaborative.api.Monitoring;
@@ -69,7 +71,7 @@ public class EditCheckboxEventHandler implements IFormEventHandler {
     public void handle(One<IPayload> payloadSink, Many<ChangeDescription> changeDescriptionSink, Form form, IFormInput formInput) {
         this.counter.increment();
 
-        Status status = Status.ERROR;
+        IStatus status = new Failure(""); //$NON-NLS-1$
         if (formInput instanceof EditCheckboxInput) {
             EditCheckboxInput input = (EditCheckboxInput) formInput;
 
@@ -80,12 +82,12 @@ public class EditCheckboxEventHandler implements IFormEventHandler {
 
             status = optionalCheckbox.map(Checkbox::getNewValueHandler)
                     .map(handler -> handler.apply(input.getNewValue()))
-                    .orElse(Status.ERROR);
+                    .orElse(new Failure("")); //$NON-NLS-1$
             // @formatter:on
 
         }
 
-        if (Status.OK.equals(status)) {
+        if (status instanceof Success) {
             payloadSink.tryEmitValue(new EditCheckboxSuccessPayload(formInput.getId()));
             changeDescriptionSink.tryEmitNext(new ChangeDescription(ChangeKind.SEMANTIC_CHANGE, formInput.getRepresentationId(), formInput));
         } else {

--- a/backend/sirius-web-spring-collaborative-forms/src/main/java/org/eclipse/sirius/web/spring/collaborative/forms/handlers/EditMultiSelectEventHandler.java
+++ b/backend/sirius-web-spring-collaborative-forms/src/main/java/org/eclipse/sirius/web/spring/collaborative/forms/handlers/EditMultiSelectEventHandler.java
@@ -19,7 +19,9 @@ import org.eclipse.sirius.web.core.api.ErrorPayload;
 import org.eclipse.sirius.web.core.api.IPayload;
 import org.eclipse.sirius.web.forms.Form;
 import org.eclipse.sirius.web.forms.MultiSelect;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.Failure;
+import org.eclipse.sirius.web.representations.IStatus;
+import org.eclipse.sirius.web.representations.Success;
 import org.eclipse.sirius.web.spring.collaborative.api.ChangeDescription;
 import org.eclipse.sirius.web.spring.collaborative.api.ChangeKind;
 import org.eclipse.sirius.web.spring.collaborative.api.Monitoring;
@@ -70,7 +72,7 @@ public class EditMultiSelectEventHandler implements IFormEventHandler {
     public void handle(One<IPayload> payloadSink, Many<ChangeDescription> changeDescriptionSink, Form form, IFormInput formInput) {
         this.counter.increment();
 
-        Status status = Status.ERROR;
+        IStatus status = new Failure(""); //$NON-NLS-1$
         if (formInput instanceof EditMultiSelectInput) {
             EditMultiSelectInput input = (EditMultiSelectInput) formInput;
 
@@ -81,12 +83,12 @@ public class EditMultiSelectEventHandler implements IFormEventHandler {
 
             status = optionalMultiSelect.map(MultiSelect::getNewValuesHandler)
                     .map(handler -> handler.apply(input.getNewValues()))
-                    .orElse(Status.ERROR);
+                    .orElse(new Failure("")); //$NON-NLS-1$
             // @formatter:on
 
         }
 
-        if (Status.OK.equals(status)) {
+        if (status instanceof Success) {
             payloadSink.tryEmitValue(new EditMultiSelectSuccessPayload(formInput.getId()));
             changeDescriptionSink.tryEmitNext(new ChangeDescription(ChangeKind.SEMANTIC_CHANGE, formInput.getRepresentationId(), formInput));
         } else {

--- a/backend/sirius-web-spring-collaborative-forms/src/main/java/org/eclipse/sirius/web/spring/collaborative/forms/handlers/EditRadioEventHandler.java
+++ b/backend/sirius-web-spring-collaborative-forms/src/main/java/org/eclipse/sirius/web/spring/collaborative/forms/handlers/EditRadioEventHandler.java
@@ -18,7 +18,9 @@ import org.eclipse.sirius.web.core.api.ErrorPayload;
 import org.eclipse.sirius.web.core.api.IPayload;
 import org.eclipse.sirius.web.forms.Form;
 import org.eclipse.sirius.web.forms.Radio;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.Failure;
+import org.eclipse.sirius.web.representations.IStatus;
+import org.eclipse.sirius.web.representations.Success;
 import org.eclipse.sirius.web.spring.collaborative.api.ChangeDescription;
 import org.eclipse.sirius.web.spring.collaborative.api.ChangeKind;
 import org.eclipse.sirius.web.spring.collaborative.api.Monitoring;
@@ -69,7 +71,7 @@ public class EditRadioEventHandler implements IFormEventHandler {
     public void handle(One<IPayload> payloadSink, Many<ChangeDescription> changeDescriptionSink, Form form, IFormInput formInput) {
         this.counter.increment();
 
-        Status status = Status.ERROR;
+        IStatus status = new Failure(""); //$NON-NLS-1$
         if (formInput instanceof EditRadioInput) {
             EditRadioInput input = (EditRadioInput) formInput;
 
@@ -80,11 +82,11 @@ public class EditRadioEventHandler implements IFormEventHandler {
 
             status = optionalRadio.map(Radio::getNewValueHandler)
                     .map(handler -> handler.apply(input.getNewValue()))
-                    .orElse(Status.ERROR);
+                    .orElse(new Failure("")); //$NON-NLS-1$
             // @formatter:on
 
         }
-        if (Status.OK.equals(status)) {
+        if (status instanceof Success) {
             payloadSink.tryEmitValue(new EditRadioSuccessPayload(formInput.getId()));
             changeDescriptionSink.tryEmitNext(new ChangeDescription(ChangeKind.SEMANTIC_CHANGE, formInput.getRepresentationId(), formInput));
         } else {

--- a/backend/sirius-web-spring-collaborative-forms/src/main/java/org/eclipse/sirius/web/spring/collaborative/forms/handlers/EditSelectEventHandler.java
+++ b/backend/sirius-web-spring-collaborative-forms/src/main/java/org/eclipse/sirius/web/spring/collaborative/forms/handlers/EditSelectEventHandler.java
@@ -19,7 +19,9 @@ import org.eclipse.sirius.web.core.api.ErrorPayload;
 import org.eclipse.sirius.web.core.api.IPayload;
 import org.eclipse.sirius.web.forms.Form;
 import org.eclipse.sirius.web.forms.Select;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.Failure;
+import org.eclipse.sirius.web.representations.IStatus;
+import org.eclipse.sirius.web.representations.Success;
 import org.eclipse.sirius.web.spring.collaborative.api.ChangeDescription;
 import org.eclipse.sirius.web.spring.collaborative.api.ChangeKind;
 import org.eclipse.sirius.web.spring.collaborative.api.Monitoring;
@@ -70,7 +72,7 @@ public class EditSelectEventHandler implements IFormEventHandler {
     public void handle(One<IPayload> payloadSink, Many<ChangeDescription> changeDescriptionSink, Form form, IFormInput formInput) {
         this.counter.increment();
 
-        Status status = Status.ERROR;
+        IStatus status = new Failure(""); //$NON-NLS-1$
         if (formInput instanceof EditSelectInput) {
             EditSelectInput input = (EditSelectInput) formInput;
 
@@ -81,12 +83,12 @@ public class EditSelectEventHandler implements IFormEventHandler {
 
             status = optionalSelect.map(Select::getNewValueHandler)
                     .map(handler -> handler.apply(input.getNewValue()))
-                    .orElse(Status.ERROR);
+                    .orElse(new Failure("")); //$NON-NLS-1$
             // @formatter:on
 
         }
 
-        if (Status.OK.equals(status)) {
+        if (status instanceof Success) {
             payloadSink.tryEmitValue(new EditSelectSuccessPayload(formInput.getId()));
             changeDescriptionSink.tryEmitNext(new ChangeDescription(ChangeKind.SEMANTIC_CHANGE, formInput.getRepresentationId(), formInput));
         } else {

--- a/backend/sirius-web-spring-collaborative-forms/src/main/java/org/eclipse/sirius/web/spring/collaborative/forms/handlers/EditTextfieldEventHandler.java
+++ b/backend/sirius-web-spring-collaborative-forms/src/main/java/org/eclipse/sirius/web/spring/collaborative/forms/handlers/EditTextfieldEventHandler.java
@@ -18,7 +18,9 @@ import org.eclipse.sirius.web.core.api.ErrorPayload;
 import org.eclipse.sirius.web.core.api.IPayload;
 import org.eclipse.sirius.web.forms.Form;
 import org.eclipse.sirius.web.forms.Textfield;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.Failure;
+import org.eclipse.sirius.web.representations.IStatus;
+import org.eclipse.sirius.web.representations.Success;
 import org.eclipse.sirius.web.spring.collaborative.api.ChangeDescription;
 import org.eclipse.sirius.web.spring.collaborative.api.ChangeKind;
 import org.eclipse.sirius.web.spring.collaborative.api.Monitoring;
@@ -69,7 +71,7 @@ public class EditTextfieldEventHandler implements IFormEventHandler {
     public void handle(One<IPayload> payloadSink, Many<ChangeDescription> changeDescriptionSink, Form form, IFormInput formInput) {
         this.counter.increment();
 
-        Status status = Status.ERROR;
+        IStatus status = new Failure(""); //$NON-NLS-1$
         if (formInput instanceof EditTextfieldInput) {
             EditTextfieldInput input = (EditTextfieldInput) formInput;
 
@@ -80,11 +82,11 @@ public class EditTextfieldEventHandler implements IFormEventHandler {
 
             status = optionalTextfield.map(Textfield::getNewValueHandler)
                     .map(handler -> handler.apply(input.getNewValue()))
-                    .orElse(Status.ERROR);
+                    .orElse(new Failure("")); //$NON-NLS-1$
             // @formatter:on
 
         }
-        if (Status.OK.equals(status)) {
+        if (status instanceof Success) {
             payloadSink.tryEmitValue(new EditTextfieldSuccessPayload(formInput.getId()));
             changeDescriptionSink.tryEmitNext(new ChangeDescription(ChangeKind.SEMANTIC_CHANGE, formInput.getRepresentationId(), formInput));
         } else {

--- a/backend/sirius-web-spring-collaborative-forms/src/test/java/org/eclipse/sirius/web/spring/collaborative/forms/handlers/EditCheckboxEventHandlerTests.java
+++ b/backend/sirius-web-spring-collaborative-forms/src/test/java/org/eclipse/sirius/web/spring/collaborative/forms/handlers/EditCheckboxEventHandlerTests.java
@@ -26,7 +26,8 @@ import org.eclipse.sirius.web.forms.Checkbox;
 import org.eclipse.sirius.web.forms.Form;
 import org.eclipse.sirius.web.forms.Group;
 import org.eclipse.sirius.web.forms.Page;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.IStatus;
+import org.eclipse.sirius.web.representations.Success;
 import org.eclipse.sirius.web.spring.collaborative.api.ChangeDescription;
 import org.eclipse.sirius.web.spring.collaborative.api.ChangeKind;
 import org.eclipse.sirius.web.spring.collaborative.forms.api.IFormQueryService;
@@ -55,9 +56,9 @@ public class EditCheckboxEventHandlerTests {
         var input = new EditCheckboxInput(UUID.randomUUID(), UUID.randomUUID(), FORM_ID, id, true);
 
         AtomicBoolean hasBeenExecuted = new AtomicBoolean();
-        Function<Boolean, Status> newValueHandler = newValue -> {
+        Function<Boolean, IStatus> newValueHandler = newValue -> {
             hasBeenExecuted.set(true);
-            return Status.OK;
+            return new Success();
         };
 
         // @formatter:off

--- a/backend/sirius-web-spring-collaborative-forms/src/test/java/org/eclipse/sirius/web/spring/collaborative/forms/handlers/EditRadioEventHandlerTests.java
+++ b/backend/sirius-web-spring-collaborative-forms/src/test/java/org/eclipse/sirius/web/spring/collaborative/forms/handlers/EditRadioEventHandlerTests.java
@@ -27,7 +27,8 @@ import org.eclipse.sirius.web.forms.Group;
 import org.eclipse.sirius.web.forms.Page;
 import org.eclipse.sirius.web.forms.Radio;
 import org.eclipse.sirius.web.forms.RadioOption;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.IStatus;
+import org.eclipse.sirius.web.representations.Success;
 import org.eclipse.sirius.web.spring.collaborative.api.ChangeDescription;
 import org.eclipse.sirius.web.spring.collaborative.api.ChangeKind;
 import org.eclipse.sirius.web.spring.collaborative.forms.api.IFormQueryService;
@@ -56,9 +57,9 @@ public class EditRadioEventHandlerTests {
         var input = new EditRadioInput(UUID.randomUUID(), UUID.randomUUID(), FORM_ID, id, "optionId"); //$NON-NLS-1$
 
         AtomicBoolean hasBeenExecuted = new AtomicBoolean();
-        Function<String, Status> newValueHandler = newValue -> {
+        Function<String, IStatus> newValueHandler = newValue -> {
             hasBeenExecuted.set(true);
-            return Status.OK;
+            return new Success();
         };
 
         // @formatter:off

--- a/backend/sirius-web-spring-collaborative-forms/src/test/java/org/eclipse/sirius/web/spring/collaborative/forms/handlers/EditTextfieldEventHandlerTests.java
+++ b/backend/sirius-web-spring-collaborative-forms/src/test/java/org/eclipse/sirius/web/spring/collaborative/forms/handlers/EditTextfieldEventHandlerTests.java
@@ -26,7 +26,8 @@ import org.eclipse.sirius.web.forms.Form;
 import org.eclipse.sirius.web.forms.Group;
 import org.eclipse.sirius.web.forms.Page;
 import org.eclipse.sirius.web.forms.Textfield;
-import org.eclipse.sirius.web.representations.Status;
+import org.eclipse.sirius.web.representations.IStatus;
+import org.eclipse.sirius.web.representations.Success;
 import org.eclipse.sirius.web.spring.collaborative.api.ChangeDescription;
 import org.eclipse.sirius.web.spring.collaborative.api.ChangeKind;
 import org.eclipse.sirius.web.spring.collaborative.forms.api.IFormQueryService;
@@ -55,9 +56,9 @@ public class EditTextfieldEventHandlerTests {
         var input = new EditTextfieldInput(UUID.randomUUID(), UUID.randomUUID(), FORM_ID, id, "New value"); //$NON-NLS-1$
 
         AtomicBoolean hasBeenExecuted = new AtomicBoolean();
-        Function<String, Status> newValueHandler = newValue -> {
+        Function<String, IStatus> newValueHandler = newValue -> {
             hasBeenExecuted.set(true);
-            return Status.OK;
+            return new Success();
         };
 
         // @formatter:off


### PR DESCRIPTION
### Type of this PR 

- [ ] Bug fix
- [x] New feature or improvement
- [ ] Documentation
- [ ] Cleanup
- [ ] Test
- [ ] Build/Releng

### Issue(s)

https://github.com/eclipse-sirius/sirius-components/issues/750

### What does this PR do?

Adds a Failure status and a Success status.
With a Failure status, any handler can provide a message if something
went wrong.
The Success status is meant to be improved soon.

### How to test this PR?


- [x] Backend Unit tests : tests have been updated

### Checklist

- [x] I have read CONTRIBUTING carefully.
- [x] I have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All my commits are signed-off (`-s`) with my mail address of my Eclipse Account.
- [x] I have covered my changes by unit tests or integration tests or manual tests.
- [x] All tests pass.
- [ ] I have updated the documentation accordingly
