### PR TITLE
[cleanup] Add a task to display typescript errors in vscode problems

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -19,6 +19,7 @@
 === Improvements
 
 - https://github.com/eclipse-sirius/sirius-components/issues/799[#799] [diagram] The buttons in the diagram's toolbar now have proper tooltips
+- [core] Add a task to display TypeScript errors in the VS Code problems view
 
 
 == v0.5.0

--- a/frontend/.vscode/tasks.json
+++ b/frontend/.vscode/tasks.json
@@ -1,0 +1,35 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "typescript compile watch mode",
+      "type": "shell",
+      "command": "npx",
+      "args": ["tsc", "--build", "tsconfig-noEmit.json", "--watch"],
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "presentation": {
+        "echo": true,
+        "reveal": "never",
+        "focus": false,
+        "panel": "shared",
+        "showReuseMessage": true,
+        "clear": false
+      },
+      "isBackground": true,
+      "problemMatcher": {
+        "base": "$tsc-watch",
+        "pattern": {
+          "regexp": "^((?!node_modules)[^\\s].*):(\\d+:\\d+|\\d+:\\d+:\\d+:\\d+)\\s+-\\s+(error|warning|info)\\s+(TS\\d+)\\s*:\\s*(.*)$",
+          "file": 1,
+          "location": 2,
+          "severity": 3,
+          "code": 4,
+          "message": 5
+        }
+      }
+    }
+  ]
+}

--- a/frontend/tsconfig-noEmit.json
+++ b/frontend/tsconfig-noEmit.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  }
+}


### PR DESCRIPTION
### Type of this PR 

- [ ] Bug fix
- [ ] New feature or improvement
- [ ] Documentation
- [x] Cleanup
- [ ] Test
- [ ] Build/Releng

### What does this PR do?

Provide a task that must be launched by hand (CMD+P in vscode).
Once launched, the task will display typescript errors in the problems view.
