### PR TITLE
[740] Remove the explicit nsURI from Domain definitions

### DIFF
--- a/backend/sirius-web-domain-edit/src/main/java/org/eclipse/sirius/web/domain/provider/DomainItemProvider.java
+++ b/backend/sirius-web-domain-edit/src/main/java/org/eclipse/sirius/web/domain/provider/DomainItemProvider.java
@@ -18,9 +18,7 @@ import java.util.List;
 import org.eclipse.emf.common.notify.AdapterFactory;
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.ecore.EStructuralFeature;
-import org.eclipse.emf.edit.provider.ComposeableAdapterFactory;
 import org.eclipse.emf.edit.provider.IItemPropertyDescriptor;
-import org.eclipse.emf.edit.provider.ItemPropertyDescriptor;
 import org.eclipse.emf.edit.provider.ViewerNotification;
 import org.eclipse.sirius.web.domain.Domain;
 import org.eclipse.sirius.web.domain.DomainFactory;
@@ -53,21 +51,8 @@ public class DomainItemProvider extends NamedElementItemProvider {
         if (this.itemPropertyDescriptors == null) {
             super.getPropertyDescriptors(object);
 
-            this.addUriPropertyDescriptor(object);
         }
         return this.itemPropertyDescriptors;
-    }
-
-    /**
-     * This adds a property descriptor for the Uri feature. <!-- begin-user-doc --> <!-- end-user-doc -->
-     *
-     * @generated
-     */
-    protected void addUriPropertyDescriptor(Object object) {
-        this.itemPropertyDescriptors
-                .add(this.createItemPropertyDescriptor(((ComposeableAdapterFactory) this.adapterFactory).getRootAdapterFactory(), this.getResourceLocator(), this.getString("_UI_Domain_uri_feature"), //$NON-NLS-1$
-                        this.getString("_UI_PropertyDescriptor_description", "_UI_Domain_uri_feature", "_UI_Domain_type"), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-                        DomainPackage.Literals.DOMAIN__URI, true, false, false, ItemPropertyDescriptor.GENERIC_VALUE_IMAGE, null, null));
     }
 
     /**
@@ -144,9 +129,6 @@ public class DomainItemProvider extends NamedElementItemProvider {
         this.updateChildren(notification);
 
         switch (notification.getFeatureID(Domain.class)) {
-        case DomainPackage.DOMAIN__URI:
-            this.fireNotifyChanged(new ViewerNotification(notification, notification.getNotifier(), false, true));
-            return;
         case DomainPackage.DOMAIN__TYPES:
             this.fireNotifyChanged(new ViewerNotification(notification, notification.getNotifier(), true, false));
             return;

--- a/backend/sirius-web-domain-edit/src/main/resources/plugin.properties
+++ b/backend/sirius-web-domain-edit/src/main/resources/plugin.properties
@@ -32,7 +32,6 @@ _UI_Unknown_type = Object
 _UI_Unknown_datatype= Value
 
 _UI_NamedElement_name_feature = Name
-_UI_Domain_uri_feature = Uri
 _UI_Domain_types_feature = Types
 _UI_Entity_attributes_feature = Attributes
 _UI_Entity_relations_feature = Relations

--- a/backend/sirius-web-domain/src/main/java/org/eclipse/sirius/web/domain/Domain.java
+++ b/backend/sirius-web-domain/src/main/java/org/eclipse/sirius/web/domain/Domain.java
@@ -21,7 +21,6 @@ import org.eclipse.emf.common.util.EList;
  * The following features are supported:
  * </p>
  * <ul>
- * <li>{@link org.eclipse.sirius.web.domain.Domain#getUri <em>Uri</em>}</li>
  * <li>{@link org.eclipse.sirius.web.domain.Domain#getTypes <em>Types</em>}</li>
  * </ul>
  *
@@ -30,29 +29,6 @@ import org.eclipse.emf.common.util.EList;
  * @generated
  */
 public interface Domain extends NamedElement {
-    /**
-     * Returns the value of the '<em><b>Uri</b></em>' attribute. The default value is <code>"domain://sample"</code>.
-     * <!-- begin-user-doc --> <!-- end-user-doc -->
-     *
-     * @return the value of the '<em>Uri</em>' attribute.
-     * @see #setUri(String)
-     * @see org.eclipse.sirius.web.domain.DomainPackage#getDomain_Uri()
-     * @model default="domain://sample"
-     * @generated
-     */
-    String getUri();
-
-    /**
-     * Sets the value of the '{@link org.eclipse.sirius.web.domain.Domain#getUri <em>Uri</em>}' attribute. <!--
-     * begin-user-doc --> <!-- end-user-doc -->
-     *
-     * @param value
-     *            the new value of the '<em>Uri</em>' attribute.
-     * @see #getUri()
-     * @generated
-     */
-    void setUri(String value);
-
     /**
      * Returns the value of the '<em><b>Types</b></em>' containment reference list. The list contents are of type
      * {@link org.eclipse.sirius.web.domain.Entity}. <!-- begin-user-doc --> <!-- end-user-doc -->

--- a/backend/sirius-web-domain/src/main/java/org/eclipse/sirius/web/domain/DomainPackage.java
+++ b/backend/sirius-web-domain/src/main/java/org/eclipse/sirius/web/domain/DomainPackage.java
@@ -116,21 +116,13 @@ public interface DomainPackage extends EPackage {
     int DOMAIN__NAME = NAMED_ELEMENT__NAME;
 
     /**
-     * The feature id for the '<em><b>Uri</b></em>' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
-     *
-     * @generated
-     * @ordered
-     */
-    int DOMAIN__URI = NAMED_ELEMENT_FEATURE_COUNT + 0;
-
-    /**
      * The feature id for the '<em><b>Types</b></em>' containment reference list. <!-- begin-user-doc --> <!--
      * end-user-doc -->
      *
      * @generated
      * @ordered
      */
-    int DOMAIN__TYPES = NAMED_ELEMENT_FEATURE_COUNT + 1;
+    int DOMAIN__TYPES = NAMED_ELEMENT_FEATURE_COUNT + 0;
 
     /**
      * The number of structural features of the '<em>Domain</em>' class. <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -138,7 +130,7 @@ public interface DomainPackage extends EPackage {
      * @generated
      * @ordered
      */
-    int DOMAIN_FEATURE_COUNT = NAMED_ELEMENT_FEATURE_COUNT + 2;
+    int DOMAIN_FEATURE_COUNT = NAMED_ELEMENT_FEATURE_COUNT + 1;
 
     /**
      * The number of operations of the '<em>Domain</em>' class. <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -434,17 +426,6 @@ public interface DomainPackage extends EPackage {
     EClass getDomain();
 
     /**
-     * Returns the meta object for the attribute '{@link org.eclipse.sirius.web.domain.Domain#getUri <em>Uri</em>}'.
-     * <!-- begin-user-doc --> <!-- end-user-doc -->
-     *
-     * @return the meta object for the attribute '<em>Uri</em>'.
-     * @see org.eclipse.sirius.web.domain.Domain#getUri()
-     * @see #getDomain()
-     * @generated
-     */
-    EAttribute getDomain_Uri();
-
-    /**
      * Returns the meta object for the containment reference list '{@link org.eclipse.sirius.web.domain.Domain#getTypes
      * <em>Types</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
      *
@@ -655,14 +636,6 @@ public interface DomainPackage extends EPackage {
          * @generated
          */
         EClass DOMAIN = eINSTANCE.getDomain();
-
-        /**
-         * The meta object literal for the '<em><b>Uri</b></em>' attribute feature. <!-- begin-user-doc --> <!--
-         * end-user-doc -->
-         *
-         * @generated
-         */
-        EAttribute DOMAIN__URI = eINSTANCE.getDomain_Uri();
 
         /**
          * The meta object literal for the '<em><b>Types</b></em>' containment reference list feature. <!--

--- a/backend/sirius-web-domain/src/main/java/org/eclipse/sirius/web/domain/impl/DomainImpl.java
+++ b/backend/sirius-web-domain/src/main/java/org/eclipse/sirius/web/domain/impl/DomainImpl.java
@@ -14,12 +14,10 @@ package org.eclipse.sirius.web.domain.impl;
 
 import java.util.Collection;
 
-import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.notify.NotificationChain;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.InternalEObject;
-import org.eclipse.emf.ecore.impl.ENotificationImpl;
 import org.eclipse.emf.ecore.util.EObjectContainmentEList;
 import org.eclipse.emf.ecore.util.InternalEList;
 import org.eclipse.sirius.web.domain.Domain;
@@ -32,32 +30,12 @@ import org.eclipse.sirius.web.domain.Entity;
  * The following features are implemented:
  * </p>
  * <ul>
- * <li>{@link org.eclipse.sirius.web.domain.impl.DomainImpl#getUri <em>Uri</em>}</li>
  * <li>{@link org.eclipse.sirius.web.domain.impl.DomainImpl#getTypes <em>Types</em>}</li>
  * </ul>
  *
  * @generated
  */
 public class DomainImpl extends NamedElementImpl implements Domain {
-    /**
-     * The default value of the '{@link #getUri() <em>Uri</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc
-     * -->
-     *
-     * @see #getUri()
-     * @generated
-     * @ordered
-     */
-    protected static final String URI_EDEFAULT = "domain://sample"; //$NON-NLS-1$
-
-    /**
-     * The cached value of the '{@link #getUri() <em>Uri</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
-     *
-     * @see #getUri()
-     * @generated
-     * @ordered
-     */
-    protected String uri = URI_EDEFAULT;
-
     /**
      * The cached value of the '{@link #getTypes() <em>Types</em>}' containment reference list. <!-- begin-user-doc -->
      * <!-- end-user-doc -->
@@ -85,29 +63,6 @@ public class DomainImpl extends NamedElementImpl implements Domain {
     @Override
     protected EClass eStaticClass() {
         return DomainPackage.Literals.DOMAIN;
-    }
-
-    /**
-     * <!-- begin-user-doc --> <!-- end-user-doc -->
-     *
-     * @generated
-     */
-    @Override
-    public String getUri() {
-        return this.uri;
-    }
-
-    /**
-     * <!-- begin-user-doc --> <!-- end-user-doc -->
-     *
-     * @generated
-     */
-    @Override
-    public void setUri(String newUri) {
-        String oldUri = this.uri;
-        this.uri = newUri;
-        if (this.eNotificationRequired())
-            this.eNotify(new ENotificationImpl(this, Notification.SET, DomainPackage.DOMAIN__URI, oldUri, this.uri));
     }
 
     /**
@@ -145,8 +100,6 @@ public class DomainImpl extends NamedElementImpl implements Domain {
     @Override
     public Object eGet(int featureID, boolean resolve, boolean coreType) {
         switch (featureID) {
-        case DomainPackage.DOMAIN__URI:
-            return this.getUri();
         case DomainPackage.DOMAIN__TYPES:
             return this.getTypes();
         }
@@ -162,9 +115,6 @@ public class DomainImpl extends NamedElementImpl implements Domain {
     @Override
     public void eSet(int featureID, Object newValue) {
         switch (featureID) {
-        case DomainPackage.DOMAIN__URI:
-            this.setUri((String) newValue);
-            return;
         case DomainPackage.DOMAIN__TYPES:
             this.getTypes().clear();
             this.getTypes().addAll((Collection<? extends Entity>) newValue);
@@ -181,9 +131,6 @@ public class DomainImpl extends NamedElementImpl implements Domain {
     @Override
     public void eUnset(int featureID) {
         switch (featureID) {
-        case DomainPackage.DOMAIN__URI:
-            this.setUri(URI_EDEFAULT);
-            return;
         case DomainPackage.DOMAIN__TYPES:
             this.getTypes().clear();
             return;
@@ -199,29 +146,10 @@ public class DomainImpl extends NamedElementImpl implements Domain {
     @Override
     public boolean eIsSet(int featureID) {
         switch (featureID) {
-        case DomainPackage.DOMAIN__URI:
-            return URI_EDEFAULT == null ? this.uri != null : !URI_EDEFAULT.equals(this.uri);
         case DomainPackage.DOMAIN__TYPES:
             return this.types != null && !this.types.isEmpty();
         }
         return super.eIsSet(featureID);
-    }
-
-    /**
-     * <!-- begin-user-doc --> <!-- end-user-doc -->
-     *
-     * @generated
-     */
-    @Override
-    public String toString() {
-        if (this.eIsProxy())
-            return super.toString();
-
-        StringBuilder result = new StringBuilder(super.toString());
-        result.append(" (uri: "); //$NON-NLS-1$
-        result.append(this.uri);
-        result.append(')');
-        return result.toString();
     }
 
 } // DomainImpl

--- a/backend/sirius-web-domain/src/main/java/org/eclipse/sirius/web/domain/impl/DomainPackageImpl.java
+++ b/backend/sirius-web-domain/src/main/java/org/eclipse/sirius/web/domain/impl/DomainPackageImpl.java
@@ -180,18 +180,8 @@ public class DomainPackageImpl extends EPackageImpl implements DomainPackage {
      * @generated
      */
     @Override
-    public EAttribute getDomain_Uri() {
-        return (EAttribute) this.domainEClass.getEStructuralFeatures().get(0);
-    }
-
-    /**
-     * <!-- begin-user-doc --> <!-- end-user-doc -->
-     *
-     * @generated
-     */
-    @Override
     public EReference getDomain_Types() {
-        return (EReference) this.domainEClass.getEStructuralFeatures().get(1);
+        return (EReference) this.domainEClass.getEStructuralFeatures().get(0);
     }
 
     /**
@@ -367,7 +357,6 @@ public class DomainPackageImpl extends EPackageImpl implements DomainPackage {
         this.createEAttribute(this.namedElementEClass, NAMED_ELEMENT__NAME);
 
         this.domainEClass = this.createEClass(DOMAIN);
-        this.createEAttribute(this.domainEClass, DOMAIN__URI);
         this.createEReference(this.domainEClass, DOMAIN__TYPES);
 
         this.entityEClass = this.createEClass(ENTITY);
@@ -431,8 +420,6 @@ public class DomainPackageImpl extends EPackageImpl implements DomainPackage {
                 IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
         this.initEClass(this.domainEClass, Domain.class, "Domain", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
-        this.initEAttribute(this.getDomain_Uri(), this.ecorePackage.getEString(), "uri", "domain://sample", 0, 1, Domain.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, //$NON-NLS-1$//$NON-NLS-2$
-                IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
         this.initEReference(this.getDomain_Types(), this.getEntity(), null, "types", null, 0, -1, Domain.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, //$NON-NLS-1$
                 !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 

--- a/backend/sirius-web-domain/src/main/resources/model/domain.ecore
+++ b/backend/sirius-web-domain/src/main/resources/model/domain.ecore
@@ -5,8 +5,6 @@
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="name" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="Domain" eSuperTypes="#//NamedElement">
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="uri" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"
-        defaultValueLiteral="domain://sample"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="types" upperBound="-1"
         eType="#//Entity" containment="true"/>
   </eClassifiers>

--- a/backend/sirius-web-domain/src/main/resources/model/domain.genmodel
+++ b/backend/sirius-web-domain/src/main/resources/model/domain.genmodel
@@ -22,7 +22,6 @@
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute domain.ecore#//NamedElement/name"/>
     </genClasses>
     <genClasses ecoreClass="domain.ecore#//Domain">
-      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute domain.ecore#//Domain/uri"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference domain.ecore#//Domain/types"/>
     </genClasses>
     <genClasses ecoreClass="domain.ecore#//Entity">

--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/domain/DomainConverter.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/domain/DomainConverter.java
@@ -40,13 +40,15 @@ import org.eclipse.sirius.web.domain.Relation;
  */
 public class DomainConverter {
 
+    public static final String DOMAIN_SCHEME = "domain"; //$NON-NLS-1$
+
     public Optional<EPackage> convert(Domain domain) {
         Optional<EPackage> result = Optional.empty();
 
         EPackage ePackage = EcoreFactory.eINSTANCE.createEPackage();
         ePackage.setName(domain.getName());
         ePackage.setNsPrefix(Optional.ofNullable(domain.getName()).orElse("").toLowerCase()); //$NON-NLS-1$
-        ePackage.setNsURI(domain.getUri());
+        ePackage.setNsURI(DOMAIN_SCHEME + "://" + domain.getName()); //$NON-NLS-1$
 
         Map<Entity, EClass> convertedTypes = new HashMap<>();
         // First pass to create the EClasses and EAttributes
@@ -70,9 +72,6 @@ public class DomainConverter {
         }
 
         // Only return valid and safe EPackages
-        if (!ePackage.getNsURI().startsWith(DomainValidator.DOMAIN_URI_SCHEME)) {
-            result = Optional.empty();
-        }
         Diagnostic diagnostic = Diagnostician.INSTANCE.validate(ePackage);
         if (diagnostic.getSeverity() < Diagnostic.ERROR) {
             result = Optional.of(ePackage);

--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/domain/DomainValidator.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/domain/DomainValidator.java
@@ -33,15 +33,11 @@ import org.eclipse.sirius.web.domain.Entity;
  */
 public class DomainValidator implements EValidator {
 
-    public static final String DOMAIN_URI_SCHEME = "domain://"; //$NON-NLS-1$
-
     private static final String DOMAIN_DISTINC_NAME_ERROR_MESSAGE = "Two entities cannot have the same name in the same domain"; //$NON-NLS-1$
 
     private static final String SIRIUS_WEB_EMF_PACKAGE = "org.eclipse.sirius.web.emf"; //$NON-NLS-1$
 
     private static final String DOMAIN_NAME_ERROR_MESSAGE = "The domain name should not be empty."; //$NON-NLS-1$
-
-    private static final String DOMAIN_URI_SCHEME_ERROR_MESSAGE = "The domain %1$s uri's does not start with \"domain://\"."; //$NON-NLS-1$
 
     @Override
     public boolean validate(EDataType eDataType, Object value, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -53,32 +49,11 @@ public class DomainValidator implements EValidator {
         boolean isValid = true;
         if (eObject instanceof Domain) {
             Domain domain = (Domain) eObject;
-            isValid = this.uriStartWithValidate(domain, diagnostics) && isValid;
             isValid = this.nameIsNotBlankValidate(domain, diagnostics) && isValid;
         }
         if (eObject instanceof Entity) {
             Entity entity = (Entity) eObject;
             isValid = this.nameIsNotUsedByOtherEntity(entity, diagnostics) && isValid;
-        }
-        return isValid;
-    }
-
-    private boolean uriStartWithValidate(Domain domain, DiagnosticChain diagnostics) {
-        boolean isValid = Optional.ofNullable(domain.getUri()).orElse("").startsWith(DOMAIN_URI_SCHEME); //$NON-NLS-1$
-
-        if (!isValid && diagnostics != null) {
-            // @formatter:off
-            BasicDiagnostic basicDiagnostic = new BasicDiagnostic(Diagnostic.ERROR,
-                    SIRIUS_WEB_EMF_PACKAGE,
-                    0,
-                    String.format(DOMAIN_URI_SCHEME_ERROR_MESSAGE, domain.getName()),
-                    new Object [] {
-                            domain,
-                            DomainPackage.Literals.DOMAIN__URI,
-                    });
-            // @formatter:on
-
-            diagnostics.add(basicDiagnostic);
         }
         return isValid;
     }

--- a/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/services/validation/DomainValidatorTests.java
+++ b/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/services/validation/DomainValidatorTests.java
@@ -38,7 +38,6 @@ public class DomainValidatorTests {
         Map<Object, Object> defaultContext = Diagnostician.INSTANCE.createDefaultContext();
         Domain domain = DomainFactory.eINSTANCE.createDomain();
         domain.setName("Family"); //$NON-NLS-1$
-        domain.setUri("domain://Family"); //$NON-NLS-1$
 
         BasicDiagnostic diagnosticChain = new BasicDiagnostic(Diagnostic.OK, null, 0, null, null);
 
@@ -49,39 +48,10 @@ public class DomainValidatorTests {
     }
 
     @Test
-    public void testDomainInvalidURI() {
-        Map<Object, Object> defaultContext = Diagnostician.INSTANCE.createDefaultContext();
-        Domain domain = DomainFactory.eINSTANCE.createDomain();
-        domain.setName("Family"); //$NON-NLS-1$
-        domain.setUri(""); //$NON-NLS-1$
-
-        BasicDiagnostic diagnosticChain = new BasicDiagnostic(Diagnostic.OK, null, 0, null, null);
-
-        boolean validationResult = new DomainValidator().validate(domain.eClass(), domain, diagnosticChain, defaultContext);
-        assertThat(validationResult).isFalse();
-
-        BasicDiagnostic expected = new BasicDiagnostic(Diagnostic.ERROR, null, 0, null, null);
-        // @formatter:off
-        expected.add(new BasicDiagnostic(Diagnostic.ERROR,
-                "org.eclipse.sirius.web.emf", //$NON-NLS-1$
-                0,
-                String.format("The domain %1$s uri's does not start with \"domain://\".", domain.getName()), //$NON-NLS-1$
-                new Object [] {
-                        domain,
-                        DomainPackage.Literals.DOMAIN__URI,
-
-        }));
-        // @formatter:on
-
-        assertThat(diagnosticChain).isEqualTo(expected);
-    }
-
-    @Test
     public void testDomainInvalidName() {
         Map<Object, Object> defaultContext = Diagnostician.INSTANCE.createDefaultContext();
         Domain domain = DomainFactory.eINSTANCE.createDomain();
         domain.setName(""); //$NON-NLS-1$
-        domain.setUri("domain://Family"); //$NON-NLS-1$
 
         BasicDiagnostic diagnosticChain = new BasicDiagnostic(Diagnostic.OK, null, 0, null, null);
 


### PR DESCRIPTION
It's a technical detail which can, and should, be derived
automatically from the name instead of delegating this responsibility
to the user.

The change also allows us to enforce the constraint that all EPackages
derived from domains will have an nsURI starting with `domain://`.