### PR TITLE
[802] Make ArchUnit more quiet during the build

### DIFF
--- a/backend/sirius-web-api/.classpath
+++ b/backend/sirius-web-api/.classpath
@@ -18,6 +18,13 @@
 			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
+		<attributes>
+			<attribute name="test" value="true"/>
+			<attribute name="ignore_optional_problems" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>

--- a/backend/sirius-web-api/src/test/resources/logback-test.xml
+++ b/backend/sirius-web-api/src/test/resources/logback-test.xml
@@ -1,0 +1,3 @@
+<configuration>
+  <logger name="com.tngtech.archunit" level="INFO" />
+</configuration>

--- a/backend/sirius-web-compatibility/.classpath
+++ b/backend/sirius-web-compatibility/.classpath
@@ -18,6 +18,13 @@
 			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
+		<attributes>
+			<attribute name="test" value="true"/>
+			<attribute name="ignore_optional_problems" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>

--- a/backend/sirius-web-compatibility/src/test/resources/logback-test.xml
+++ b/backend/sirius-web-compatibility/src/test/resources/logback-test.xml
@@ -1,0 +1,3 @@
+<configuration>
+  <logger name="com.tngtech.archunit" level="INFO" />
+</configuration>

--- a/backend/sirius-web-components/.classpath
+++ b/backend/sirius-web-components/.classpath
@@ -18,6 +18,13 @@
 			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
+		<attributes>
+			<attribute name="test" value="true"/>
+			<attribute name="ignore_optional_problems" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>	
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>

--- a/backend/sirius-web-components/src/test/resources/logback-test.xml
+++ b/backend/sirius-web-components/src/test/resources/logback-test.xml
@@ -1,0 +1,3 @@
+<configuration>
+  <logger name="com.tngtech.archunit" level="INFO" />
+</configuration>

--- a/backend/sirius-web-core-api/.classpath
+++ b/backend/sirius-web-core-api/.classpath
@@ -18,6 +18,13 @@
 			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
+		<attributes>
+			<attribute name="test" value="true"/>
+			<attribute name="ignore_optional_problems" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>

--- a/backend/sirius-web-core-api/src/test/resources/logback-test.xml
+++ b/backend/sirius-web-core-api/src/test/resources/logback-test.xml
@@ -1,0 +1,3 @@
+<configuration>
+  <logger name="com.tngtech.archunit" level="INFO" />
+</configuration>

--- a/backend/sirius-web-diagrams-layout-api/.classpath
+++ b/backend/sirius-web-diagrams-layout-api/.classpath
@@ -18,6 +18,13 @@
 			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
+		<attributes>
+			<attribute name="test" value="true"/>
+			<attribute name="ignore_optional_problems" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>

--- a/backend/sirius-web-diagrams-layout-api/src/test/resources/logback-test.xml
+++ b/backend/sirius-web-diagrams-layout-api/src/test/resources/logback-test.xml
@@ -1,0 +1,3 @@
+<configuration>
+  <logger name="com.tngtech.archunit" level="INFO" />
+</configuration>

--- a/backend/sirius-web-diagrams-layout/src/test/resources/logback-test.xml
+++ b/backend/sirius-web-diagrams-layout/src/test/resources/logback-test.xml
@@ -1,0 +1,3 @@
+<configuration>
+  <logger name="com.tngtech.archunit" level="INFO" />
+</configuration>

--- a/backend/sirius-web-diagrams/.classpath
+++ b/backend/sirius-web-diagrams/.classpath
@@ -18,6 +18,13 @@
 			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
+		<attributes>
+			<attribute name="test" value="true"/>
+			<attribute name="ignore_optional_problems" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>

--- a/backend/sirius-web-diagrams/src/test/resources/logback-test.xml
+++ b/backend/sirius-web-diagrams/src/test/resources/logback-test.xml
@@ -1,0 +1,3 @@
+<configuration>
+  <logger name="com.tngtech.archunit" level="INFO" />
+</configuration>

--- a/backend/sirius-web-emf/src/test/resources/logback-test.xml
+++ b/backend/sirius-web-emf/src/test/resources/logback-test.xml
@@ -1,0 +1,3 @@
+<configuration>
+  <logger name="com.tngtech.archunit" level="INFO" />
+</configuration>

--- a/backend/sirius-web-forms/.classpath
+++ b/backend/sirius-web-forms/.classpath
@@ -18,6 +18,13 @@
 			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
+		<attributes>
+			<attribute name="test" value="true"/>
+			<attribute name="ignore_optional_problems" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>

--- a/backend/sirius-web-forms/src/test/resources/logback-test.xml
+++ b/backend/sirius-web-forms/src/test/resources/logback-test.xml
@@ -1,0 +1,3 @@
+<configuration>
+  <logger name="com.tngtech.archunit" level="INFO" />
+</configuration>

--- a/backend/sirius-web-graphql-utils/.classpath
+++ b/backend/sirius-web-graphql-utils/.classpath
@@ -18,6 +18,13 @@
 			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
+		<attributes>
+			<attribute name="test" value="true"/>
+			<attribute name="ignore_optional_problems" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>

--- a/backend/sirius-web-graphql-utils/src/test/resources/logback-test.xml
+++ b/backend/sirius-web-graphql-utils/src/test/resources/logback-test.xml
@@ -1,0 +1,3 @@
+<configuration>
+  <logger name="com.tngtech.archunit" level="INFO" />
+</configuration>

--- a/backend/sirius-web-selection/.classpath
+++ b/backend/sirius-web-selection/.classpath
@@ -18,6 +18,13 @@
 			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
+		<attributes>
+			<attribute name="test" value="true"/>
+			<attribute name="ignore_optional_problems" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>

--- a/backend/sirius-web-selection/src/test/resources/logback-test.xml
+++ b/backend/sirius-web-selection/src/test/resources/logback-test.xml
@@ -1,0 +1,3 @@
+<configuration>
+  <logger name="com.tngtech.archunit" level="INFO" />
+</configuration>

--- a/backend/sirius-web-spring-collaborative-diagrams/.classpath
+++ b/backend/sirius-web-spring-collaborative-diagrams/.classpath
@@ -18,6 +18,13 @@
 			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
+		<attributes>
+			<attribute name="test" value="true"/>
+			<attribute name="ignore_optional_problems" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>

--- a/backend/sirius-web-spring-collaborative-diagrams/src/test/resources/logback-test.xml
+++ b/backend/sirius-web-spring-collaborative-diagrams/src/test/resources/logback-test.xml
@@ -1,0 +1,3 @@
+<configuration>
+  <logger name="com.tngtech.archunit" level="INFO" />
+</configuration>

--- a/backend/sirius-web-spring-collaborative-forms/.classpath
+++ b/backend/sirius-web-spring-collaborative-forms/.classpath
@@ -18,6 +18,13 @@
 			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
+		<attributes>
+			<attribute name="test" value="true"/>
+			<attribute name="ignore_optional_problems" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>

--- a/backend/sirius-web-spring-collaborative-forms/src/test/resources/logback-test.xml
+++ b/backend/sirius-web-spring-collaborative-forms/src/test/resources/logback-test.xml
@@ -1,0 +1,3 @@
+<configuration>
+  <logger name="com.tngtech.archunit" level="INFO" />
+</configuration>

--- a/backend/sirius-web-spring-collaborative-selection/.classpath
+++ b/backend/sirius-web-spring-collaborative-selection/.classpath
@@ -18,6 +18,13 @@
 			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
+		<attributes>
+			<attribute name="test" value="true"/>
+			<attribute name="ignore_optional_problems" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>

--- a/backend/sirius-web-spring-collaborative-selection/src/test/resources/logback-test.xml
+++ b/backend/sirius-web-spring-collaborative-selection/src/test/resources/logback-test.xml
@@ -1,0 +1,3 @@
+<configuration>
+  <logger name="com.tngtech.archunit" level="INFO" />
+</configuration>

--- a/backend/sirius-web-spring-collaborative-trees/.classpath
+++ b/backend/sirius-web-spring-collaborative-trees/.classpath
@@ -18,6 +18,13 @@
 			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
+		<attributes>
+			<attribute name="test" value="true"/>
+			<attribute name="ignore_optional_problems" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>

--- a/backend/sirius-web-spring-collaborative-trees/src/test/resources/logback-test.xml
+++ b/backend/sirius-web-spring-collaborative-trees/src/test/resources/logback-test.xml
@@ -1,0 +1,3 @@
+<configuration>
+  <logger name="com.tngtech.archunit" level="INFO" />
+</configuration>

--- a/backend/sirius-web-spring-collaborative-validation/.classpath
+++ b/backend/sirius-web-spring-collaborative-validation/.classpath
@@ -18,6 +18,13 @@
 			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
+		<attributes>
+			<attribute name="test" value="true"/>
+			<attribute name="ignore_optional_problems" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>

--- a/backend/sirius-web-spring-collaborative-validation/src/test/resources/logback-test.xml
+++ b/backend/sirius-web-spring-collaborative-validation/src/test/resources/logback-test.xml
@@ -1,0 +1,3 @@
+<configuration>
+  <logger name="com.tngtech.archunit" level="INFO" />
+</configuration>

--- a/backend/sirius-web-spring-collaborative/.classpath
+++ b/backend/sirius-web-spring-collaborative/.classpath
@@ -18,6 +18,13 @@
 			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
+		<attributes>
+			<attribute name="test" value="true"/>
+			<attribute name="ignore_optional_problems" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>

--- a/backend/sirius-web-spring-collaborative/src/test/resources/logback-test.xml
+++ b/backend/sirius-web-spring-collaborative/src/test/resources/logback-test.xml
@@ -1,0 +1,3 @@
+<configuration>
+  <logger name="com.tngtech.archunit" level="INFO" />
+</configuration>

--- a/backend/sirius-web-spring-graphql/.classpath
+++ b/backend/sirius-web-spring-graphql/.classpath
@@ -18,6 +18,13 @@
 			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
+		<attributes>
+			<attribute name="test" value="true"/>
+			<attribute name="ignore_optional_problems" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>

--- a/backend/sirius-web-spring-graphql/src/test/resources/logback-test.xml
+++ b/backend/sirius-web-spring-graphql/src/test/resources/logback-test.xml
@@ -1,0 +1,3 @@
+<configuration>
+  <logger name="com.tngtech.archunit" level="INFO" />
+</configuration>

--- a/backend/sirius-web-spring-tests/.classpath
+++ b/backend/sirius-web-spring-tests/.classpath
@@ -18,6 +18,13 @@
 			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
+		<attributes>
+			<attribute name="test" value="true"/>
+			<attribute name="ignore_optional_problems" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>

--- a/backend/sirius-web-spring-tests/src/test/resources/logback-test.xml
+++ b/backend/sirius-web-spring-tests/src/test/resources/logback-test.xml
@@ -1,0 +1,3 @@
+<configuration>
+  <logger name="com.tngtech.archunit" level="INFO" />
+</configuration>

--- a/backend/sirius-web-tests/.classpath
+++ b/backend/sirius-web-tests/.classpath
@@ -18,6 +18,13 @@
 			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
+		<attributes>
+			<attribute name="test" value="true"/>
+			<attribute name="ignore_optional_problems" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>

--- a/backend/sirius-web-tests/src/test/resources/logback-test.xml
+++ b/backend/sirius-web-tests/src/test/resources/logback-test.xml
@@ -1,0 +1,3 @@
+<configuration>
+  <logger name="com.tngtech.archunit" level="INFO" />
+</configuration>

--- a/backend/sirius-web-trees/.classpath
+++ b/backend/sirius-web-trees/.classpath
@@ -18,6 +18,13 @@
 			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
+		<attributes>
+			<attribute name="test" value="true"/>
+			<attribute name="ignore_optional_problems" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>

--- a/backend/sirius-web-trees/src/test/resources/logback-test.xml
+++ b/backend/sirius-web-trees/src/test/resources/logback-test.xml
@@ -1,0 +1,3 @@
+<configuration>
+  <logger name="com.tngtech.archunit" level="INFO" />
+</configuration>

--- a/backend/sirius-web-validation/.classpath
+++ b/backend/sirius-web-validation/.classpath
@@ -18,6 +18,13 @@
 			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
+		<attributes>
+			<attribute name="test" value="true"/>
+			<attribute name="ignore_optional_problems" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>

--- a/backend/sirius-web-validation/src/test/resources/logback-test.xml
+++ b/backend/sirius-web-validation/src/test/resources/logback-test.xml
@@ -1,0 +1,3 @@
+<configuration>
+  <logger name="com.tngtech.archunit" level="INFO" />
+</configuration>


### PR DESCRIPTION
Reduce (drastically) the volume of logs when running `mvn clean verify -f backend/pom.xml`: from 9867 lines down to 2778.