### PR TITLE
[cleanup] Simplify the name of Views' canonical creation tools

### DIFF
--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/view/ViewConverter.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/view/ViewConverter.java
@@ -261,7 +261,7 @@ public class ViewConverter {
             if (i == 0) {
                 // @formatter:off
                 CreateNodeTool tool = CreateNodeTool.newCreateNodeTool(this.idProvider.apply(nodeDescription) + "_creationTool") //$NON-NLS-1$
-                        .label("New node " + nodeDescription.getDomainType()) //$NON-NLS-1$
+                        .label("New " + nodeDescription.getDomainType()) //$NON-NLS-1$
                         .imageURL(NODE_CREATION_TOOL_ICON)
                         .handler(variableManager -> this.canonicalBehaviors.createNewNode(nodeDescription, variableManager))
                         .targetDescriptions(Optional.ofNullable(nodeDescription.eContainer()).map(this.convertedNodes::get).stream().collect(Collectors.toList()))
@@ -294,7 +294,7 @@ public class ViewConverter {
             if (i == 0) {
                 // @formatter:off
                 CreateEdgeTool tool = CreateEdgeTool.newCreateEdgeTool(this.idProvider.apply(edgeDescription) + "_creationTool") //$NON-NLS-1$
-                        .label("New edge" + edgeDescription.getDomainType()) //$NON-NLS-1$
+                        .label("New " + edgeDescription.getDomainType()) //$NON-NLS-1$
                         .imageURL(EDGE_CREATION_TOOL_ICON)
                         .edgeCandidates(List.of(EdgeCandidate.newEdgeCandidate()
                                 .sources(edgeDescription.getSourceNodeDescriptions().stream().map(this.convertedNodes::get).collect(Collectors.toList()))


### PR DESCRIPTION
Signed-off-by: Pierre-Charles David <pierre-charles.david@obeo.fr>

### Type of this PR 

- [ ] Bug fix
- [ ] New feature or improvement
- [ ] Documentation
- [ ] Cleanup
- [ ] Test
- [ ] Build/Releng

### Issue(s)

...

### What does this PR do?

...

### Screenshot/screencast of this PR

...
 

### Potential side effects

...

### How to test this PR?

- [ ] Frontend Unit tests
- [ ] Backend Unit tests
- [ ] Cypress : please specify
- [ ] Manual Test : please specify

### Checklist

- [ ] I have read CONTRIBUTING carefully.
- [ ] I have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [ ] All my commits are signed-off (`-s`) with my mail address of my Eclipse Account.
- [ ] I have covered my changes by unit tests or integration tests or manual tests.
- [ ] All tests pass.
- [ ] I have updated the documentation accordingly
- [ ] New React components are availables in storybook
