### PR TITLE
Improve support for unsynchronized diagrams in the compatibility layer 

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -16,6 +16,10 @@
 
 - https://github.com/eclipse-sirius/sirius-components/issues/804[#804] [core] Update the name of our configuration properties. The configuration property `sirius.web.graphql.websocket.allowed.origins` will now be `sirius.components.cors.allowedOriginPatterns` and it will support complex patterns on top of regular origins. The default value will be restored to nothing since it has temporarily been set to `*`. In a development environment, the recommended value would be both patterns `https://localhost:[*]` and `http://localhost:[*]` in order to accept requests from any application hosted on the same machine. The configuration property `org.eclipse.sirius.web.editingContextEventProcessorRegistry.disposeDelay` will now be `sirius.components.editingContext.disposeDelay`. Its default value will be 1s since it is the only realistic option with domain and view support.
 
+=== New features
+
+- https://github.com/eclipse-sirius/sirius-components/issues/773[#773] [compatibility] Add support for both `createView` and `deleteView` model operations which can be used to support unsynchronized diagrams from Sirius Desktop.
+
 === Improvements
 
 - https://github.com/eclipse-sirius/sirius-components/issues/799[#799] [diagram] The buttons in the diagram's toolbar now have proper tooltips

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -20,6 +20,7 @@
 
 - https://github.com/eclipse-sirius/sirius-components/issues/799[#799] [diagram] The buttons in the diagram's toolbar now have proper tooltips
 - [core] Add a task to display TypeScript errors in the VS Code problems view
+- https://github.com/eclipse-sirius/sirius-components/issues/773[#773] [compatibility] The synchronization policy of the node descriptions is now properly computed from the `AbstractNodeMapping`
 
 
 == v0.5.0

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -15,7 +15,7 @@
 
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-components</artifactId>
-	<version>0.5.1</version>
+	<version>0.5.2</version>
 
 	<name>sirius-components</name>
 	<description>Sirius Components</description>

--- a/backend/sirius-web-annotations-spring/pom.xml
+++ b/backend/sirius-web-annotations-spring/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-annotations-spring</artifactId>
-	<version>0.5.1</version>
+	<version>0.5.2</version>
 	<name>sirius-web-annotations-spring</name>
 	<description>Sirius Web Annotations Spring</description>
 

--- a/backend/sirius-web-annotations/pom.xml
+++ b/backend/sirius-web-annotations/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-annotations</artifactId>
-	<version>0.5.1</version>
+	<version>0.5.2</version>
 	<name>sirius-web-annotations</name>
 	<description>Sirius Web Annotations</description>
 

--- a/backend/sirius-web-api/pom.xml
+++ b/backend/sirius-web-api/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-api</artifactId>
-	<version>0.5.1</version>
+	<version>0.5.2</version>
 	<name>sirius-web-api</name>
 	<description>Sirius Web API</description>
 
@@ -47,17 +47,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-annotations</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-representations</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-forms</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>io.projectreactor</groupId>
@@ -66,7 +66,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend/sirius-web-compatibility/pom.xml
+++ b/backend/sirius-web-compatibility/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-compatibility</artifactId>
-	<version>0.5.1</version>
+	<version>0.5.2</version>
 	<name>sirius-web-compatibility</name>
 	<description>Sirius Web Compatibility</description>
 
@@ -72,7 +72,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -82,43 +82,43 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-tests</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-api</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-core-api</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-collaborative-diagrams</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-forms</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-selection</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-trees</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-interpreter</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.emf</groupId>

--- a/backend/sirius-web-compatibility/pom.xml
+++ b/backend/sirius-web-compatibility/pom.xml
@@ -97,7 +97,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
-			<artifactId>sirius-web-diagrams</artifactId>
+			<artifactId>sirius-web-spring-collaborative-diagrams</artifactId>
 			<version>0.5.1</version>
 		</dependency>
 		<dependency>

--- a/backend/sirius-web-compatibility/src/main/java/org/eclipse/sirius/web/compat/services/diagrams/ToolProvider.java
+++ b/backend/sirius-web-compatibility/src/main/java/org/eclipse/sirius/web/compat/services/diagrams/ToolProvider.java
@@ -46,6 +46,7 @@ import org.eclipse.sirius.web.compat.api.IIdentifierProvider;
 import org.eclipse.sirius.web.compat.api.IModelOperationHandlerSwitchProvider;
 import org.eclipse.sirius.web.compat.api.IToolImageProviderFactory;
 import org.eclipse.sirius.web.compat.services.SelectModelElementVariableProvider;
+import org.eclipse.sirius.web.diagrams.Node;
 import org.eclipse.sirius.web.diagrams.description.EdgeDescription;
 import org.eclipse.sirius.web.diagrams.description.NodeDescription;
 import org.eclipse.sirius.web.diagrams.tools.CreateEdgeTool;
@@ -58,6 +59,7 @@ import org.eclipse.sirius.web.representations.Failure;
 import org.eclipse.sirius.web.representations.IStatus;
 import org.eclipse.sirius.web.representations.Success;
 import org.eclipse.sirius.web.representations.VariableManager;
+import org.eclipse.sirius.web.spring.collaborative.diagrams.api.IDiagramContext;
 import org.springframework.stereotype.Service;
 
 /**
@@ -83,6 +85,12 @@ public class ToolProvider implements IToolProvider {
      * container creation tool has been invoked.
      */
     public static final String CONTAINER = "container"; //$NON-NLS-1$
+
+    /**
+     * The name of the compatibility variable used to store and retrieve the graphical element on which a node or
+     * container creation tool has been invoked.
+     */
+    public static final String CONTAINER_VIEW = "containerView"; //$NON-NLS-1$
 
     /**
      * The name of the compatibility variable used to store and retrieve the semantic element on which a generic tool
@@ -348,6 +356,18 @@ public class ToolProvider implements IToolProvider {
                 Map<String, Object> variables = variableManager.getVariables();
                 // Provide compatibility aliases for this variable
                 variables.put(CONTAINER, variables.get(VariableManager.SELF));
+                if (variables.get(Node.SELECTED_NODE) != null) {
+                    variables.put(CONTAINER_VIEW, variables.get(Node.SELECTED_NODE));
+                } else {
+                    // @formatter:off
+                    Optional.ofNullable(variables.get(IDiagramContext.DIAGRAM_CONTEXT))
+                            .filter(IDiagramContext.class::isInstance)
+                            .map(IDiagramContext.class::cast)
+                            .ifPresent(diagramContext -> {
+                                variables.put(CONTAINER_VIEW, diagramContext.getDiagram());
+                            });
+                    // @formatter:on
+                }
                 var selectModelelementVariableOpt = new SelectModelElementVariableProvider().getSelectModelElementVariable(toolDescription.getVariable());
                 if (selectModelelementVariableOpt.isPresent()) {
                     variables.put(selectModelelementVariableOpt.get().getName(), variables.get(CreateNodeTool.SELECTED_OBJECT));
@@ -369,6 +389,19 @@ public class ToolProvider implements IToolProvider {
                 Map<String, Object> variables = variableManager.getVariables();
                 // Provide compatibility aliases for this variable
                 variables.put(CONTAINER, variables.get(VariableManager.SELF));
+                if (variables.get(Node.SELECTED_NODE) != null) {
+                    variables.put(CONTAINER_VIEW, variables.get(Node.SELECTED_NODE));
+                } else {
+                    // @formatter:off
+                    Optional.ofNullable(variables.get(IDiagramContext.DIAGRAM_CONTEXT))
+                            .filter(IDiagramContext.class::isInstance)
+                            .map(IDiagramContext.class::cast)
+                            .ifPresent(diagramContext -> {
+                                variables.put(CONTAINER_VIEW, diagramContext.getDiagram());
+                            });
+                    // @formatter:on
+                }
+
                 var selectModelelementVariableOpt = new SelectModelElementVariableProvider().getSelectModelElementVariable(toolDescription.getVariable());
                 if (selectModelelementVariableOpt.isPresent()) {
                     variables.put(selectModelelementVariableOpt.get().getName(), variables.get(CreateNodeTool.SELECTED_OBJECT));

--- a/backend/sirius-web-components/pom.xml
+++ b/backend/sirius-web-components/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-components</artifactId>
-	<version>0.5.1</version>
+	<version>0.5.2</version>
 	<name>sirius-web-components</name>
 	<description>Sirius Web Components</description>
 
@@ -52,7 +52,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend/sirius-web-core-api/pom.xml
+++ b/backend/sirius-web-core-api/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-core-api</artifactId>
-	<version>0.5.1</version>
+	<version>0.5.2</version>
 	<name>sirius-web-core-api</name>
 	<description>Sirius Web Core API</description>
 
@@ -47,17 +47,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-annotations</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-representations</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend/sirius-web-diagrams-layout-api/pom.xml
+++ b/backend/sirius-web-diagrams-layout-api/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-diagrams-layout-api</artifactId>
-	<version>0.5.1</version>
+	<version>0.5.2</version>
 	<name>sirius-web-diagrams-layout-api</name>
 	<description>Sirius Web Diagrams Layout API</description>
 
@@ -42,12 +42,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-diagrams</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-core-api</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 	</dependencies>
 

--- a/backend/sirius-web-diagrams-layout/pom.xml
+++ b/backend/sirius-web-diagrams-layout/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-diagrams-layout</artifactId>
-	<version>0.5.1</version>
+	<version>0.5.2</version>
 	<name>sirius-web-diagrams-layout</name>
 	<description>Sirius Web Diagrams layout</description>
 
@@ -65,17 +65,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-annotations</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-core-api</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-diagrams-layout-api</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.elk</groupId>
@@ -112,7 +112,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -127,12 +127,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-diagrams</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-diagrams-tests</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/backend/sirius-web-diagrams-tests/pom.xml
+++ b/backend/sirius-web-diagrams-tests/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-diagrams-tests</artifactId>
-	<version>0.5.1</version>
+	<version>0.5.2</version>
 	<name>sirius-web-diagrams-tests</name>
 	<description>Sirius Web Diagrams Tests</description>
 
@@ -42,7 +42,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-diagrams</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.assertj</groupId>

--- a/backend/sirius-web-diagrams/pom.xml
+++ b/backend/sirius-web-diagrams/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-diagrams</artifactId>
-	<version>0.5.1</version>
+	<version>0.5.2</version>
 	<name>sirius-web-diagrams</name>
 	<description>Sirius Web Diagrams</description>
 
@@ -42,12 +42,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-components</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-representations</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -57,7 +57,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/tools/DeleteTool.java
+++ b/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/tools/DeleteTool.java
@@ -1,0 +1,143 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.diagrams.tools;
+
+import java.text.MessageFormat;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+
+import org.eclipse.sirius.web.annotations.Immutable;
+import org.eclipse.sirius.web.annotations.graphql.GraphQLField;
+import org.eclipse.sirius.web.annotations.graphql.GraphQLID;
+import org.eclipse.sirius.web.annotations.graphql.GraphQLNonNull;
+import org.eclipse.sirius.web.annotations.graphql.GraphQLObjectType;
+import org.eclipse.sirius.web.diagrams.description.NodeDescription;
+import org.eclipse.sirius.web.representations.IStatus;
+import org.eclipse.sirius.web.representations.VariableManager;
+
+/**
+ * A delete element Tool implementation.
+ *
+ * @author arichard
+ */
+@Immutable
+@GraphQLObjectType
+public final class DeleteTool implements ITool {
+
+    private String id;
+
+    private String imageURL;
+
+    private String label;
+
+    private Function<VariableManager, IStatus> handler;
+
+    private List<NodeDescription> targetDescriptions;
+
+    private DeleteTool() {
+        // Prevent instantiation
+    }
+
+    @GraphQLID
+    @GraphQLNonNull
+    @Override
+    public String getId() {
+        return this.id;
+    }
+
+    @GraphQLNonNull
+    @Override
+    public String getLabel() {
+        return this.label;
+    }
+
+    @Override
+    public Function<VariableManager, IStatus> getHandler() {
+        return this.handler;
+    }
+
+    @GraphQLNonNull
+    @Override
+    public String getImageURL() {
+        return this.imageURL;
+    }
+
+    @GraphQLField
+    @GraphQLNonNull
+    public List<@GraphQLNonNull NodeDescription> getTargetDescriptions() {
+        return this.targetDescriptions;
+    }
+
+    @Override
+    public String toString() {
+        String pattern = "{0} '{'id: {1}, label: {2}, imageURL: {3}'}'"; //$NON-NLS-1$
+        return MessageFormat.format(pattern, this.getClass().getSimpleName(), this.id, this.label, this.imageURL);
+    }
+
+    public static Builder newDeleteTool(String id) {
+        return new Builder(id);
+    }
+
+    /**
+     * The builder used to create a tool.
+     *
+     * @author arichard
+     */
+    @SuppressWarnings("checkstyle:HiddenField")
+    public static final class Builder {
+        private String id;
+
+        private String imageURL;
+
+        private String label;
+
+        private Function<VariableManager, IStatus> handler;
+
+        private List<NodeDescription> targetDescriptions;
+
+        private Builder(String id) {
+            this.id = Objects.requireNonNull(id);
+        }
+
+        public Builder imageURL(String imageURL) {
+            this.imageURL = Objects.requireNonNull(imageURL);
+            return this;
+        }
+
+        public Builder label(String label) {
+            this.label = Objects.requireNonNull(label);
+            return this;
+        }
+
+        public Builder handler(Function<VariableManager, IStatus> handler) {
+            this.handler = Objects.requireNonNull(handler);
+            return this;
+        }
+
+        public Builder targetDescriptions(List<NodeDescription> targetDescriptions) {
+            this.targetDescriptions = Objects.requireNonNull(targetDescriptions);
+            return this;
+        }
+
+        public DeleteTool build() {
+            DeleteTool tool = new DeleteTool();
+            tool.id = Objects.requireNonNull(this.id);
+            tool.imageURL = Objects.requireNonNull(this.imageURL);
+            tool.label = Objects.requireNonNull(this.label);
+            tool.handler = Objects.requireNonNull(this.handler);
+            tool.targetDescriptions = Objects.requireNonNull(this.targetDescriptions);
+            return tool;
+        }
+    }
+}

--- a/backend/sirius-web-domain-design/pom.xml
+++ b/backend/sirius-web-domain-design/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-domain-design</artifactId>
-	<version>0.5.1</version>
+	<version>0.5.2</version>
 	<name>sirius-web-domain-design</name>
 	<description>Sirius Web Domain Definition DSL - Graphical Modeler Definition</description>
 
@@ -64,7 +64,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-domain</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 	</dependencies>
 	

--- a/backend/sirius-web-domain-edit/pom.xml
+++ b/backend/sirius-web-domain-edit/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-domain-edit</artifactId>
-	<version>0.5.1</version>
+	<version>0.5.2</version>
 	<name>sirius-web-domain-edit</name>
 	<description>Sirius Web Domain Definition DSL - Edit Support</description>
 
@@ -64,7 +64,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-domain</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 	</dependencies>
 	

--- a/backend/sirius-web-domain/pom.xml
+++ b/backend/sirius-web-domain/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-domain</artifactId>
-	<version>0.5.1</version>
+	<version>0.5.2</version>
 	<name>sirius-web-domain</name>
 	<description>Sirius Web Domain Definition DSL</description>
 

--- a/backend/sirius-web-emf/pom.xml
+++ b/backend/sirius-web-emf/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-emf</artifactId>
-	<version>0.5.1</version>
+	<version>0.5.2</version>
 	<name>sirius-web-emf</name>
 	<description>Sirius Web EMF</description>
 
@@ -66,52 +66,52 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-graphql-api</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-collaborative</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-collaborative-diagrams</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-collaborative-forms</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-collaborative-trees</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-collaborative-validation</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-compatibility</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-interpreter</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-domain</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-view</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.emf</groupId>
@@ -160,13 +160,13 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-tests</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend/sirius-web-emf/pom.xml
+++ b/backend/sirius-web-emf/pom.xml
@@ -75,6 +75,11 @@
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
+			<artifactId>sirius-web-spring-collaborative-diagrams</artifactId>
+			<version>0.5.1</version>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-collaborative-forms</artifactId>
 			<version>0.5.1</version>
 		</dependency>

--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/modeloperations/ChangeContextOperationHandler.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/modeloperations/ChangeContextOperationHandler.java
@@ -20,7 +20,9 @@ import java.util.Optional;
 
 import org.eclipse.sirius.viewpoint.description.tool.ChangeContext;
 import org.eclipse.sirius.viewpoint.description.tool.ModelOperation;
+import org.eclipse.sirius.web.compat.api.IIdentifierProvider;
 import org.eclipse.sirius.web.compat.api.IModelOperationHandler;
+import org.eclipse.sirius.web.core.api.IObjectService;
 import org.eclipse.sirius.web.interpreter.AQLInterpreter;
 import org.eclipse.sirius.web.representations.IStatus;
 import org.eclipse.sirius.web.representations.VariableManager;
@@ -32,13 +34,20 @@ import org.eclipse.sirius.web.representations.VariableManager;
  */
 public class ChangeContextOperationHandler implements IModelOperationHandler {
 
+    private final IObjectService objectService;
+
+    private final IIdentifierProvider identifierProvider;
+
     private final AQLInterpreter interpreter;
 
     private final ChildModelOperationHandler childModelOperationHandler;
 
     private final ChangeContext changeContext;
 
-    public ChangeContextOperationHandler(AQLInterpreter interpreter, ChildModelOperationHandler childModelOperationHandler, ChangeContext changeContext) {
+    public ChangeContextOperationHandler(IObjectService objectService, IIdentifierProvider identifierProvider, AQLInterpreter interpreter, ChildModelOperationHandler childModelOperationHandler,
+            ChangeContext changeContext) {
+        this.objectService = Objects.requireNonNull(objectService);
+        this.identifierProvider = Objects.requireNonNull(identifierProvider);
         this.interpreter = Objects.requireNonNull(interpreter);
         this.childModelOperationHandler = Objects.requireNonNull(childModelOperationHandler);
         this.changeContext = Objects.requireNonNull(changeContext);
@@ -54,7 +63,7 @@ public class ChangeContextOperationHandler implements IModelOperationHandler {
         }
 
         List<ModelOperation> subModelOperations = this.changeContext.getSubModelOperations();
-        return this.childModelOperationHandler.handle(this.interpreter, childVariables, subModelOperations);
+        return this.childModelOperationHandler.handle(this.objectService, this.identifierProvider, this.interpreter, childVariables, subModelOperations);
     }
 
 }

--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/modeloperations/ChildModelOperationHandler.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/modeloperations/ChildModelOperationHandler.java
@@ -17,7 +17,9 @@ import java.util.Map;
 import java.util.Optional;
 
 import org.eclipse.sirius.viewpoint.description.tool.ModelOperation;
+import org.eclipse.sirius.web.compat.api.IIdentifierProvider;
 import org.eclipse.sirius.web.compat.api.IModelOperationHandler;
+import org.eclipse.sirius.web.core.api.IObjectService;
 import org.eclipse.sirius.web.interpreter.AQLInterpreter;
 import org.eclipse.sirius.web.representations.Failure;
 import org.eclipse.sirius.web.representations.IStatus;
@@ -29,10 +31,10 @@ import org.eclipse.sirius.web.representations.Success;
  * @author sbegaudeau
  */
 public class ChildModelOperationHandler {
-    public IStatus handle(AQLInterpreter interpreter, Map<String, Object> variables, List<ModelOperation> modelOperations) {
+    public IStatus handle(IObjectService objectService, IIdentifierProvider identifierProvider, AQLInterpreter interpreter, Map<String, Object> variables, List<ModelOperation> modelOperations) {
         boolean hasBeenSuccessfullyExecuted = true;
 
-        ModelOperationHandlerSwitch modelOperationHandlerSwitch = new ModelOperationHandlerSwitch(interpreter);
+        ModelOperationHandlerSwitch modelOperationHandlerSwitch = new ModelOperationHandlerSwitch(objectService, identifierProvider, interpreter);
         for (ModelOperation modelOperation : modelOperations) {
             Optional<IModelOperationHandler> optionalModelOperationHandler = modelOperationHandlerSwitch.apply(modelOperation);
 

--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/modeloperations/CreateInstanceOperationHandler.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/modeloperations/CreateInstanceOperationHandler.java
@@ -28,8 +28,10 @@ import org.eclipse.sirius.ecore.extender.business.api.accessor.EcoreMetamodelDes
 import org.eclipse.sirius.ecore.extender.business.internal.accessor.ecore.EcoreIntrinsicExtender;
 import org.eclipse.sirius.viewpoint.description.tool.CreateInstance;
 import org.eclipse.sirius.viewpoint.description.tool.ModelOperation;
+import org.eclipse.sirius.web.compat.api.IIdentifierProvider;
 import org.eclipse.sirius.web.compat.api.IModelOperationHandler;
 import org.eclipse.sirius.web.core.api.IEditingContext;
+import org.eclipse.sirius.web.core.api.IObjectService;
 import org.eclipse.sirius.web.emf.compatibility.EPackageService;
 import org.eclipse.sirius.web.emf.services.EditingContext;
 import org.eclipse.sirius.web.interpreter.AQLInterpreter;
@@ -52,6 +54,10 @@ public class CreateInstanceOperationHandler implements IModelOperationHandler {
 
     private final Logger logger = LoggerFactory.getLogger(CreateInstanceOperationHandler.class);
 
+    private final IObjectService objectService;
+
+    private final IIdentifierProvider identifierProvider;
+
     private final AQLInterpreter interpreter;
 
     private final EPackageService ePackageService;
@@ -60,7 +66,10 @@ public class CreateInstanceOperationHandler implements IModelOperationHandler {
 
     private final CreateInstance createInstance;
 
-    public CreateInstanceOperationHandler(AQLInterpreter interpreter, EPackageService ePackageService, ChildModelOperationHandler childModelOperationHandler, CreateInstance createInstance) {
+    public CreateInstanceOperationHandler(IObjectService objectService, IIdentifierProvider identifierProvider, AQLInterpreter interpreter, EPackageService ePackageService,
+            ChildModelOperationHandler childModelOperationHandler, CreateInstance createInstance) {
+        this.objectService = Objects.requireNonNull(objectService);
+        this.identifierProvider = Objects.requireNonNull(identifierProvider);
         this.interpreter = Objects.requireNonNull(interpreter);
         this.ePackageService = Objects.requireNonNull(ePackageService);
         this.childModelOperationHandler = Objects.requireNonNull(childModelOperationHandler);
@@ -120,6 +129,6 @@ public class CreateInstanceOperationHandler implements IModelOperationHandler {
         }
 
         List<ModelOperation> subModelOperations = this.createInstance.getSubModelOperations();
-        return this.childModelOperationHandler.handle(this.interpreter, childVariables, subModelOperations);
+        return this.childModelOperationHandler.handle(this.objectService, this.identifierProvider, this.interpreter, childVariables, subModelOperations);
     }
 }

--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/modeloperations/CreateViewOperationHandler.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/modeloperations/CreateViewOperationHandler.java
@@ -98,9 +98,9 @@ public class CreateViewOperationHandler implements IModelOperationHandler {
                     .build();
 
             Optional.ofNullable(variables.get(IDiagramContext.DIAGRAM_CONTEXT))
-            .filter(IDiagramContext.class::isInstance)
-            .map(IDiagramContext.class::cast)
-            .ifPresent(diagramContext -> diagramContext.getViewCreationRequests().add(viewCreationRequest));
+                    .filter(IDiagramContext.class::isInstance)
+                    .map(IDiagramContext.class::cast)
+                    .ifPresent(diagramContext -> diagramContext.getViewCreationRequests().add(viewCreationRequest));
         } catch (IllegalArgumentException exception) {
             this.logger.warn(exception.getMessage(), exception);
         }

--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/modeloperations/CreateViewOperationHandler.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/modeloperations/CreateViewOperationHandler.java
@@ -1,0 +1,114 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.emf.compatibility.modeloperations;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.eclipse.sirius.diagram.description.DiagramElementMapping;
+import org.eclipse.sirius.diagram.description.tool.CreateView;
+import org.eclipse.sirius.viewpoint.description.tool.ModelOperation;
+import org.eclipse.sirius.web.compat.api.IIdentifierProvider;
+import org.eclipse.sirius.web.compat.api.IModelOperationHandler;
+import org.eclipse.sirius.web.core.api.IObjectService;
+import org.eclipse.sirius.web.diagrams.Diagram;
+import org.eclipse.sirius.web.diagrams.Node;
+import org.eclipse.sirius.web.diagrams.ViewCreationRequest;
+import org.eclipse.sirius.web.interpreter.AQLInterpreter;
+import org.eclipse.sirius.web.representations.Failure;
+import org.eclipse.sirius.web.representations.IStatus;
+import org.eclipse.sirius.web.representations.VariableManager;
+import org.eclipse.sirius.web.spring.collaborative.diagrams.api.IDiagramContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Handles the create view model operation.
+ *
+ * @author sbegaudeau
+ */
+public class CreateViewOperationHandler implements IModelOperationHandler {
+
+    private final Logger logger = LoggerFactory.getLogger(CreateViewOperationHandler.class);
+
+    private final IObjectService objectService;
+
+    private final IIdentifierProvider identifierProvider;
+
+    private final AQLInterpreter interpreter;
+
+    private final ChildModelOperationHandler childModelOperationHandler;
+
+    private final CreateView createView;
+
+    public CreateViewOperationHandler(IObjectService objectService, IIdentifierProvider identifierProvider, AQLInterpreter interpreter, ChildModelOperationHandler childModelOperationHandler,
+            CreateView createView) {
+        this.objectService = Objects.requireNonNull(objectService);
+        this.identifierProvider = Objects.requireNonNull(identifierProvider);
+        this.interpreter = Objects.requireNonNull(interpreter);
+        this.childModelOperationHandler = Objects.requireNonNull(childModelOperationHandler);
+        this.createView = Objects.requireNonNull(createView);
+    }
+
+    @Override
+    public IStatus handle(Map<String, Object> variables) {
+        String containerViewExpression = this.createView.getContainerViewExpression();
+
+        var optionalParentElementId = this.interpreter.evaluateExpression(variables, containerViewExpression).asObject().flatMap(parentElement -> {
+            Optional<UUID> optionalElementId = Optional.empty();
+            if (parentElement instanceof Diagram) {
+                Diagram diagram = (Diagram) parentElement;
+                optionalElementId = Optional.of(diagram.getId());
+            } else if (parentElement instanceof Node) {
+                Node node = (Node) parentElement;
+                optionalElementId = Optional.of(node.getId());
+            }
+            return optionalElementId;
+        });
+
+        if (optionalParentElementId.isEmpty()) {
+            return new Failure(""); //$NON-NLS-1$
+        }
+
+        DiagramElementMapping diagramElementMapping = this.createView.getMapping();
+        String diagramElementMappingId = this.identifierProvider.getIdentifier(diagramElementMapping);
+        String targetObjectId = this.objectService.getId(variables.get(VariableManager.SELF));
+
+        // @formatter:off
+        try {
+            UUID descriptionId = UUID.fromString(diagramElementMappingId);
+            ViewCreationRequest viewCreationRequest = ViewCreationRequest.newViewCreationRequest()
+                    .parentElementId(optionalParentElementId.get())
+                    .descriptionId(descriptionId)
+                    .targetObjectId(targetObjectId)
+                    .build();
+
+            Optional.ofNullable(variables.get(IDiagramContext.DIAGRAM_CONTEXT))
+            .filter(IDiagramContext.class::isInstance)
+            .map(IDiagramContext.class::cast)
+            .ifPresent(diagramContext -> diagramContext.getViewCreationRequests().add(viewCreationRequest));
+        } catch (IllegalArgumentException exception) {
+            this.logger.warn(exception.getMessage(), exception);
+        }
+        // @formatter:on
+
+        Map<String, Object> childVariables = new HashMap<>(variables);
+        List<ModelOperation> subModelOperations = this.createView.getSubModelOperations();
+        return this.childModelOperationHandler.handle(this.objectService, this.identifierProvider, this.interpreter, childVariables, subModelOperations);
+    }
+
+}

--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/modeloperations/DeleteViewOperationHandler.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/modeloperations/DeleteViewOperationHandler.java
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.emf.compatibility.modeloperations;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.eclipse.sirius.viewpoint.description.tool.DeleteView;
+import org.eclipse.sirius.viewpoint.description.tool.ModelOperation;
+import org.eclipse.sirius.web.compat.api.IIdentifierProvider;
+import org.eclipse.sirius.web.compat.api.IModelOperationHandler;
+import org.eclipse.sirius.web.core.api.IObjectService;
+import org.eclipse.sirius.web.diagrams.Node;
+import org.eclipse.sirius.web.diagrams.ViewDeletionRequest;
+import org.eclipse.sirius.web.interpreter.AQLInterpreter;
+import org.eclipse.sirius.web.representations.Failure;
+import org.eclipse.sirius.web.representations.IStatus;
+import org.eclipse.sirius.web.representations.VariableManager;
+import org.eclipse.sirius.web.spring.collaborative.diagrams.api.IDiagramContext;
+
+/**
+ * Handles the delete view model operation.
+ *
+ * @author arichard
+ */
+public class DeleteViewOperationHandler implements IModelOperationHandler {
+
+    private final IObjectService objectService;
+
+    private final IIdentifierProvider identifierProvider;
+
+    private final AQLInterpreter interpreter;
+
+    private final ChildModelOperationHandler childModelOperationHandler;
+
+    private final DeleteView deleteView;
+
+    public DeleteViewOperationHandler(IObjectService objectService, IIdentifierProvider identifierProvider, AQLInterpreter interpreter, ChildModelOperationHandler childModelOperationHandler,
+            DeleteView deleteView) {
+        this.objectService = Objects.requireNonNull(objectService);
+        this.identifierProvider = Objects.requireNonNull(identifierProvider);
+        this.interpreter = Objects.requireNonNull(interpreter);
+        this.childModelOperationHandler = Objects.requireNonNull(childModelOperationHandler);
+        this.deleteView = Objects.requireNonNull(deleteView);
+    }
+
+    @Override
+    public IStatus handle(Map<String, Object> variables) {
+        Object self = variables.get(VariableManager.SELF);
+        if (self instanceof Node) {
+            UUID elementId = ((Node) self).getId();
+            // @formatter:off
+            ViewDeletionRequest viewDeletionRequest = ViewDeletionRequest.newViewDeletionRequest()
+                    .elementId(elementId)
+                    .build();
+
+            Optional.ofNullable(variables.get(IDiagramContext.DIAGRAM_CONTEXT))
+                    .filter(IDiagramContext.class::isInstance)
+                    .map(IDiagramContext.class::cast)
+                    .ifPresent(diagramContext -> diagramContext.getViewDeletionRequests().add(viewDeletionRequest));
+            // @formatter:on
+
+            Map<String, Object> childVariables = new HashMap<>(variables);
+            List<ModelOperation> subModelOperations = this.deleteView.getSubModelOperations();
+            return this.childModelOperationHandler.handle(this.objectService, this.identifierProvider, this.interpreter, childVariables, subModelOperations);
+        }
+        return new Failure(""); //$NON-NLS-1$
+    }
+
+}

--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/modeloperations/ForOperationHandler.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/modeloperations/ForOperationHandler.java
@@ -20,7 +20,9 @@ import java.util.Optional;
 
 import org.eclipse.sirius.viewpoint.description.tool.For;
 import org.eclipse.sirius.viewpoint.description.tool.ModelOperation;
+import org.eclipse.sirius.web.compat.api.IIdentifierProvider;
 import org.eclipse.sirius.web.compat.api.IModelOperationHandler;
+import org.eclipse.sirius.web.core.api.IObjectService;
 import org.eclipse.sirius.web.interpreter.AQLInterpreter;
 import org.eclipse.sirius.web.representations.IStatus;
 import org.eclipse.sirius.web.representations.Success;
@@ -32,13 +34,20 @@ import org.eclipse.sirius.web.representations.Success;
  */
 public class ForOperationHandler implements IModelOperationHandler {
 
+    private final IObjectService objectService;
+
+    private final IIdentifierProvider identifierProvider;
+
     private final AQLInterpreter interpreter;
 
     private final ChildModelOperationHandler childModelOperationHandler;
 
     private final For forOperation;
 
-    public ForOperationHandler(AQLInterpreter interpreter, ChildModelOperationHandler childModelOperationHandler, For forOperation) {
+    public ForOperationHandler(IObjectService objectService, IIdentifierProvider identifierProvider, AQLInterpreter interpreter, ChildModelOperationHandler childModelOperationHandler,
+            For forOperation) {
+        this.objectService = Objects.requireNonNull(objectService);
+        this.identifierProvider = Objects.requireNonNull(identifierProvider);
         this.interpreter = Objects.requireNonNull(interpreter);
         this.childModelOperationHandler = Objects.requireNonNull(childModelOperationHandler);
         this.forOperation = Objects.requireNonNull(forOperation);
@@ -60,7 +69,7 @@ public class ForOperationHandler implements IModelOperationHandler {
                     childVariables.put(iteratedVariableName, object);
 
                     List<ModelOperation> subModelOperations = this.forOperation.getSubModelOperations();
-                    this.childModelOperationHandler.handle(this.interpreter, childVariables, subModelOperations);
+                    this.childModelOperationHandler.handle(this.objectService, this.identifierProvider, this.interpreter, childVariables, subModelOperations);
                 }
             }
         }

--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/modeloperations/IfOperationHandler.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/modeloperations/IfOperationHandler.java
@@ -19,7 +19,9 @@ import java.util.Optional;
 
 import org.eclipse.sirius.viewpoint.description.tool.If;
 import org.eclipse.sirius.viewpoint.description.tool.ModelOperation;
+import org.eclipse.sirius.web.compat.api.IIdentifierProvider;
 import org.eclipse.sirius.web.compat.api.IModelOperationHandler;
+import org.eclipse.sirius.web.core.api.IObjectService;
 import org.eclipse.sirius.web.interpreter.AQLInterpreter;
 import org.eclipse.sirius.web.representations.IStatus;
 import org.eclipse.sirius.web.representations.Success;
@@ -31,13 +33,19 @@ import org.eclipse.sirius.web.representations.Success;
  */
 public class IfOperationHandler implements IModelOperationHandler {
 
+    private final IObjectService objectService;
+
+    private final IIdentifierProvider identifierProvider;
+
     private final AQLInterpreter interpreter;
 
     private final ChildModelOperationHandler childModelOperationHandler;
 
     private final If ifOperation;
 
-    public IfOperationHandler(AQLInterpreter interpreter, ChildModelOperationHandler childModelOperationHandler, If ifOperation) {
+    public IfOperationHandler(IObjectService objectService, IIdentifierProvider identifierProvider, AQLInterpreter interpreter, ChildModelOperationHandler childModelOperationHandler, If ifOperation) {
+        this.objectService = Objects.requireNonNull(objectService);
+        this.identifierProvider = Objects.requireNonNull(identifierProvider);
         this.interpreter = Objects.requireNonNull(interpreter);
         this.childModelOperationHandler = Objects.requireNonNull(childModelOperationHandler);
         this.ifOperation = Objects.requireNonNull(ifOperation);
@@ -51,7 +59,7 @@ public class IfOperationHandler implements IModelOperationHandler {
 
             if (optionalValueObject.isPresent() && optionalValueObject.get()) {
                 List<ModelOperation> subModelOperations = this.ifOperation.getSubModelOperations();
-                return this.childModelOperationHandler.handle(this.interpreter, variables, subModelOperations);
+                return this.childModelOperationHandler.handle(this.objectService, this.identifierProvider, this.interpreter, variables, subModelOperations);
             }
         }
 

--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/modeloperations/LetOperationHandler.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/modeloperations/LetOperationHandler.java
@@ -20,7 +20,9 @@ import java.util.Optional;
 
 import org.eclipse.sirius.viewpoint.description.tool.Let;
 import org.eclipse.sirius.viewpoint.description.tool.ModelOperation;
+import org.eclipse.sirius.web.compat.api.IIdentifierProvider;
 import org.eclipse.sirius.web.compat.api.IModelOperationHandler;
+import org.eclipse.sirius.web.core.api.IObjectService;
 import org.eclipse.sirius.web.interpreter.AQLInterpreter;
 import org.eclipse.sirius.web.representations.IStatus;
 
@@ -31,13 +33,20 @@ import org.eclipse.sirius.web.representations.IStatus;
  */
 public class LetOperationHandler implements IModelOperationHandler {
 
+    private final IObjectService objectService;
+
+    private final IIdentifierProvider identifierProvider;
+
     private final AQLInterpreter interpreter;
 
     private final ChildModelOperationHandler childModelOperationHandler;
 
     private final Let letOperation;
 
-    public LetOperationHandler(AQLInterpreter interpreter, ChildModelOperationHandler childModelOperationHandler, Let letOperation) {
+    public LetOperationHandler(IObjectService objectService, IIdentifierProvider identifierProvider, AQLInterpreter interpreter, ChildModelOperationHandler childModelOperationHandler,
+            Let letOperation) {
+        this.objectService = Objects.requireNonNull(objectService);
+        this.identifierProvider = Objects.requireNonNull(identifierProvider);
         this.interpreter = Objects.requireNonNull(interpreter);
         this.childModelOperationHandler = Objects.requireNonNull(childModelOperationHandler);
         this.letOperation = Objects.requireNonNull(letOperation);
@@ -60,7 +69,7 @@ public class LetOperationHandler implements IModelOperationHandler {
         }
 
         List<ModelOperation> subModelOperations = this.letOperation.getSubModelOperations();
-        return this.childModelOperationHandler.handle(this.interpreter, childVariables, subModelOperations);
+        return this.childModelOperationHandler.handle(this.objectService, this.identifierProvider, this.interpreter, childVariables, subModelOperations);
     }
 
 }

--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/modeloperations/ModelOperationHandlerSwitch.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/modeloperations/ModelOperationHandlerSwitch.java
@@ -31,7 +31,9 @@ import org.eclipse.sirius.viewpoint.description.tool.SetObject;
 import org.eclipse.sirius.viewpoint.description.tool.SetValue;
 import org.eclipse.sirius.viewpoint.description.tool.Switch;
 import org.eclipse.sirius.viewpoint.description.tool.Unset;
+import org.eclipse.sirius.web.compat.api.IIdentifierProvider;
 import org.eclipse.sirius.web.compat.api.IModelOperationHandler;
+import org.eclipse.sirius.web.core.api.IObjectService;
 import org.eclipse.sirius.web.emf.compatibility.EPackageService;
 import org.eclipse.sirius.web.interpreter.AQLInterpreter;
 import org.slf4j.Logger;
@@ -46,11 +48,17 @@ public class ModelOperationHandlerSwitch implements Function<ModelOperation, Opt
 
     private final Logger logger = LoggerFactory.getLogger(ModelOperationHandlerSwitch.class);
 
+    private final IObjectService objectService;
+
+    private final IIdentifierProvider identifierProvider;
+
     private final AQLInterpreter interpreter;
 
     private final ChildModelOperationHandler childModelOperationHandler;
 
-    public ModelOperationHandlerSwitch(AQLInterpreter interpreter) {
+    public ModelOperationHandlerSwitch(IObjectService objectService, IIdentifierProvider identifierProvider, AQLInterpreter interpreter) {
+        this.objectService = Objects.requireNonNull(objectService);
+        this.identifierProvider = Objects.requireNonNull(identifierProvider);
         this.interpreter = Objects.requireNonNull(interpreter);
         this.childModelOperationHandler = new ChildModelOperationHandler();
     }
@@ -97,15 +105,16 @@ public class ModelOperationHandlerSwitch implements Function<ModelOperation, Opt
     }
 
     private Optional<IModelOperationHandler> caseChangeContext(ChangeContext changeContextOperation) {
-        return Optional.of(new ChangeContextOperationHandler(this.interpreter, this.childModelOperationHandler, changeContextOperation));
+        return Optional.of(new ChangeContextOperationHandler(this.objectService, this.identifierProvider, this.interpreter, this.childModelOperationHandler, changeContextOperation));
     }
 
     private Optional<IModelOperationHandler> caseCreateInstance(CreateInstance createInstanceOperation) {
-        return Optional.of(new CreateInstanceOperationHandler(this.interpreter, new EPackageService(), this.childModelOperationHandler, createInstanceOperation));
+        return Optional
+                .of(new CreateInstanceOperationHandler(this.objectService, this.identifierProvider, this.interpreter, new EPackageService(), this.childModelOperationHandler, createInstanceOperation));
     }
 
     private Optional<IModelOperationHandler> caseCreateView(CreateView createViewOperation) {
-        return Optional.empty();
+        return Optional.of(new CreateViewOperationHandler(this.objectService, this.identifierProvider, this.interpreter, this.childModelOperationHandler, createViewOperation));
     }
 
     private Optional<IModelOperationHandler> caseDeleteView(DeleteView deleteViewOperation) {
@@ -113,19 +122,19 @@ public class ModelOperationHandlerSwitch implements Function<ModelOperation, Opt
     }
 
     private Optional<IModelOperationHandler> caseFor(For forOperation) {
-        return Optional.of(new ForOperationHandler(this.interpreter, this.childModelOperationHandler, forOperation));
+        return Optional.of(new ForOperationHandler(this.objectService, this.identifierProvider, this.interpreter, this.childModelOperationHandler, forOperation));
     }
 
     private Optional<IModelOperationHandler> caseIf(If ifOperation) {
-        return Optional.of(new IfOperationHandler(this.interpreter, this.childModelOperationHandler, ifOperation));
+        return Optional.of(new IfOperationHandler(this.objectService, this.identifierProvider, this.interpreter, this.childModelOperationHandler, ifOperation));
     }
 
     private Optional<IModelOperationHandler> caseLet(Let letOperation) {
-        return Optional.of(new LetOperationHandler(this.interpreter, this.childModelOperationHandler, letOperation));
+        return Optional.of(new LetOperationHandler(this.objectService, this.identifierProvider, this.interpreter, this.childModelOperationHandler, letOperation));
     }
 
     private Optional<IModelOperationHandler> caseMoveElement(MoveElement moveElementOperation) {
-        return Optional.of(new MoveElementOperationHandler(this.interpreter, this.childModelOperationHandler, moveElementOperation));
+        return Optional.of(new MoveElementOperationHandler(this.objectService, this.identifierProvider, this.interpreter, this.childModelOperationHandler, moveElementOperation));
     }
 
     private Optional<IModelOperationHandler> caseNavigation(Navigation navigationOperation) {
@@ -133,7 +142,7 @@ public class ModelOperationHandlerSwitch implements Function<ModelOperation, Opt
     }
 
     private Optional<IModelOperationHandler> caseRemoveElement(RemoveElement removeElementOperation) {
-        return Optional.of(new RemoveElementOperationHandler(this.interpreter, this.childModelOperationHandler, removeElementOperation));
+        return Optional.of(new RemoveElementOperationHandler(this.objectService, this.identifierProvider, this.interpreter, this.childModelOperationHandler, removeElementOperation));
     }
 
     private Optional<IModelOperationHandler> caseSetObject(SetObject setObjectOperation) {
@@ -141,15 +150,15 @@ public class ModelOperationHandlerSwitch implements Function<ModelOperation, Opt
     }
 
     private Optional<IModelOperationHandler> caseSetValue(SetValue setValueOperation) {
-        return Optional.of(new SetValueOperationHandler(this.interpreter, this.childModelOperationHandler, setValueOperation));
+        return Optional.of(new SetValueOperationHandler(this.objectService, this.identifierProvider, this.interpreter, this.childModelOperationHandler, setValueOperation));
     }
 
     private Optional<IModelOperationHandler> caseUnset(Unset unsetOperation) {
-        return Optional.of(new UnsetOperationHandler(this.interpreter, this.childModelOperationHandler, unsetOperation));
+        return Optional.of(new UnsetOperationHandler(this.objectService, this.identifierProvider, this.interpreter, this.childModelOperationHandler, unsetOperation));
     }
 
     private Optional<IModelOperationHandler> caseSwitch(Switch switchOperation) {
-        return Optional.of(new SwitchOperationHandler(this.interpreter, this.childModelOperationHandler, switchOperation));
+        return Optional.of(new SwitchOperationHandler(this.objectService, this.identifierProvider, this.interpreter, this.childModelOperationHandler, switchOperation));
     }
 
 }

--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/modeloperations/ModelOperationHandlerSwitch.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/modeloperations/ModelOperationHandlerSwitch.java
@@ -118,7 +118,7 @@ public class ModelOperationHandlerSwitch implements Function<ModelOperation, Opt
     }
 
     private Optional<IModelOperationHandler> caseDeleteView(DeleteView deleteViewOperation) {
-        return Optional.empty();
+        return Optional.of(new DeleteViewOperationHandler(this.objectService, this.identifierProvider, this.interpreter, this.childModelOperationHandler, deleteViewOperation));
     }
 
     private Optional<IModelOperationHandler> caseFor(For forOperation) {

--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/modeloperations/MoveElementOperationHandler.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/modeloperations/MoveElementOperationHandler.java
@@ -22,7 +22,9 @@ import org.eclipse.emf.ecore.EObject;
 import org.eclipse.sirius.ecore.extender.business.internal.accessor.ecore.EcoreIntrinsicExtender;
 import org.eclipse.sirius.viewpoint.description.tool.ModelOperation;
 import org.eclipse.sirius.viewpoint.description.tool.MoveElement;
+import org.eclipse.sirius.web.compat.api.IIdentifierProvider;
 import org.eclipse.sirius.web.compat.api.IModelOperationHandler;
+import org.eclipse.sirius.web.core.api.IObjectService;
 import org.eclipse.sirius.web.interpreter.AQLInterpreter;
 import org.eclipse.sirius.web.representations.IStatus;
 import org.eclipse.sirius.web.representations.VariableManager;
@@ -37,13 +39,20 @@ import org.slf4j.LoggerFactory;
 public class MoveElementOperationHandler implements IModelOperationHandler {
     private final Logger logger = LoggerFactory.getLogger(MoveElementOperationHandler.class);
 
+    private final IObjectService objectService;
+
+    private final IIdentifierProvider identifierProvider;
+
     private final AQLInterpreter interpreter;
 
     private final ChildModelOperationHandler childModelOperationHandler;
 
     private final MoveElement moveElementOperation;
 
-    public MoveElementOperationHandler(AQLInterpreter interpreter, ChildModelOperationHandler childModelOperationHandler, MoveElement moveElementOperation) {
+    public MoveElementOperationHandler(IObjectService objectService, IIdentifierProvider identifierProvider, AQLInterpreter interpreter, ChildModelOperationHandler childModelOperationHandler,
+            MoveElement moveElementOperation) {
+        this.objectService = Objects.requireNonNull(objectService);
+        this.identifierProvider = Objects.requireNonNull(identifierProvider);
         this.interpreter = Objects.requireNonNull(interpreter);
         this.childModelOperationHandler = Objects.requireNonNull(childModelOperationHandler);
         this.moveElementOperation = Objects.requireNonNull(moveElementOperation);
@@ -74,7 +83,7 @@ public class MoveElementOperationHandler implements IModelOperationHandler {
 
         Map<String, Object> childVariables = new HashMap<>(variables);
         List<ModelOperation> subModelOperations = this.moveElementOperation.getSubModelOperations();
-        return this.childModelOperationHandler.handle(this.interpreter, childVariables, subModelOperations);
+        return this.childModelOperationHandler.handle(this.objectService, this.identifierProvider, this.interpreter, childVariables, subModelOperations);
     }
 
     /**

--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/modeloperations/RemoveElementOperationHandler.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/modeloperations/RemoveElementOperationHandler.java
@@ -22,7 +22,9 @@ import org.eclipse.emf.ecore.EObject;
 import org.eclipse.sirius.ecore.extender.business.internal.accessor.ecore.EcoreIntrinsicExtender;
 import org.eclipse.sirius.viewpoint.description.tool.ModelOperation;
 import org.eclipse.sirius.viewpoint.description.tool.RemoveElement;
+import org.eclipse.sirius.web.compat.api.IIdentifierProvider;
 import org.eclipse.sirius.web.compat.api.IModelOperationHandler;
+import org.eclipse.sirius.web.core.api.IObjectService;
 import org.eclipse.sirius.web.interpreter.AQLInterpreter;
 import org.eclipse.sirius.web.representations.IStatus;
 import org.eclipse.sirius.web.representations.VariableManager;
@@ -36,6 +38,10 @@ import org.slf4j.LoggerFactory;
  */
 public class RemoveElementOperationHandler implements IModelOperationHandler {
 
+    private final IObjectService objectService;
+
+    private final IIdentifierProvider identifierProvider;
+
     private final AQLInterpreter interpreter;
 
     private final ChildModelOperationHandler childModelOperationHandler;
@@ -44,7 +50,10 @@ public class RemoveElementOperationHandler implements IModelOperationHandler {
 
     private final Logger logger = LoggerFactory.getLogger(RemoveElementOperationHandler.class);
 
-    public RemoveElementOperationHandler(AQLInterpreter interpreter, ChildModelOperationHandler childModelOperationHandler, RemoveElement removeElementOperation) {
+    public RemoveElementOperationHandler(IObjectService objectService, IIdentifierProvider identifierProvider, AQLInterpreter interpreter, ChildModelOperationHandler childModelOperationHandler,
+            RemoveElement removeElementOperation) {
+        this.objectService = Objects.requireNonNull(objectService);
+        this.identifierProvider = Objects.requireNonNull(identifierProvider);
         this.interpreter = Objects.requireNonNull(interpreter);
         this.childModelOperationHandler = Objects.requireNonNull(childModelOperationHandler);
         this.removeElementOperation = Objects.requireNonNull(removeElementOperation);
@@ -72,7 +81,7 @@ public class RemoveElementOperationHandler implements IModelOperationHandler {
 
         Map<String, Object> childVariables = new HashMap<>(variables);
         List<ModelOperation> subModelOperations = this.removeElementOperation.getSubModelOperations();
-        return this.childModelOperationHandler.handle(this.interpreter, childVariables, subModelOperations);
+        return this.childModelOperationHandler.handle(this.objectService, this.identifierProvider, this.interpreter, childVariables, subModelOperations);
     }
 
 }

--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/modeloperations/SetValueOperationHandler.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/modeloperations/SetValueOperationHandler.java
@@ -22,7 +22,9 @@ import org.eclipse.emf.ecore.EObject;
 import org.eclipse.sirius.ecore.extender.business.internal.accessor.ecore.EcoreIntrinsicExtender;
 import org.eclipse.sirius.viewpoint.description.tool.ModelOperation;
 import org.eclipse.sirius.viewpoint.description.tool.SetValue;
+import org.eclipse.sirius.web.compat.api.IIdentifierProvider;
 import org.eclipse.sirius.web.compat.api.IModelOperationHandler;
+import org.eclipse.sirius.web.core.api.IObjectService;
 import org.eclipse.sirius.web.interpreter.AQLInterpreter;
 import org.eclipse.sirius.web.representations.IStatus;
 import org.eclipse.sirius.web.representations.VariableManager;
@@ -34,13 +36,20 @@ import org.eclipse.sirius.web.representations.VariableManager;
  */
 public class SetValueOperationHandler implements IModelOperationHandler {
 
+    private final IObjectService objectService;
+
+    private final IIdentifierProvider identifierProvider;
+
     private final AQLInterpreter interpreter;
 
     private final ChildModelOperationHandler childModelOperationHandler;
 
     private final SetValue setValue;
 
-    public SetValueOperationHandler(AQLInterpreter interpreter, ChildModelOperationHandler childModelOperationHandler, SetValue setValue) {
+    public SetValueOperationHandler(IObjectService objectService, IIdentifierProvider identifierProvider, AQLInterpreter interpreter, ChildModelOperationHandler childModelOperationHandler,
+            SetValue setValue) {
+        this.objectService = Objects.requireNonNull(objectService);
+        this.identifierProvider = Objects.requireNonNull(identifierProvider);
         this.interpreter = Objects.requireNonNull(interpreter);
         this.childModelOperationHandler = Objects.requireNonNull(childModelOperationHandler);
         this.setValue = Objects.requireNonNull(setValue);
@@ -69,7 +78,7 @@ public class SetValueOperationHandler implements IModelOperationHandler {
 
         Map<String, Object> childVariables = new HashMap<>(variables);
         List<ModelOperation> subModelOperations = this.setValue.getSubModelOperations();
-        return this.childModelOperationHandler.handle(this.interpreter, childVariables, subModelOperations);
+        return this.childModelOperationHandler.handle(this.objectService, this.identifierProvider, this.interpreter, childVariables, subModelOperations);
     }
 
 }

--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/modeloperations/SwitchOperationHandler.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/modeloperations/SwitchOperationHandler.java
@@ -23,7 +23,9 @@ import org.eclipse.sirius.viewpoint.description.tool.Case;
 import org.eclipse.sirius.viewpoint.description.tool.Default;
 import org.eclipse.sirius.viewpoint.description.tool.ModelOperation;
 import org.eclipse.sirius.viewpoint.description.tool.Switch;
+import org.eclipse.sirius.web.compat.api.IIdentifierProvider;
 import org.eclipse.sirius.web.compat.api.IModelOperationHandler;
+import org.eclipse.sirius.web.core.api.IObjectService;
 import org.eclipse.sirius.web.interpreter.AQLInterpreter;
 import org.eclipse.sirius.web.representations.IStatus;
 import org.eclipse.sirius.web.representations.Success;
@@ -35,13 +37,20 @@ import org.eclipse.sirius.web.representations.Success;
  */
 public class SwitchOperationHandler implements IModelOperationHandler {
 
+    private final IObjectService objectService;
+
+    private final IIdentifierProvider identifierProvider;
+
     private final AQLInterpreter interpreter;
 
     private final ChildModelOperationHandler childModelOperationHandler;
 
     private final Switch switchOperation;
 
-    public SwitchOperationHandler(AQLInterpreter interpreter, ChildModelOperationHandler childModelOperationHandler, Switch switchOperation) {
+    public SwitchOperationHandler(IObjectService objectService, IIdentifierProvider identifierProvider, AQLInterpreter interpreter, ChildModelOperationHandler childModelOperationHandler,
+            Switch switchOperation) {
+        this.objectService = Objects.requireNonNull(objectService);
+        this.identifierProvider = Objects.requireNonNull(identifierProvider);
         this.interpreter = Objects.requireNonNull(interpreter);
         this.childModelOperationHandler = Objects.requireNonNull(childModelOperationHandler);
         this.switchOperation = Objects.requireNonNull(switchOperation);
@@ -61,7 +70,7 @@ public class SwitchOperationHandler implements IModelOperationHandler {
 
                 if (optionalValueObject.isPresent() && optionalValueObject.get()) {
                     List<ModelOperation> subModelOperations = switchCase.getSubModelOperations();
-                    status = this.childModelOperationHandler.handle(this.interpreter, childVariables, subModelOperations);
+                    status = this.childModelOperationHandler.handle(this.objectService, this.identifierProvider, this.interpreter, childVariables, subModelOperations);
 
                     oneCaseHasBeenExecuted = true;
                     break;
@@ -73,7 +82,7 @@ public class SwitchOperationHandler implements IModelOperationHandler {
             Default defaultCase = this.switchOperation.getDefault();
             if (defaultCase != null) {
                 List<ModelOperation> subModelOperations = defaultCase.getSubModelOperations();
-                status = this.childModelOperationHandler.handle(this.interpreter, childVariables, subModelOperations);
+                status = this.childModelOperationHandler.handle(this.objectService, this.identifierProvider, this.interpreter, childVariables, subModelOperations);
             }
         }
 

--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/modeloperations/UnsetOperationHandler.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/modeloperations/UnsetOperationHandler.java
@@ -25,7 +25,9 @@ import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.sirius.viewpoint.description.tool.ModelOperation;
 import org.eclipse.sirius.viewpoint.description.tool.Unset;
+import org.eclipse.sirius.web.compat.api.IIdentifierProvider;
 import org.eclipse.sirius.web.compat.api.IModelOperationHandler;
+import org.eclipse.sirius.web.core.api.IObjectService;
 import org.eclipse.sirius.web.interpreter.AQLInterpreter;
 import org.eclipse.sirius.web.representations.IStatus;
 import org.eclipse.sirius.web.representations.VariableManager;
@@ -37,13 +39,20 @@ import org.eclipse.sirius.web.representations.VariableManager;
  */
 public class UnsetOperationHandler implements IModelOperationHandler {
 
+    private final IObjectService objectService;
+
+    private final IIdentifierProvider identifierProvider;
+
     private final AQLInterpreter interpreter;
 
     private final ChildModelOperationHandler childModelOperationHandler;
 
     private final Unset unsetOperation;
 
-    public UnsetOperationHandler(AQLInterpreter interpreter, ChildModelOperationHandler childModelOperationHandler, Unset unsetOperation) {
+    public UnsetOperationHandler(IObjectService objectService, IIdentifierProvider identifierProvider, AQLInterpreter interpreter, ChildModelOperationHandler childModelOperationHandler,
+            Unset unsetOperation) {
+        this.objectService = Objects.requireNonNull(objectService);
+        this.identifierProvider = Objects.requireNonNull(identifierProvider);
         this.interpreter = Objects.requireNonNull(interpreter);
         this.childModelOperationHandler = Objects.requireNonNull(childModelOperationHandler);
         this.unsetOperation = Objects.requireNonNull(unsetOperation);
@@ -112,7 +121,7 @@ public class UnsetOperationHandler implements IModelOperationHandler {
     private IStatus executeChildrenOperations(Map<String, Object> variables) {
         Map<String, Object> childVariables = new HashMap<>(variables);
         List<ModelOperation> subModelOperations = this.unsetOperation.getSubModelOperations();
-        return this.childModelOperationHandler.handle(this.interpreter, childVariables, subModelOperations);
+        return this.childModelOperationHandler.handle(this.objectService, this.identifierProvider, this.interpreter, childVariables, subModelOperations);
     }
 
 }

--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/configuration/CompatibilityConfiguration.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/configuration/CompatibilityConfiguration.java
@@ -14,6 +14,7 @@ package org.eclipse.sirius.web.emf.configuration;
 
 import org.eclipse.emf.ecore.EPackage;
 import org.eclipse.sirius.web.compat.api.ICanCreateDiagramPredicateFactory;
+import org.eclipse.sirius.web.compat.api.IIdentifierProvider;
 import org.eclipse.sirius.web.compat.api.IModelOperationHandlerSwitchProvider;
 import org.eclipse.sirius.web.compat.api.ISemanticCandidatesProviderFactory;
 import org.eclipse.sirius.web.compat.api.IToolImageProviderFactory;
@@ -32,6 +33,7 @@ import org.springframework.context.annotation.Configuration;
  */
 @Configuration
 public class CompatibilityConfiguration {
+
     @Bean
     public ISemanticCandidatesProviderFactory semanticCandidatesProviderFactory() {
         return SemanticCandidatesProvider::new;
@@ -43,8 +45,8 @@ public class CompatibilityConfiguration {
     }
 
     @Bean
-    public IModelOperationHandlerSwitchProvider modelOperationHandlerSwitchProvider() {
-        return ModelOperationHandlerSwitch::new;
+    public IModelOperationHandlerSwitchProvider modelOperationHandlerSwitchProvider(IObjectService objectService, IIdentifierProvider identifierProvider) {
+        return (interpreter) -> new ModelOperationHandlerSwitch(objectService, identifierProvider, interpreter);
     }
 
     @Bean

--- a/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/compatibility/diagrams/EdgeMappingConverterTests.java
+++ b/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/compatibility/diagrams/EdgeMappingConverterTests.java
@@ -70,10 +70,11 @@ public class EdgeMappingConverterTests {
         );
         // @formatter:on
 
+        IObjectService objectService = new IObjectService.NoOp();
         IIdentifierProvider identifierProvider = element -> containerMappingUUID.toString();
         ISemanticCandidatesProviderFactory semanticCandidatesProviderFactory = SemanticCandidatesProvider::new;
-        IModelOperationHandlerSwitchProvider modelOperationHandlerSwitchProvider = ModelOperationHandlerSwitch::new;
-        EdgeMappingConverter edgeMappingConverter = new EdgeMappingConverter(new IObjectService.NoOp(), new IEditService.NoOp(), identifierProvider, semanticCandidatesProviderFactory,
+        IModelOperationHandlerSwitchProvider modelOperationHandlerSwitchProvider = interpeter -> new ModelOperationHandlerSwitch(objectService, identifierProvider, interpeter);
+        EdgeMappingConverter edgeMappingConverter = new EdgeMappingConverter(objectService, new IEditService.NoOp(), identifierProvider, semanticCandidatesProviderFactory,
                 modelOperationHandlerSwitchProvider);
 
         EdgeDescription edgeDescription = edgeMappingConverter.convert(edgeMapping, new AQLInterpreter(List.of(), List.of()), id2NodeDescriptions);
@@ -137,10 +138,11 @@ public class EdgeMappingConverterTests {
                 containerMappingUUID, this.createNodeDescription(containerMappingUUID)
         );
         // @formatter:on
+        IObjectService objectService = new IObjectService.NoOp();
         IIdentifierProvider identifierProvider = element -> containerMappingUUID.toString();
         ISemanticCandidatesProviderFactory semanticCandidatesProviderFactory = SemanticCandidatesProvider::new;
-        IModelOperationHandlerSwitchProvider modelOperationHandlerSwitchProvider = ModelOperationHandlerSwitch::new;
-        EdgeMappingConverter edgeMappingConverter = new EdgeMappingConverter(new IObjectService.NoOp(), new IEditService.NoOp(), identifierProvider, semanticCandidatesProviderFactory,
+        IModelOperationHandlerSwitchProvider modelOperationHandlerSwitchProvider = interpeter -> new ModelOperationHandlerSwitch(objectService, identifierProvider, interpeter);
+        EdgeMappingConverter edgeMappingConverter = new EdgeMappingConverter(objectService, new IEditService.NoOp(), identifierProvider, semanticCandidatesProviderFactory,
                 modelOperationHandlerSwitchProvider);
 
         EdgeDescription edgeDescription = edgeMappingConverter.convert(edgeMapping, new AQLInterpreter(List.of(), List.of()), id2NodeDescriptions);
@@ -169,10 +171,11 @@ public class EdgeMappingConverterTests {
                 targetContainerMappingUUID, this.createNodeDescription(targetContainerMappingUUID)
         );
         // @formatter:on
+        IObjectService objectService = new IObjectService.NoOp();
         IIdentifierProvider identifierProvider = element -> targetContainerMappingUUID.toString();
         ISemanticCandidatesProviderFactory semanticCandidatesProviderFactory = SemanticCandidatesProvider::new;
-        IModelOperationHandlerSwitchProvider modelOperationHandlerSwitchProvider = ModelOperationHandlerSwitch::new;
-        EdgeMappingConverter edgeMappingConverter = new EdgeMappingConverter(new IObjectService.NoOp(), new IEditService.NoOp(), identifierProvider, semanticCandidatesProviderFactory,
+        IModelOperationHandlerSwitchProvider modelOperationHandlerSwitchProvider = interpeter -> new ModelOperationHandlerSwitch(objectService, identifierProvider, interpeter);
+        EdgeMappingConverter edgeMappingConverter = new EdgeMappingConverter(objectService, new IEditService.NoOp(), identifierProvider, semanticCandidatesProviderFactory,
                 modelOperationHandlerSwitchProvider);
 
         EdgeDescription edgeDescription = edgeMappingConverter.convert(edgeMapping, new AQLInterpreter(List.of(), List.of()), id2NodeDescriptions);

--- a/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/compatibility/operations/ChangeContextOperationHandlerTests.java
+++ b/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/compatibility/operations/ChangeContextOperationHandlerTests.java
@@ -46,7 +46,8 @@ public class ChangeContextOperationHandlerTests {
         this.operationTestContext = new OperationTestContext();
 
         this.changeContext = ToolFactory.eINSTANCE.createChangeContext();
-        this.changeContextOperationHandler = new ChangeContextOperationHandler(this.operationTestContext.getInterpreter(), new ChildModelOperationHandler(), this.changeContext);
+        this.changeContextOperationHandler = new ChangeContextOperationHandler(this.operationTestContext.getObjectService(), this.operationTestContext.getIdentifierProvider(),
+                this.operationTestContext.getInterpreter(), new ChildModelOperationHandler(), this.changeContext);
     }
 
     @Test

--- a/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/compatibility/operations/CreateInstanceOperationHandlerTests.java
+++ b/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/compatibility/operations/CreateInstanceOperationHandlerTests.java
@@ -79,8 +79,8 @@ public class CreateInstanceOperationHandlerTests {
         this.operationTestContext.getVariables().put(IEditingContext.EDITING_CONTEXT, editingContext);
 
         this.createInstanceOperation = ToolFactory.eINSTANCE.createCreateInstance();
-        this.createInstanceOperationHandler = new CreateInstanceOperationHandler(this.operationTestContext.getInterpreter(), new EPackageService(), new ChildModelOperationHandler(),
-                this.createInstanceOperation);
+        this.createInstanceOperationHandler = new CreateInstanceOperationHandler(this.operationTestContext.getObjectService(), this.operationTestContext.getIdentifierProvider(),
+                this.operationTestContext.getInterpreter(), new EPackageService(), new ChildModelOperationHandler(), this.createInstanceOperation);
     }
 
     @Test

--- a/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/compatibility/operations/CreateViewOperationHandlerTests.java
+++ b/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/compatibility/operations/CreateViewOperationHandlerTests.java
@@ -1,0 +1,255 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.emf.compatibility.operations;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Function;
+
+import org.eclipse.emf.common.command.BasicCommandStack;
+import org.eclipse.emf.ecore.ENamedElement;
+import org.eclipse.emf.ecore.EPackage;
+import org.eclipse.emf.ecore.EcorePackage;
+import org.eclipse.emf.ecore.impl.EPackageRegistryImpl;
+import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
+import org.eclipse.emf.ecore.util.EcoreAdapterFactory;
+import org.eclipse.emf.edit.domain.AdapterFactoryEditingDomain;
+import org.eclipse.emf.edit.provider.ComposedAdapterFactory;
+import org.eclipse.emf.edit.provider.ReflectiveItemProviderAdapterFactory;
+import org.eclipse.sirius.diagram.description.DescriptionFactory;
+import org.eclipse.sirius.diagram.description.NodeMapping;
+import org.eclipse.sirius.diagram.description.tool.CreateView;
+import org.eclipse.sirius.viewpoint.description.tool.ChangeContext;
+import org.eclipse.sirius.viewpoint.description.tool.ToolFactory;
+import org.eclipse.sirius.web.core.api.IEditingContext;
+import org.eclipse.sirius.web.diagrams.Diagram;
+import org.eclipse.sirius.web.diagrams.INodeStyle;
+import org.eclipse.sirius.web.diagrams.LineStyle;
+import org.eclipse.sirius.web.diagrams.Position;
+import org.eclipse.sirius.web.diagrams.RectangularNodeStyle;
+import org.eclipse.sirius.web.diagrams.Size;
+import org.eclipse.sirius.web.diagrams.ViewCreationRequest;
+import org.eclipse.sirius.web.diagrams.description.DiagramDescription;
+import org.eclipse.sirius.web.diagrams.description.LabelDescription;
+import org.eclipse.sirius.web.diagrams.description.LabelStyleDescription;
+import org.eclipse.sirius.web.diagrams.description.NodeDescription;
+import org.eclipse.sirius.web.diagrams.description.SynchronizationPolicy;
+import org.eclipse.sirius.web.emf.compatibility.modeloperations.ChildModelOperationHandler;
+import org.eclipse.sirius.web.emf.compatibility.modeloperations.CreateViewOperationHandler;
+import org.eclipse.sirius.web.emf.services.EditingContext;
+import org.eclipse.sirius.web.representations.IStatus;
+import org.eclipse.sirius.web.representations.Success;
+import org.eclipse.sirius.web.representations.VariableManager;
+import org.eclipse.sirius.web.spring.collaborative.diagrams.api.IDiagramContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests of the CreateView operation handler.
+ *
+ * @author arichard
+ */
+public class CreateViewOperationHandlerTests {
+
+    private static final String AQL = "aql:"; //$NON-NLS-1$
+
+    private static final String VARIABLE_NAME = "myVariableName"; //$NON-NLS-1$
+
+    private static final String CONTAINER_VIEW = "containerView"; //$NON-NLS-1$
+
+    private CreateViewOperationHandler createViewOperationHandler;
+
+    private CreateView createViewOperation;
+
+    private OperationTestContext operationTestContext;
+
+    @BeforeEach
+    public void initialize() {
+        this.operationTestContext = new OperationTestContext();
+
+        ComposedAdapterFactory composedAdapterFactory = new ComposedAdapterFactory();
+        composedAdapterFactory.addAdapterFactory(new EcoreAdapterFactory());
+        composedAdapterFactory.addAdapterFactory(new ReflectiveItemProviderAdapterFactory());
+
+        EPackage.Registry ePackageRegistry = new EPackageRegistryImpl();
+        ePackageRegistry.put(EcorePackage.eINSTANCE.getNsURI(), EcorePackage.eINSTANCE);
+
+        ResourceSet resourceSet = new ResourceSetImpl();
+        resourceSet.setPackageRegistry(ePackageRegistry);
+
+        // @formatter:off
+        DiagramDescription diagramDescription = DiagramDescription.newDiagramDescription(UUID.randomUUID())
+                .label("DiagramDescriptionTest") //$NON-NLS-1$
+                .targetObjectIdProvider(variableManager -> "diagramTargetObjectId") //$NON-NLS-1$
+                .canCreatePredicate(variableManager -> true)
+                .labelProvider(variableManager -> "Diagram") //$NON-NLS-1$
+                .toolSections(List.of())
+                .nodeDescriptions(List.of(this.getNodeDescription(UUID.randomUUID())))
+                .edgeDescriptions(List.of())
+                .build();
+
+        Diagram diagram = Diagram.newDiagram(UUID.randomUUID())
+                .descriptionId(diagramDescription.getId())
+                .targetObjectId(UUID.randomUUID().toString())
+                .label("DiagramTest") //$NON-NLS-1$
+                .position(Position.at(0, 0))
+                .size(Size.of(100, 100))
+                .nodes(new ArrayList<>())
+                .edges(List.of())
+                .build();
+
+        IDiagramContext diagramContext = new IDiagramContext.NoOp() {
+            @Override
+            public List<ViewCreationRequest> getViewCreationRequests() {
+                return new ArrayList<>();
+            }
+        };
+        this.operationTestContext.getVariables().put(IDiagramContext.DIAGRAM_CONTEXT, diagramContext);
+        // @formatter:on
+
+        AdapterFactoryEditingDomain editingDomain = new AdapterFactoryEditingDomain(composedAdapterFactory, new BasicCommandStack(), resourceSet);
+        EditingContext editingContext = new EditingContext(UUID.randomUUID(), editingDomain);
+        this.operationTestContext.getVariables().put(IEditingContext.EDITING_CONTEXT, editingContext);
+        this.operationTestContext.getVariables().put(CONTAINER_VIEW, diagram);
+        this.createViewOperation = org.eclipse.sirius.diagram.description.tool.ToolFactory.eINSTANCE.createCreateView();
+        this.createViewOperationHandler = new CreateViewOperationHandler(this.operationTestContext.getObjectService(), this.operationTestContext.getIdentifierProvider(),
+                this.operationTestContext.getInterpreter(), new ChildModelOperationHandler(), this.createViewOperation);
+    }
+
+    @Test
+    public void createViewOperationHandlerNominalCaseTest() {
+        // used to check that the variable name is added in variable scope
+        String className = "newClass"; //$NON-NLS-1$
+        ChangeContext subChangeContext = ToolFactory.eINSTANCE.createChangeContext();
+        subChangeContext.setBrowseExpression(AQL + VARIABLE_NAME + ".renameENamedElementService('" + className + "'))"); //$NON-NLS-1$ //$NON-NLS-2$
+        this.createViewOperation.getSubModelOperations().add(subChangeContext);
+
+        // check the nominal case
+        NodeMapping nodeMapping = DescriptionFactory.eINSTANCE.createNodeMapping();
+        nodeMapping.setName(UUID.randomUUID().toString());
+        this.createViewOperation.setMapping(nodeMapping);
+        this.createViewOperation.setContainerViewExpression(AQL + CONTAINER_VIEW);
+        this.createViewOperation.setVariableName(VARIABLE_NAME);
+
+        IStatus handleResult = this.createViewOperationHandler.handle(this.operationTestContext.getVariables());
+
+        assertTrue(handleResult instanceof Success);
+
+        // check that an empty variable name is a valid case
+        this.createViewOperation.setVariableName(""); //$NON-NLS-1$
+
+        handleResult = this.createViewOperationHandler.handle(this.operationTestContext.getVariables());
+
+        assertTrue(handleResult instanceof Success);
+    }
+
+    /**
+     * Check that a null or empty data do not stop the handle of subOperations.</br>
+     */
+    @Test
+    public void createViewOperationHandlerErrorCasesTest() {
+        // Add a SubModelOperations to check that it is handled
+        ChangeContext subChangeContext = ToolFactory.eINSTANCE.createChangeContext();
+        this.createViewOperation.getSubModelOperations().add(subChangeContext);
+
+        // Check null expression case
+        this.handleAndCheckExecution(null, this.operationTestContext.getRootPackage());
+
+        // Check empty expression case
+        this.handleAndCheckExecution("", this.operationTestContext.getRootPackage()); //$NON-NLS-1$
+        // $NON-NLS-3$
+
+        this.handleAndCheckExecution(VARIABLE_NAME, this.operationTestContext.getRootPackage());
+    }
+
+    /**
+     * Execute the root operation and check that the sub ChangeContext operation is properly executed.
+     */
+    private void handleAndCheckExecution(String variableName, ENamedElement renamedElement) {
+        String newName = UUID.randomUUID().toString();
+        String renameExpression = MessageFormat.format(ModelOperationServices.AQL_RENAME_EXPRESSION, newName);
+        ((ChangeContext) this.createViewOperation.getSubModelOperations().get(0)).setBrowseExpression(renameExpression);
+
+        // execute
+        NodeMapping nodeMapping = DescriptionFactory.eINSTANCE.createNodeMapping();
+        nodeMapping.setName(UUID.randomUUID().toString());
+        this.createViewOperation.setContainerViewExpression(AQL + CONTAINER_VIEW);
+        this.createViewOperation.setVariableName(variableName);
+
+        IStatus handleResult = this.createViewOperationHandler.handle(this.operationTestContext.getVariables());
+
+        // check
+        assertTrue(handleResult instanceof Success);
+        assertEquals(newName, renamedElement.getName());
+    }
+
+    private NodeDescription getNodeDescription(UUID nodeDescriptionId) {
+        // @formatter:off
+        LabelStyleDescription labelStyleDescription = LabelStyleDescription.newLabelStyleDescription()
+                .colorProvider(variableManager -> "#000000") //$NON-NLS-1$
+                .fontSizeProvider(variableManager -> 16)
+                .boldProvider(variableManager -> false)
+                .italicProvider(variableManager -> false)
+                .underlineProvider(variableManager -> false)
+                .strikeThroughProvider(variableManager -> false)
+                .iconURLProvider(variableManager -> "") //$NON-NLS-1$
+                .build();
+
+        LabelDescription labelDescription = LabelDescription.newLabelDescription("labelDescriptionId") //$NON-NLS-1$
+                .idProvider(variableManager -> "labelId") //$NON-NLS-1$
+                .textProvider(variableManager -> "Node") //$NON-NLS-1$
+                .styleDescriptionProvider(variableManager -> labelStyleDescription)
+                .build();
+
+        Function<VariableManager, INodeStyle> nodeStyleProvider = variableManager -> {
+            return RectangularNodeStyle.newRectangularNodeStyle()
+                    .color("") //$NON-NLS-1$
+                    .borderColor("") //$NON-NLS-1$
+                    .borderSize(0)
+                    .borderStyle(LineStyle.Solid)
+                    .build();
+        };
+
+        Function<VariableManager, String> targetObjectIdProvider = variableManager -> {
+            Object object = variableManager.getVariables().get(VariableManager.SELF);
+            if (object instanceof String) {
+                return nodeDescriptionId + "__" +  object; //$NON-NLS-1$
+            }
+            return null;
+        };
+
+        return NodeDescription.newNodeDescription(nodeDescriptionId)
+                .synchronizationPolicy(SynchronizationPolicy.UNSYNCHRONIZED)
+                .typeProvider(variableManager -> "") //$NON-NLS-1$
+                .semanticElementsProvider(variableManager -> List.of())
+                .targetObjectIdProvider(targetObjectIdProvider)
+                .targetObjectKindProvider(variableManager -> "") //$NON-NLS-1$
+                .targetObjectLabelProvider(variableManager -> "")//$NON-NLS-1$
+                .labelDescription(labelDescription)
+                .styleProvider(nodeStyleProvider)
+                .sizeProvider(variableManager -> Size.UNDEFINED)
+                .borderNodeDescriptions(new ArrayList<>())
+                .childNodeDescriptions(new ArrayList<>())
+                .labelEditHandler((variableManager, newLabel) -> new Success())
+                .deleteHandler(variableManager -> new Success())
+                .build();
+        // @formatter:on
+    }
+
+}

--- a/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/compatibility/operations/DeleteViewOperationHandlerTests.java
+++ b/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/compatibility/operations/DeleteViewOperationHandlerTests.java
@@ -1,0 +1,225 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.emf.compatibility.operations;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Function;
+
+import org.eclipse.emf.common.command.BasicCommandStack;
+import org.eclipse.emf.ecore.EPackage;
+import org.eclipse.emf.ecore.EcorePackage;
+import org.eclipse.emf.ecore.impl.EPackageRegistryImpl;
+import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
+import org.eclipse.emf.ecore.util.EcoreAdapterFactory;
+import org.eclipse.emf.edit.domain.AdapterFactoryEditingDomain;
+import org.eclipse.emf.edit.provider.ComposedAdapterFactory;
+import org.eclipse.emf.edit.provider.ReflectiveItemProviderAdapterFactory;
+import org.eclipse.sirius.viewpoint.description.tool.ChangeContext;
+import org.eclipse.sirius.viewpoint.description.tool.DeleteView;
+import org.eclipse.sirius.viewpoint.description.tool.ToolFactory;
+import org.eclipse.sirius.web.core.api.IEditingContext;
+import org.eclipse.sirius.web.diagrams.Diagram;
+import org.eclipse.sirius.web.diagrams.INodeStyle;
+import org.eclipse.sirius.web.diagrams.ImageNodeStyle;
+import org.eclipse.sirius.web.diagrams.Label;
+import org.eclipse.sirius.web.diagrams.LabelStyle;
+import org.eclipse.sirius.web.diagrams.LineStyle;
+import org.eclipse.sirius.web.diagrams.Node;
+import org.eclipse.sirius.web.diagrams.Position;
+import org.eclipse.sirius.web.diagrams.RectangularNodeStyle;
+import org.eclipse.sirius.web.diagrams.Size;
+import org.eclipse.sirius.web.diagrams.ViewDeletionRequest;
+import org.eclipse.sirius.web.diagrams.description.DiagramDescription;
+import org.eclipse.sirius.web.diagrams.description.LabelDescription;
+import org.eclipse.sirius.web.diagrams.description.LabelStyleDescription;
+import org.eclipse.sirius.web.diagrams.description.NodeDescription;
+import org.eclipse.sirius.web.diagrams.description.SynchronizationPolicy;
+import org.eclipse.sirius.web.emf.compatibility.modeloperations.ChildModelOperationHandler;
+import org.eclipse.sirius.web.emf.compatibility.modeloperations.DeleteViewOperationHandler;
+import org.eclipse.sirius.web.emf.services.EditingContext;
+import org.eclipse.sirius.web.representations.IStatus;
+import org.eclipse.sirius.web.representations.Success;
+import org.eclipse.sirius.web.representations.VariableManager;
+import org.eclipse.sirius.web.spring.collaborative.diagrams.api.IDiagramContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests of the DeleteView operation handler.
+ *
+ * @author arichard
+ */
+public class DeleteViewOperationHandlerTests {
+    /**
+     *
+     */
+    private static final String AQL = "aql:"; //$NON-NLS-1$
+
+    private static final String VARIABLE_NAME = "myVariableName"; //$NON-NLS-1$
+
+    private static final String CONTAINER_VIEW = "containerView"; //$NON-NLS-1$
+
+    private DeleteViewOperationHandler deleteViewOperationHandler;
+
+    private DeleteView deleteViewOperation;
+
+    private OperationTestContext operationTestContext;
+
+    @BeforeEach
+    public void initialize() {
+        this.operationTestContext = new OperationTestContext();
+
+        ComposedAdapterFactory composedAdapterFactory = new ComposedAdapterFactory();
+        composedAdapterFactory.addAdapterFactory(new EcoreAdapterFactory());
+        composedAdapterFactory.addAdapterFactory(new ReflectiveItemProviderAdapterFactory());
+
+        EPackage.Registry ePackageRegistry = new EPackageRegistryImpl();
+        ePackageRegistry.put(EcorePackage.eINSTANCE.getNsURI(), EcorePackage.eINSTANCE);
+
+        ResourceSet resourceSet = new ResourceSetImpl();
+        resourceSet.setPackageRegistry(ePackageRegistry);
+
+        // @formatter:off
+        DiagramDescription diagramDescription = DiagramDescription.newDiagramDescription(UUID.randomUUID())
+                .label("DiagramDescriptionTest") //$NON-NLS-1$
+                .targetObjectIdProvider(variableManager -> "diagramTargetObjectId") //$NON-NLS-1$
+                .canCreatePredicate(variableManager -> true)
+                .labelProvider(variableManager -> "Diagram") //$NON-NLS-1$
+                .toolSections(List.of())
+                .nodeDescriptions(List.of(this.getNodeDescription(UUID.randomUUID())))
+                .edgeDescriptions(List.of())
+                .build();
+
+        Node node = Node.newNode(UUID.randomUUID())
+                .descriptionId(UUID.randomUUID())
+                .type("Node") //$NON-NLS-1$
+                .targetObjectId(UUID.randomUUID().toString())
+                .targetObjectKind("ecore::EPackage") //$NON-NLS-1$
+                .targetObjectLabel(OperationTestContext.ROOT_PACKAGE_NAME)
+                .label(Label.newLabel(UUID.randomUUID())
+                        .type("Label") //$NON-NLS-1$
+                        .text(OperationTestContext.ROOT_PACKAGE_NAME)
+                        .position(Position.at(0, 0))
+                        .size(Size.of(10, 10))
+                        .alignment(Position.at(0, 0))
+                        .style(LabelStyle.newLabelStyle().color("").fontSize(0).iconURL("").build()) //$NON-NLS-1$ //$NON-NLS-2$
+                        .build())
+                .style(ImageNodeStyle.newImageNodeStyle().imageURL("").scalingFactor(0).build()) //$NON-NLS-1$
+                .position(Position.at(0, 0))
+                .size(Size.of(10, 10))
+                .borderNodes(List.of())
+                .childNodes(List.of())
+                .build();
+
+        Diagram diagram = Diagram.newDiagram(UUID.randomUUID())
+                .descriptionId(diagramDescription.getId())
+                .targetObjectId(UUID.randomUUID().toString())
+                .label("DiagramTest") //$NON-NLS-1$
+                .position(Position.at(0, 0))
+                .size(Size.of(100, 100))
+                .nodes(List.of(node))
+                .edges(List.of())
+                .build();
+
+        IDiagramContext diagramContext = new IDiagramContext.NoOp() {
+            @Override
+            public List<ViewDeletionRequest> getViewDeletionRequests() {
+                return new ArrayList<>();
+            }
+        };
+        this.operationTestContext.getVariables().put(IDiagramContext.DIAGRAM_CONTEXT, diagramContext);
+        // @formatter:on
+
+        AdapterFactoryEditingDomain editingDomain = new AdapterFactoryEditingDomain(composedAdapterFactory, new BasicCommandStack(), resourceSet);
+        EditingContext editingContext = new EditingContext(UUID.randomUUID(), editingDomain);
+        this.operationTestContext.getVariables().put(IEditingContext.EDITING_CONTEXT, editingContext);
+        this.operationTestContext.getVariables().put(CONTAINER_VIEW, diagram);
+        this.operationTestContext.getVariables().put(VariableManager.SELF, diagram.getNodes().get(0));
+        this.deleteViewOperation = ToolFactory.eINSTANCE.createDeleteView();
+        this.deleteViewOperationHandler = new DeleteViewOperationHandler(this.operationTestContext.getObjectService(), this.operationTestContext.getIdentifierProvider(),
+                this.operationTestContext.getInterpreter(), new ChildModelOperationHandler(), this.deleteViewOperation);
+    }
+
+    @Test
+    public void deleteViewOperationHandlerNominalCaseTest() {
+        // used to check that the variable name is added in variable scope
+        String className = "newClass"; //$NON-NLS-1$
+        ChangeContext subChangeContext = ToolFactory.eINSTANCE.createChangeContext();
+        subChangeContext.setBrowseExpression(AQL + VARIABLE_NAME + ".renameENamedElementService('" + className + "'))"); //$NON-NLS-1$ //$NON-NLS-2$
+        this.deleteViewOperation.getSubModelOperations().add(subChangeContext);
+
+        // check the nominal case
+        IStatus handleResult = this.deleteViewOperationHandler.handle(this.operationTestContext.getVariables());
+
+        assertTrue(handleResult instanceof Success);
+    }
+
+    private NodeDescription getNodeDescription(UUID nodeDescriptionId) {
+        // @formatter:off
+        LabelStyleDescription labelStyleDescription = LabelStyleDescription.newLabelStyleDescription()
+                .colorProvider(variableManager -> "#000000") //$NON-NLS-1$
+                .fontSizeProvider(variableManager -> 16)
+                .boldProvider(variableManager -> false)
+                .italicProvider(variableManager -> false)
+                .underlineProvider(variableManager -> false)
+                .strikeThroughProvider(variableManager -> false)
+                .iconURLProvider(variableManager -> "") //$NON-NLS-1$
+                .build();
+
+        LabelDescription labelDescription = LabelDescription.newLabelDescription("labelDescriptionId") //$NON-NLS-1$
+                .idProvider(variableManager -> "labelId") //$NON-NLS-1$
+                .textProvider(variableManager -> "Node") //$NON-NLS-1$
+                .styleDescriptionProvider(variableManager -> labelStyleDescription)
+                .build();
+
+        Function<VariableManager, INodeStyle> nodeStyleProvider = variableManager -> {
+            return RectangularNodeStyle.newRectangularNodeStyle()
+                    .color("") //$NON-NLS-1$
+                    .borderColor("") //$NON-NLS-1$
+                    .borderSize(0)
+                    .borderStyle(LineStyle.Solid)
+                    .build();
+        };
+
+        Function<VariableManager, String> targetObjectIdProvider = variableManager -> {
+            Object object = variableManager.getVariables().get(VariableManager.SELF);
+            if (object instanceof String) {
+                return nodeDescriptionId + "__" +  object; //$NON-NLS-1$
+            }
+            return null;
+        };
+
+        return NodeDescription.newNodeDescription(nodeDescriptionId)
+                .synchronizationPolicy(SynchronizationPolicy.UNSYNCHRONIZED)
+                .typeProvider(variableManager -> "") //$NON-NLS-1$
+                .semanticElementsProvider(variableManager -> List.of())
+                .targetObjectIdProvider(targetObjectIdProvider)
+                .targetObjectKindProvider(variableManager -> "") //$NON-NLS-1$
+                .targetObjectLabelProvider(variableManager -> "")//$NON-NLS-1$
+                .labelDescription(labelDescription)
+                .styleProvider(nodeStyleProvider)
+                .sizeProvider(variableManager -> Size.UNDEFINED)
+                .borderNodeDescriptions(new ArrayList<>())
+                .childNodeDescriptions(new ArrayList<>())
+                .labelEditHandler((variableManager, newLabel) -> new Success())
+                .deleteHandler(variableManager -> new Success())
+                .build();
+        // @formatter:on
+    }
+
+}

--- a/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/compatibility/operations/ForOperationHandlerTests.java
+++ b/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/compatibility/operations/ForOperationHandlerTests.java
@@ -50,7 +50,8 @@ public class ForOperationHandlerTests {
         this.operationTestContext = new OperationTestContext();
 
         this.forOperation = ToolFactory.eINSTANCE.createFor();
-        this.forOperationHandler = new ForOperationHandler(this.operationTestContext.getInterpreter(), new ChildModelOperationHandler(), this.forOperation);
+        this.forOperationHandler = new ForOperationHandler(this.operationTestContext.getObjectService(), this.operationTestContext.getIdentifierProvider(), this.operationTestContext.getInterpreter(),
+                new ChildModelOperationHandler(), this.forOperation);
     }
 
     @Test

--- a/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/compatibility/operations/IfOperationHandlerTests.java
+++ b/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/compatibility/operations/IfOperationHandlerTests.java
@@ -48,7 +48,8 @@ public class IfOperationHandlerTests {
         this.operationTestContext = new OperationTestContext();
 
         this.ifOperation = ToolFactory.eINSTANCE.createIf();
-        this.ifOperationHandler = new IfOperationHandler(this.operationTestContext.getInterpreter(), new ChildModelOperationHandler(), this.ifOperation);
+        this.ifOperationHandler = new IfOperationHandler(this.operationTestContext.getObjectService(), this.operationTestContext.getIdentifierProvider(), this.operationTestContext.getInterpreter(),
+                new ChildModelOperationHandler(), this.ifOperation);
     }
 
     @Test

--- a/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/compatibility/operations/LetOperationHandlerTests.java
+++ b/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/compatibility/operations/LetOperationHandlerTests.java
@@ -48,7 +48,8 @@ public class LetOperationHandlerTests {
         this.operationTestContext = new OperationTestContext();
 
         this.letOperation = ToolFactory.eINSTANCE.createLet();
-        this.letOperationHandler = new LetOperationHandler(this.operationTestContext.getInterpreter(), new ChildModelOperationHandler(), this.letOperation);
+        this.letOperationHandler = new LetOperationHandler(this.operationTestContext.getObjectService(), this.operationTestContext.getIdentifierProvider(), this.operationTestContext.getInterpreter(),
+                new ChildModelOperationHandler(), this.letOperation);
     }
 
     @Test

--- a/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/compatibility/operations/MoveElementOperationHandlerTests.java
+++ b/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/compatibility/operations/MoveElementOperationHandlerTests.java
@@ -64,7 +64,8 @@ public class MoveElementOperationHandlerTests {
         this.operationTestContext.getVariables().put(VariableManager.SELF, this.operationTestContext.getClass1());
 
         this.moveElementOperation = ToolFactory.eINSTANCE.createMoveElement();
-        this.moveElementOperationHandler = new MoveElementOperationHandler(this.operationTestContext.getInterpreter(), new ChildModelOperationHandler(), this.moveElementOperation);
+        this.moveElementOperationHandler = new MoveElementOperationHandler(this.operationTestContext.getObjectService(), this.operationTestContext.getIdentifierProvider(),
+                this.operationTestContext.getInterpreter(), new ChildModelOperationHandler(), this.moveElementOperation);
     }
 
     @Test

--- a/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/compatibility/operations/OperationTestContext.java
+++ b/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/compatibility/operations/OperationTestContext.java
@@ -21,7 +21,6 @@ import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EPackage;
 import org.eclipse.emf.ecore.EcoreFactory;
 import org.eclipse.emf.ecore.EcorePackage;
-import org.eclipse.sirius.diagram.description.NodeMapping;
 import org.eclipse.sirius.web.compat.api.IIdentifierProvider;
 import org.eclipse.sirius.web.core.api.IObjectService;
 import org.eclipse.sirius.web.interpreter.AQLInterpreter;
@@ -59,12 +58,7 @@ public class OperationTestContext {
         this.rootPackage.getEClassifiers().add(0, this.class1);
 
         this.objectService = new IObjectService.NoOp();
-        this.identifierProvider = element -> {
-            if (element instanceof NodeMapping) {
-                return ((NodeMapping) element).getName();
-            }
-            return UUID.randomUUID().toString();
-        };
+        this.identifierProvider = element -> UUID.randomUUID().toString();
         this.interpreter = new AQLInterpreter(List.of(ModelOperationServices.class), List.of(EcorePackage.eINSTANCE));
 
         this.variables = new HashMap<>();

--- a/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/compatibility/operations/OperationTestContext.java
+++ b/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/compatibility/operations/OperationTestContext.java
@@ -15,11 +15,15 @@ package org.eclipse.sirius.web.emf.compatibility.operations;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EPackage;
 import org.eclipse.emf.ecore.EcoreFactory;
 import org.eclipse.emf.ecore.EcorePackage;
+import org.eclipse.sirius.diagram.description.NodeMapping;
+import org.eclipse.sirius.web.compat.api.IIdentifierProvider;
+import org.eclipse.sirius.web.core.api.IObjectService;
 import org.eclipse.sirius.web.interpreter.AQLInterpreter;
 import org.eclipse.sirius.web.representations.VariableManager;
 
@@ -40,6 +44,10 @@ public class OperationTestContext {
 
     private Map<String, Object> variables;
 
+    private IObjectService objectService;
+
+    private IIdentifierProvider identifierProvider;
+
     private AQLInterpreter interpreter;
 
     public OperationTestContext() {
@@ -50,6 +58,13 @@ public class OperationTestContext {
         this.class1.setName(CLASS1_NAME);
         this.rootPackage.getEClassifiers().add(0, this.class1);
 
+        this.objectService = new IObjectService.NoOp();
+        this.identifierProvider = element -> {
+            if (element instanceof NodeMapping) {
+                return ((NodeMapping) element).getName();
+            }
+            return UUID.randomUUID().toString();
+        };
         this.interpreter = new AQLInterpreter(List.of(ModelOperationServices.class), List.of(EcorePackage.eINSTANCE));
 
         this.variables = new HashMap<>();
@@ -66,6 +81,14 @@ public class OperationTestContext {
 
     public Map<String, Object> getVariables() {
         return this.variables;
+    }
+
+    public IObjectService getObjectService() {
+        return this.objectService;
+    }
+
+    public IIdentifierProvider getIdentifierProvider() {
+        return this.identifierProvider;
     }
 
     public AQLInterpreter getInterpreter() {

--- a/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/compatibility/operations/RemoveElementOperationHandlerTests.java
+++ b/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/compatibility/operations/RemoveElementOperationHandlerTests.java
@@ -44,7 +44,8 @@ public class RemoveElementOperationHandlerTests {
         this.operationTestContext.getVariables().put(VariableManager.SELF, this.operationTestContext.getClass1());
 
         this.removeElementOperation = ToolFactory.eINSTANCE.createRemoveElement();
-        this.removeElementOperationHandler = new RemoveElementOperationHandler(this.operationTestContext.getInterpreter(), new ChildModelOperationHandler(), this.removeElementOperation);
+        this.removeElementOperationHandler = new RemoveElementOperationHandler(this.operationTestContext.getObjectService(), this.operationTestContext.getIdentifierProvider(),
+                this.operationTestContext.getInterpreter(), new ChildModelOperationHandler(), this.removeElementOperation);
     }
 
     @Test

--- a/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/compatibility/operations/SetValueOperationHandlerTests.java
+++ b/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/compatibility/operations/SetValueOperationHandlerTests.java
@@ -48,7 +48,8 @@ public class SetValueOperationHandlerTests {
         this.operationTestContext = new OperationTestContext();
 
         this.setValue = ToolFactory.eINSTANCE.createSetValue();
-        this.setValueOperationHandler = new SetValueOperationHandler(this.operationTestContext.getInterpreter(), new ChildModelOperationHandler(), this.setValue);
+        this.setValueOperationHandler = new SetValueOperationHandler(this.operationTestContext.getObjectService(), this.operationTestContext.getIdentifierProvider(),
+                this.operationTestContext.getInterpreter(), new ChildModelOperationHandler(), this.setValue);
     }
 
     @Test

--- a/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/compatibility/operations/SwitchOperationHandlerTests.java
+++ b/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/compatibility/operations/SwitchOperationHandlerTests.java
@@ -72,7 +72,8 @@ public class SwitchOperationHandlerTests {
         this.defaultCase.getSubModelOperations().add(subChangeContextDefault);
         this.switchOperation.setDefault(this.defaultCase);
 
-        this.switchOperationHandler = new SwitchOperationHandler(this.operationTestContext.getInterpreter(), new ChildModelOperationHandler(), this.switchOperation);
+        this.switchOperationHandler = new SwitchOperationHandler(this.operationTestContext.getObjectService(), this.operationTestContext.getIdentifierProvider(),
+                this.operationTestContext.getInterpreter(), new ChildModelOperationHandler(), this.switchOperation);
     }
 
     @Test

--- a/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/compatibility/operations/UnsetOperationHandlerTests.java
+++ b/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/compatibility/operations/UnsetOperationHandlerTests.java
@@ -63,7 +63,8 @@ public class UnsetOperationHandlerTests {
         this.operationTestContext.getRootPackage().setEFactoryInstance(EcoreFactory.eINSTANCE.createEFactory());
 
         this.unset = ToolFactory.eINSTANCE.createUnset();
-        this.unsetOperationHandler = new UnsetOperationHandler(this.operationTestContext.getInterpreter(), new ChildModelOperationHandler(), this.unset);
+        this.unsetOperationHandler = new UnsetOperationHandler(this.operationTestContext.getObjectService(), this.operationTestContext.getIdentifierProvider(),
+                this.operationTestContext.getInterpreter(), new ChildModelOperationHandler(), this.unset);
     }
 
     @Test

--- a/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/compatibility/properties/FormRendererTests.java
+++ b/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/compatibility/properties/FormRendererTests.java
@@ -71,11 +71,12 @@ public class FormRendererTests {
             }
         };
 
+        IObjectService objectService = new IObjectService.NoOp();
         IIdentifierProvider identifierProvider = element -> UUID.randomUUID().toString();
         IdentifiedElementLabelProvider identifiedElementLabelProvider = new IdentifiedElementLabelProvider();
         ISemanticCandidatesProviderFactory semanticCandidatesProviderFactory = SemanticCandidatesProvider::new;
-        IModelOperationHandlerSwitchProvider modelOperationHandlerSwitchProvider = ModelOperationHandlerSwitch::new;
-        ViewExtensionDescriptionConverter converter = new ViewExtensionDescriptionConverter(new IObjectService.NoOp(), interpreterFactory, identifierProvider, semanticCandidatesProviderFactory,
+        IModelOperationHandlerSwitchProvider modelOperationHandlerSwitchProvider = interpeter -> new ModelOperationHandlerSwitch(objectService, identifierProvider, interpeter);
+        ViewExtensionDescriptionConverter converter = new ViewExtensionDescriptionConverter(objectService, interpreterFactory, identifierProvider, semanticCandidatesProviderFactory,
                 modelOperationHandlerSwitchProvider, identifiedElementLabelProvider);
         FormDescription description = converter.convert(viewExtensionDescription);
 

--- a/backend/sirius-web-forms-tests/pom.xml
+++ b/backend/sirius-web-forms-tests/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-forms-tests</artifactId>
-	<version>0.5.1</version>
+	<version>0.5.2</version>
 	<name>sirius-web-forms-tests</name>
 	<description>Sirius Web Forms Tests</description>
 
@@ -42,7 +42,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-forms</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.assertj</groupId>

--- a/backend/sirius-web-forms/pom.xml
+++ b/backend/sirius-web-forms/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-forms</artifactId>
-	<version>0.5.1</version>
+	<version>0.5.2</version>
 	<name>sirius-web-forms</name>
 	<description>Sirius Web Forms</description>
 
@@ -46,17 +46,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-annotations</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-components</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-representations</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -66,7 +66,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/backend/sirius-web-graphiql/pom.xml
+++ b/backend/sirius-web-graphiql/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-graphiql</artifactId>
-	<version>0.5.1</version>
+	<version>0.5.2</version>
 	<name>sirius-web-graphiql</name>
 	<description>Sirius Web Graphiql support. This project contribute a GraphQL query tool on the /graphiql/index.html URI.</description>
 

--- a/backend/sirius-web-graphql-utils/pom.xml
+++ b/backend/sirius-web-graphql-utils/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-graphql-utils</artifactId>
-	<version>0.5.1</version>
+	<version>0.5.2</version>
 	<name>sirius-web-graphql-utils</name>
 	<description>Sirius Web GraphQL Utils</description>
 
@@ -43,7 +43,7 @@
 		<dependency>
         	<groupId>org.eclipse.sirius.web</groupId>
         	<artifactId>sirius-web-annotations</artifactId>
-        	<version>0.5.1</version>
+        	<version>0.5.2</version>
     	</dependency>
 		<dependency>
         	<groupId>com.graphql-java</groupId>
@@ -53,7 +53,7 @@
     	<dependency>
    			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 			<scope>test</scope>
     	</dependency>
     	<dependency>

--- a/backend/sirius-web-graphql-voyager/pom.xml
+++ b/backend/sirius-web-graphql-voyager/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-graphql-voyager</artifactId>
-	<version>0.5.1</version>
+	<version>0.5.2</version>
 	<name>sirius-web-graphql-voyager</name>
 	<description>Sirius Web Graph Voyager. This project contribute a GraphQL API UX thanks to the https://github.com/APIs-guru/graphql-voyager project.</description>
 

--- a/backend/sirius-web-interpreter/pom.xml
+++ b/backend/sirius-web-interpreter/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-interpreter</artifactId>
-	<version>0.5.1</version>
+	<version>0.5.2</version>
 	<name>sirius-web-interpreter</name>
 	<description>Sirius Web Intepreter</description>
 

--- a/backend/sirius-web-representations/pom.xml
+++ b/backend/sirius-web-representations/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-representations</artifactId>
-	<version>0.5.1</version>
+	<version>0.5.2</version>
 	<name>sirius-web-representations</name>
 	<description>Sirius Web Representations</description>
 
@@ -42,7 +42,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-annotations</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 	</dependencies>
 

--- a/backend/sirius-web-selection/pom.xml
+++ b/backend/sirius-web-selection/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-selection</artifactId>
-	<version>0.5.1</version>
+	<version>0.5.2</version>
 	<name>sirius-web-selection</name>
 	<description>Sirius Web Selection</description>
 
@@ -42,17 +42,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-annotations</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-representations</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend/sirius-web-spring-collaborative-diagrams/pom.xml
+++ b/backend/sirius-web-spring-collaborative-diagrams/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-spring-collaborative-diagrams</artifactId>
-	<version>0.5.1</version>
+	<version>0.5.2</version>
 	<name>sirius-web-spring-collaborative-diagrams</name>
 	<description>Sirius Web Spring Collaborative Diagrams</description>
 
@@ -50,39 +50,39 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-api</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-diagrams</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-collaborative</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-diagrams-layout</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 		<dependency>
     		<groupId>org.eclipse.sirius.web</groupId>
     		<artifactId>sirius-web-tests</artifactId>
-    		<version>0.5.1</version>
+    		<version>0.5.2</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius.web</groupId>
     		<artifactId>sirius-web-spring-tests</artifactId>
-    		<version>0.5.1</version>
+    		<version>0.5.2</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-diagrams-tests</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/dto/InvokeDeleteToolOnDiagramInput.java
+++ b/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/dto/InvokeDeleteToolOnDiagramInput.java
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.spring.collaborative.diagrams.dto;
+
+import java.text.MessageFormat;
+import java.util.UUID;
+
+import org.eclipse.sirius.web.annotations.graphql.GraphQLField;
+import org.eclipse.sirius.web.annotations.graphql.GraphQLID;
+import org.eclipse.sirius.web.annotations.graphql.GraphQLInputObjectType;
+import org.eclipse.sirius.web.annotations.graphql.GraphQLNonNull;
+import org.eclipse.sirius.web.spring.collaborative.diagrams.api.IDiagramInput;
+
+/**
+ * The input for the "Invoke a delete tool on diagram" mutation.
+ *
+ * @author arichard
+ */
+@GraphQLInputObjectType
+public final class InvokeDeleteToolOnDiagramInput implements IDiagramInput {
+    private UUID id;
+
+    private UUID editingContextId;
+
+    private UUID representationId;
+
+    private UUID diagramElementId;
+
+    private String toolId;
+
+    @Override
+    @GraphQLID
+    @GraphQLField
+    @GraphQLNonNull
+    public UUID getId() {
+        return this.id;
+    }
+
+    @GraphQLID
+    @GraphQLField
+    @GraphQLNonNull
+    public UUID getEditingContextId() {
+        return this.editingContextId;
+    }
+
+    @Override
+    @GraphQLID
+    @GraphQLField
+    @GraphQLNonNull
+    public UUID getRepresentationId() {
+        return this.representationId;
+    }
+
+    @GraphQLID
+    @GraphQLField
+    @GraphQLNonNull
+    public UUID getDiagramElementId() {
+        return this.diagramElementId;
+    }
+
+    @GraphQLID
+    @GraphQLField
+    @GraphQLNonNull
+    public String getToolId() {
+        return this.toolId;
+    }
+
+    @Override
+    public String toString() {
+        String pattern = "{0} '{'id: {1}, editingContextId: {2}, representationId: {3}, diagramElementId: {4}, toolId: {5}'}'"; //$NON-NLS-1$
+        return MessageFormat.format(pattern, this.getClass().getSimpleName(), this.id, this.editingContextId, this.representationId, this.diagramElementId, this.toolId);
+    }
+
+}

--- a/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/dto/InvokeDeleteToolOnDiagramSuccessPayload.java
+++ b/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/dto/InvokeDeleteToolOnDiagramSuccessPayload.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.spring.collaborative.diagrams.dto;
+
+import java.text.MessageFormat;
+import java.util.Objects;
+import java.util.UUID;
+
+import org.eclipse.sirius.web.annotations.graphql.GraphQLField;
+import org.eclipse.sirius.web.annotations.graphql.GraphQLID;
+import org.eclipse.sirius.web.annotations.graphql.GraphQLNonNull;
+import org.eclipse.sirius.web.annotations.graphql.GraphQLObjectType;
+import org.eclipse.sirius.web.core.api.IPayload;
+import org.eclipse.sirius.web.diagrams.Diagram;
+
+/**
+ * The payload of the "Invoke delete tool on diagram" mutation returned on success.
+ *
+ * @author arichard
+ */
+@GraphQLObjectType
+public final class InvokeDeleteToolOnDiagramSuccessPayload implements IPayload {
+    private final UUID id;
+
+    private final Diagram diagram;
+
+    public InvokeDeleteToolOnDiagramSuccessPayload(UUID id, Diagram diagram) {
+        this.id = Objects.requireNonNull(id);
+        this.diagram = Objects.requireNonNull(diagram);
+    }
+
+    @Override
+    @GraphQLID
+    @GraphQLField
+    @GraphQLNonNull
+    public UUID getId() {
+        return this.id;
+    }
+
+    @GraphQLField
+    @GraphQLNonNull
+    public Diagram getDiagram() {
+        return this.diagram;
+    }
+
+    @Override
+    public String toString() {
+        String pattern = "{0} '{'id: {1}, diagram: '{'id: {2}, label: {3}'}''}'"; //$NON-NLS-1$
+        return MessageFormat.format(pattern, this.getClass().getSimpleName(), this.diagram.getId(), this.diagram.getLabel());
+    }
+}

--- a/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/handlers/DeleteFromDiagramEventHandler.java
+++ b/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/handlers/DeleteFromDiagramEventHandler.java
@@ -240,5 +240,4 @@ public class DeleteFromDiagramEventHandler implements IDiagramEventHandler {
                 .flatMap(diagramDescription -> this.diagramDescriptionService.findEdgeDescriptionById(diagramDescription, edge.getDescriptionId()));
         // @formatter:on
     }
-
 }

--- a/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/handlers/InvokeDeleteToolOnDiagramEventHandler.java
+++ b/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/handlers/InvokeDeleteToolOnDiagramEventHandler.java
@@ -1,0 +1,136 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.spring.collaborative.diagrams.handlers;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.eclipse.sirius.web.core.api.ErrorPayload;
+import org.eclipse.sirius.web.core.api.IEditingContext;
+import org.eclipse.sirius.web.core.api.IObjectService;
+import org.eclipse.sirius.web.core.api.IPayload;
+import org.eclipse.sirius.web.diagrams.Diagram;
+import org.eclipse.sirius.web.diagrams.Node;
+import org.eclipse.sirius.web.diagrams.tools.DeleteTool;
+import org.eclipse.sirius.web.representations.Failure;
+import org.eclipse.sirius.web.representations.IStatus;
+import org.eclipse.sirius.web.representations.Success;
+import org.eclipse.sirius.web.representations.VariableManager;
+import org.eclipse.sirius.web.spring.collaborative.api.ChangeDescription;
+import org.eclipse.sirius.web.spring.collaborative.api.ChangeKind;
+import org.eclipse.sirius.web.spring.collaborative.api.Monitoring;
+import org.eclipse.sirius.web.spring.collaborative.diagrams.api.IDiagramContext;
+import org.eclipse.sirius.web.spring.collaborative.diagrams.api.IDiagramEventHandler;
+import org.eclipse.sirius.web.spring.collaborative.diagrams.api.IDiagramInput;
+import org.eclipse.sirius.web.spring.collaborative.diagrams.api.IDiagramQueryService;
+import org.eclipse.sirius.web.spring.collaborative.diagrams.api.IToolService;
+import org.eclipse.sirius.web.spring.collaborative.diagrams.dto.InvokeDeleteToolOnDiagramInput;
+import org.eclipse.sirius.web.spring.collaborative.diagrams.dto.InvokeDeleteToolOnDiagramSuccessPayload;
+import org.eclipse.sirius.web.spring.collaborative.diagrams.dto.InvokeNodeToolOnDiagramInput;
+import org.eclipse.sirius.web.spring.collaborative.diagrams.messages.ICollaborativeDiagramMessageService;
+import org.springframework.stereotype.Service;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import reactor.core.publisher.Sinks.Many;
+import reactor.core.publisher.Sinks.One;
+
+/**
+ * Handle "Invoke delete tool on diagram" events.
+ *
+ * @author arichard
+ */
+@Service
+public class InvokeDeleteToolOnDiagramEventHandler implements IDiagramEventHandler {
+
+    private final IObjectService objectService;
+
+    private final IDiagramQueryService diagramQueryService;
+
+    private final IToolService toolService;
+
+    private final ICollaborativeDiagramMessageService messageService;
+
+    private final Counter counter;
+
+    public InvokeDeleteToolOnDiagramEventHandler(IObjectService objectService, IDiagramQueryService diagramQueryService, IToolService toolService,
+            ICollaborativeDiagramMessageService messageService, MeterRegistry meterRegistry) {
+        this.objectService = Objects.requireNonNull(objectService);
+        this.diagramQueryService = Objects.requireNonNull(diagramQueryService);
+        this.toolService = Objects.requireNonNull(toolService);
+        this.messageService = Objects.requireNonNull(messageService);
+
+        // @formatter:off
+        this.counter = Counter.builder(Monitoring.EVENT_HANDLER)
+                .tag(Monitoring.NAME, this.getClass().getSimpleName())
+                .register(meterRegistry);
+        // @formatter:on
+    }
+
+    @Override
+    public boolean canHandle(IDiagramInput diagramInput) {
+        return diagramInput instanceof InvokeDeleteToolOnDiagramInput;
+    }
+
+    @Override
+    public void handle(One<IPayload> payloadSink, Many<ChangeDescription> changeDescriptionSink, IEditingContext editingContext, IDiagramContext diagramContext, IDiagramInput diagramInput) {
+        this.counter.increment();
+
+        String message = this.messageService.invalidInput(diagramInput.getClass().getSimpleName(), InvokeNodeToolOnDiagramInput.class.getSimpleName());
+        IPayload payload = new ErrorPayload(diagramInput.getId(), message);
+        ChangeDescription changeDescription = new ChangeDescription(ChangeKind.NOTHING, diagramInput.getRepresentationId(), diagramInput);
+
+        if (diagramInput instanceof InvokeDeleteToolOnDiagramInput) {
+            InvokeDeleteToolOnDiagramInput input = (InvokeDeleteToolOnDiagramInput) diagramInput;
+            Diagram diagram = diagramContext.getDiagram();
+            // @formatter:off
+            var optionalTool = this.toolService.findToolById(editingContext, diagram, input.getToolId())
+                    .filter(DeleteTool.class::isInstance)
+                    .map(DeleteTool.class::cast);
+            // @formatter:on
+            if (optionalTool.isPresent()) {
+                IStatus status = this.executeTool(editingContext, diagramContext, input.getDiagramElementId(), optionalTool.get());
+                if (status instanceof Success) {
+
+                    payload = new InvokeDeleteToolOnDiagramSuccessPayload(diagramInput.getId(), diagram);
+                    changeDescription = new ChangeDescription(ChangeKind.SEMANTIC_CHANGE, diagramInput.getRepresentationId(), diagramInput);
+                }
+            }
+        }
+
+        payloadSink.tryEmitValue(payload);
+        changeDescriptionSink.tryEmitNext(changeDescription);
+    }
+
+    private IStatus executeTool(IEditingContext editingContext, IDiagramContext diagramContext, UUID diagramElementId, DeleteTool tool) {
+        IStatus result = new Failure(""); //$NON-NLS-1$
+        Diagram diagram = diagramContext.getDiagram();
+        Optional<Node> node = this.diagramQueryService.findNodeById(diagram, diagramElementId);
+        Optional<Object> self = Optional.empty();
+        if (node.isPresent()) {
+            self = this.objectService.getObject(editingContext, node.get().getTargetObjectId());
+        }
+
+        if (self.isPresent()) {
+            VariableManager variableManager = new VariableManager();
+            variableManager.put(IDiagramContext.DIAGRAM_CONTEXT, diagramContext);
+            variableManager.put(IEditingContext.EDITING_CONTEXT, editingContext);
+            variableManager.put(VariableManager.SELF, self.get());
+            variableManager.put(Node.SELECTED_NODE, node.get());
+            result = tool.getHandler().apply(variableManager);
+        }
+        return result;
+    }
+
+}

--- a/backend/sirius-web-spring-collaborative-diagrams/src/main/resources/schema/diagram.graphqls
+++ b/backend/sirius-web-spring-collaborative-diagrams/src/main/resources/schema/diagram.graphqls
@@ -174,6 +174,13 @@ type CreateEdgeTool implements Tool {
   edgeCandidates: [EdgeCandidate]!
 }
 
+type DeleteTool implements Tool {
+  id: ID!
+  label: String!
+  imageURL: String!
+  targetDescriptions: [NodeDescription!]!
+}
+
 type EdgeCandidate {
   sources: [NodeDescription!]!
   targets: [NodeDescription!]!
@@ -195,6 +202,7 @@ extend type Mutation {
   editLabel(input: EditLabelInput!): EditLabelPayload!
   invokeEdgeToolOnDiagram(input: InvokeEdgeToolOnDiagramInput!): InvokeEdgeToolOnDiagramPayload!
   invokeNodeToolOnDiagram(input: InvokeNodeToolOnDiagramInput!): InvokeNodeToolOnDiagramPayload!
+  invokeDeleteToolOnDiagram(input: InvokeDeleteToolOnDiagramInput!): InvokeDeleteToolOnDiagramPayload!
   updateNodeBounds(input: UpdateNodeBoundsInput!): UpdateNodeBoundsPayload!
   updateNodePosition(input: UpdateNodePositionInput!): UpdateNodePositionPayload!
 }
@@ -271,6 +279,21 @@ input InvokeNodeToolOnDiagramInput {
 union InvokeNodeToolOnDiagramPayload = ErrorPayload | InvokeNodeToolOnDiagramSuccessPayload
 
 type InvokeNodeToolOnDiagramSuccessPayload {
+  id: ID!
+  diagram: Diagram!
+}
+
+input InvokeDeleteToolOnDiagramInput {
+  id: ID!
+  editingContextId: ID!
+  representationId: ID!
+  diagramElementId: ID!
+  toolId: ID!
+}
+
+union InvokeDeleteToolOnDiagramPayload = ErrorPayload | InvokeDeleteToolOnDiagramSuccessPayload
+
+type InvokeDeleteToolOnDiagramSuccessPayload {
   id: ID!
   diagram: Diagram!
 }

--- a/backend/sirius-web-spring-collaborative-forms/pom.xml
+++ b/backend/sirius-web-spring-collaborative-forms/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-spring-collaborative-forms</artifactId>
-	<version>0.5.1</version>
+	<version>0.5.2</version>
 	<name>sirius-web-spring-collaborative-forms</name>
 	<description>Sirius Web Spring Collaborative Forms</description>
 
@@ -50,28 +50,28 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-api</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-forms</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-collaborative</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 		<dependency>
     		<groupId>org.eclipse.sirius.web</groupId>
     		<artifactId>sirius-web-tests</artifactId>
-    		<version>0.5.1</version>
+    		<version>0.5.2</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius.web</groupId>
     		<artifactId>sirius-web-spring-tests</artifactId>
-    		<version>0.5.1</version>
+    		<version>0.5.2</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>

--- a/backend/sirius-web-spring-collaborative-selection/pom.xml
+++ b/backend/sirius-web-spring-collaborative-selection/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-spring-collaborative-selection</artifactId>
-	<version>0.5.1</version>
+	<version>0.5.2</version>
 	<name>sirius-web-spring-collaborative-selection</name>
 	<description>Sirius Web Spring Collaborative Selection</description>
 
@@ -43,7 +43,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-selection</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>
@@ -56,23 +56,23 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-api</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-collaborative</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-tests</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/backend/sirius-web-spring-collaborative-trees/pom.xml
+++ b/backend/sirius-web-spring-collaborative-trees/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-spring-collaborative-trees</artifactId>
-	<version>0.5.1</version>
+	<version>0.5.2</version>
 	<name>sirius-web-spring-collaborative-trees</name>
 	<description>Sirius Web Spring Collaborative Trees</description>
 
@@ -42,12 +42,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-collaborative</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-trees</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>
@@ -68,13 +68,13 @@
 		<dependency>
     		<groupId>org.eclipse.sirius.web</groupId>
     		<artifactId>sirius-web-tests</artifactId>
-    		<version>0.5.1</version>
+    		<version>0.5.2</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius.web</groupId>
     		<artifactId>sirius-web-spring-tests</artifactId>
-    		<version>0.5.1</version>
+    		<version>0.5.2</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>

--- a/backend/sirius-web-spring-collaborative-validation/pom.xml
+++ b/backend/sirius-web-spring-collaborative-validation/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-spring-collaborative-validation</artifactId>
-	<version>0.5.1</version>
+	<version>0.5.2</version>
 	<name>sirius-web-spring-collaborative-validation</name>
 	<description>Sirius Web Spring Collaborative Validation</description>
 	
@@ -46,17 +46,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-api</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-collaborative</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-validation</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -66,13 +66,13 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 			<scope>test</scope>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius.web</groupId>
     		<artifactId>sirius-web-spring-tests</artifactId>
-    		<version>0.5.1</version>
+    		<version>0.5.2</version>
     		<scope>test</scope>
     	</dependency>
 	</dependencies>

--- a/backend/sirius-web-spring-collaborative/pom.xml
+++ b/backend/sirius-web-spring-collaborative/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-spring-collaborative</artifactId>
-	<version>0.5.1</version>
+	<version>0.5.2</version>
 	<name>sirius-web-spring-collaborative</name>
 	<description>Sirius Web Spring Collaborative</description>
 
@@ -70,23 +70,23 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-core-api</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-representations</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 		<dependency>
     		<groupId>org.eclipse.sirius.web</groupId>
     		<artifactId>sirius-web-tests</artifactId>
-    		<version>0.5.1</version>
+    		<version>0.5.2</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius.web</groupId>
     		<artifactId>sirius-web-spring-tests</artifactId>
-    		<version>0.5.1</version>
+    		<version>0.5.2</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>

--- a/backend/sirius-web-spring-graphql-api/pom.xml
+++ b/backend/sirius-web-spring-graphql-api/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-spring-graphql-api</artifactId>
-	<version>0.5.1</version>
+	<version>0.5.2</version>
 	<name>sirius-web-spring-graphql-api</name>
 	<description>Sirius Web Spring GraphQL API</description>
 
@@ -48,7 +48,7 @@
     	<dependency>
         	<groupId>org.eclipse.sirius.web</groupId>
         	<artifactId>sirius-web-annotations-spring</artifactId>
-        	<version>0.5.1</version>
+        	<version>0.5.2</version>
     	</dependency>
 	</dependencies>
 

--- a/backend/sirius-web-spring-graphql/pom.xml
+++ b/backend/sirius-web-spring-graphql/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-spring-graphql</artifactId>
-	<version>0.5.1</version>
+	<version>0.5.2</version>
 	<name>sirius-web-spring-graphql</name>
 	<description>Sirius Web Spring GraphQL</description>
 
@@ -68,28 +68,28 @@
     	<dependency>
     		<groupId>org.eclipse.sirius.web</groupId>
     		<artifactId>sirius-web-annotations</artifactId>
-    		<version>0.5.1</version>
+    		<version>0.5.2</version>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius.web</groupId>
     		<artifactId>sirius-web-graphql-utils</artifactId>
-    		<version>0.5.1</version>
+    		<version>0.5.2</version>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius.web</groupId>
     		<artifactId>sirius-web-spring-graphql-api</artifactId>
-    		<version>0.5.1</version>
+    		<version>0.5.2</version>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius.web</groupId>
     		<artifactId>sirius-web-tests</artifactId>
-    		<version>0.5.1</version>
+    		<version>0.5.2</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius.web</groupId>
     		<artifactId>sirius-web-spring-tests</artifactId>
-    		<version>0.5.1</version>
+    		<version>0.5.2</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>

--- a/backend/sirius-web-spring-starter/pom.xml
+++ b/backend/sirius-web-spring-starter/pom.xml
@@ -15,7 +15,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-spring-starter</artifactId>
-	<version>0.5.1</version>
+	<version>0.5.2</version>
 	<name>sirius-web-spring-starter</name>
 	<description>Sirius Web Spring Starter</description>
 
@@ -47,52 +47,52 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-graphql</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-diagrams-layout</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-collaborative</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-collaborative-diagrams</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-collaborative-forms</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-collaborative-selection</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-collaborative-trees</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-collaborative-validation</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-emf</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-compatibility</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 	</dependencies>
 

--- a/backend/sirius-web-spring-tests/pom.xml
+++ b/backend/sirius-web-spring-tests/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-spring-tests</artifactId>
-	<version>0.5.1</version>
+	<version>0.5.2</version>
 	<name>sirius-web-spring-tests</name>
 	<description>Sirius Web Spring Tests</description>
 
@@ -46,7 +46,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-annotations</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>

--- a/backend/sirius-web-tests/pom.xml
+++ b/backend/sirius-web-tests/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-tests</artifactId>
-	<version>0.5.1</version>
+	<version>0.5.2</version>
 	<name>sirius-web-tests</name>
 	<description>Sirius Web Tests</description>
 
@@ -51,7 +51,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-annotations</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 	</dependencies>
 

--- a/backend/sirius-web-trees/pom.xml
+++ b/backend/sirius-web-trees/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-trees</artifactId>
-	<version>0.5.1</version>
+	<version>0.5.2</version>
 	<name>sirius-web-trees</name>
 	<description>Sirius Web Trees</description>
 
@@ -42,17 +42,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-annotations</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-representations</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/backend/sirius-web-validation/pom.xml
+++ b/backend/sirius-web-validation/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-validation</artifactId>
-	<version>0.5.1</version>
+	<version>0.5.2</version>
 	<name>sirius-web-validation</name>
 	<description>Sirius Web Validation</description>
 	
@@ -47,17 +47,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-components</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-representations</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend/sirius-web-view-edit/pom.xml
+++ b/backend/sirius-web-view-edit/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-view-edit</artifactId>
-	<version>0.5.1</version>
+	<version>0.5.2</version>
 	<name>sirius-web-view-edit</name>
 	<description>Sirius Web View Definition DSL - Edit Support</description>
 
@@ -64,7 +64,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-view</artifactId>
-			<version>0.5.1</version>
+			<version>0.5.2</version>
 		</dependency>
 	</dependencies>
 	

--- a/backend/sirius-web-view/pom.xml
+++ b/backend/sirius-web-view/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-view</artifactId>
-	<version>0.5.1</version>
+	<version>0.5.2</version>
 	<name>sirius-web-view</name>
 	<description>Sirius Web View Definition DSL</description>
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@eclipse-sirius/sirius-components",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@eclipse-sirius/sirius-components",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "license": "EPL-2.0",
       "dependencies": {
         "uuid": "8.3.2"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-sirius/sirius-components",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "author": "Eclipse Sirius",
   "license": "EPL-2.0",
   "description": "Reusable components used to build the Sirius Web frontend",

--- a/frontend/src/diagram/DiagramWebSocketContainer.types.ts
+++ b/frontend/src/diagram/DiagramWebSocketContainer.types.ts
@@ -58,6 +58,8 @@ export interface CreateEdgeTool extends Tool {
   edgeCandidates: EdgeCandidate[];
 }
 
+export interface DeleteTool extends Tool {}
+
 export interface EdgeCandidate {
   sources: NodeDescription[];
   targets: NodeDescription[];

--- a/frontend/src/diagram/operations.ts
+++ b/frontend/src/diagram/operations.ts
@@ -295,6 +295,22 @@ export const invokeEdgeToolOnDiagramMutation = gql`
   }
 `;
 
+export const invokeDeleteToolOnDiagramMutation = gql`
+  mutation invokeDeleteToolOnDiagram($input: InvokeDeleteToolOnDiagramInput!) {
+    invokeDeleteToolOnDiagram(input: $input) {
+      __typename
+      ... on InvokeDeleteToolOnDiagramSuccessPayload {
+        diagram {
+          id
+        }
+      }
+      ... on ErrorPayload {
+        message
+      }
+    }
+  }
+`;
+
 export const getToolSectionsQuery = gql`
   fragment edgeCandidateField on EdgeCandidate {
     sources {
@@ -329,6 +345,11 @@ export const getToolSectionsQuery = gql`
                 ... on CreateEdgeTool {
                   edgeCandidates {
                     ...edgeCandidateField
+                  }
+                }
+                ... on DeleteTool {
+                  targetDescriptions {
+                    id
                   }
                 }
               }

--- a/frontend/src/diagram/sprotty/WebSocketDiagramServer.tsx
+++ b/frontend/src/diagram/sprotty/WebSocketDiagramServer.tsx
@@ -236,6 +236,8 @@ export class SiriusWebWebSocketDiagramServer extends ModelSource {
         this.invokeTool(this.activeTool, element.id);
       } else if (this.activeTool.__typename === 'CreateEdgeTool') {
         this.invokeTool(this.activeTool, this.diagramSourceElement.id, element.id);
+      } else if (this.activeTool.__typename === 'DeleteTool') {
+        this.invokeTool(this.activeTool, element.id);
       }
     } else {
       this.actionDispatcher.dispatch({

--- a/frontend/src/diagram/toolServices.ts
+++ b/frontend/src/diagram/toolServices.ts
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Obeo.
+ * Copyright (c) 2019, 2021 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -19,6 +19,8 @@ export function isContextualTool(tool, element) {
     result = tool.edgeCandidates.some((edgeCandidate) =>
       edgeCandidate.sources.some((source) => source.id === element.descriptionId)
     );
+  } else if (tool.__typename === 'DeleteTool') {
+    result = tool.targetDescriptions.some((targetDescription) => targetDescription.id === element.descriptionId);
   }
   return result;
 }

--- a/frontend/src/icons/GenericTool.tsx
+++ b/frontend/src/icons/GenericTool.tsx
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Remix Design Studio, Obeo and others
+ * Copyright (c) 2020, 2021 Remix Design Studio, Obeo and others
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,15 +25,15 @@ export const GenericTool = ({ title, ...props }) => {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 24 24"
-      width="24"
-      height="24"
+      viewBox="0 0 16 16"
+      width="16"
+      height="16"
       aria-labelledby="title"
       aria-describedby="desc"
       role="img"
       {...props}>
       <title>{title}</title>
-      <path d="M12 22C6.477 22 2 17.523 2 12S6.477 2 12 2s10 4.477 10 10-4.477 10-10 10zm0-2a8 8 0 1 0 0-16 8 8 0 0 0 0 16zm0-12.95L16.95 12 12 16.95 7.05 12 12 7.05zm0 2.829L9.879 12 12 14.121 14.121 12 12 9.879z" />
+      <path d="M 8,15 C 4.1339,15 1,11.8661 1,8 1,4.1339 4.1339,1 8,1 c 3.8661,0 7,3.1339 7,7 0,3.8661 -3.1339,7 -7,7 z M 8,13.6 A 5.6,5.6 0 1 0 8,2.4 5.6,5.6 0 0 0 8,13.6 Z M 8,4.535 11.465,8 8,11.465 4.535,8 Z M 8,6.5153 6.5153,8 8,9.4847 9.4847,8 Z" />
     </svg>
   );
 };


### PR DESCRIPTION
### Type of this PR 

- [x] New feature or improvement

### Issue(s)

https://github.com/eclipse-sirius/sirius-components/issues/773

### What does this PR do?

Improve support for unsynchronized diagrams in the compatibility layer -> handle unsynchronized nodes in diagrams, along with CreateView and DeleteView operations from odesign

### How to test this PR?

- [x] Backend Unit tests

### Checklist

- [x] I have read CONTRIBUTING carefully.
- [x] I have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All my commits are signed-off (`-s`) with my mail address of my Eclipse Account.
- [x] I have covered my changes by unit tests or integration tests or manual tests.
- [x] All tests pass.
- [x] I have updated the documentation accordingly
- [x] New React components are available in storybook
