### PR TITLE
[700] Switch IEditingContext#id and IRepresentation#id from UUID to String

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -4,6 +4,7 @@
 
 === Architectural decision records
 
+- [ADR-032] Relax our ID policy for editing context and representation (update)
 - [ADR-034] Switch from semver to calver
 - [ADR-035] Use a common pattern for configuration properties
 - [ADR-036] Adopt a more structured selection
@@ -17,6 +18,7 @@
 
 - https://github.com/eclipse-sirius/sirius-components/issues/804[#804] [core] Update the name of our configuration properties. The configuration property `sirius.web.graphql.websocket.allowed.origins` will now be `sirius.components.cors.allowedOriginPatterns` and it will support complex patterns on top of regular origins. The default value will be restored to nothing since it has temporarily been set to `*`. In a development environment, the recommended value would be both patterns `https://localhost:[*]` and `http://localhost:[*]` in order to accept requests from any application hosted on the same machine. The configuration property `org.eclipse.sirius.web.editingContextEventProcessorRegistry.disposeDelay` will now be `sirius.components.editingContext.disposeDelay`. Its default value will be 1s since it is the only realistic option with domain and view support.
 - https://github.com/eclipse-sirius/sirius-components/issues/692[#692] [explorer] The explorer view is now more generic and extensible. It can represent arbitrary kinds of tree items, but the tree items supported must be configured for each application.
+- https://github.com/eclipse-sirius/sirius-components/issues/700[#700] [core] editingContextId and representationId are no longer UUID but String. Products that rely on sirius-components will be able to have their own ID policy for the editingContextId and representationId.
 
 === New features
 

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -15,7 +15,7 @@
 
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-components</artifactId>
-	<version>0.5.4</version>
+	<version>0.5.5</version>
 
 	<name>sirius-components</name>
 	<description>Sirius Components</description>

--- a/backend/sirius-web-annotations-spring/pom.xml
+++ b/backend/sirius-web-annotations-spring/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-annotations-spring</artifactId>
-	<version>0.5.4</version>
+	<version>0.5.5</version>
 	<name>sirius-web-annotations-spring</name>
 	<description>Sirius Web Annotations Spring</description>
 

--- a/backend/sirius-web-annotations/pom.xml
+++ b/backend/sirius-web-annotations/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-annotations</artifactId>
-	<version>0.5.4</version>
+	<version>0.5.5</version>
 	<name>sirius-web-annotations</name>
 	<description>Sirius Web Annotations</description>
 

--- a/backend/sirius-web-api/pom.xml
+++ b/backend/sirius-web-api/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-api</artifactId>
-	<version>0.5.4</version>
+	<version>0.5.5</version>
 	<name>sirius-web-api</name>
 	<description>Sirius Web API</description>
 
@@ -47,17 +47,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-annotations</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-representations</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-forms</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 		<dependency>
 			<groupId>io.projectreactor</groupId>
@@ -66,7 +66,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend/sirius-web-compatibility/pom.xml
+++ b/backend/sirius-web-compatibility/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-compatibility</artifactId>
-	<version>0.5.4</version>
+	<version>0.5.5</version>
 	<name>sirius-web-compatibility</name>
 	<description>Sirius Web Compatibility</description>
 
@@ -72,7 +72,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -82,43 +82,43 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-tests</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-api</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-core-api</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-collaborative-diagrams</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-forms</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-selection</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-trees</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-interpreter</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.emf</groupId>

--- a/backend/sirius-web-compatibility/src/test/java/org/eclipse/sirius/web/compat/diagrams/DomainBasedSourceNodesProviderTests.java
+++ b/backend/sirius-web-compatibility/src/test/java/org/eclipse/sirius/web/compat/diagrams/DomainBasedSourceNodesProviderTests.java
@@ -74,7 +74,7 @@ public class DomainBasedSourceNodesProviderTests {
                 .scalingFactor(42)
                 .build();
 
-        NodeElementProps nodeElementProps = NodeElementProps.newNodeElementProps(UUID.randomUUID())
+        NodeElementProps nodeElementProps = NodeElementProps.newNodeElementProps(UUID.randomUUID().toString())
                 .type("type") //$NON-NLS-1$
                 .targetObjectId("targetObjectId") //$NON-NLS-1$
                 .targetObjectKind("targetObjectKind") //$NON-NLS-1$

--- a/backend/sirius-web-compatibility/src/test/java/org/eclipse/sirius/web/compat/diagrams/RelationBasedSourceNodesProviderTests.java
+++ b/backend/sirius-web-compatibility/src/test/java/org/eclipse/sirius/web/compat/diagrams/RelationBasedSourceNodesProviderTests.java
@@ -67,7 +67,7 @@ public class RelationBasedSourceNodesProviderTests {
                 .imageURL("") //$NON-NLS-1$
                 .build();
 
-        NodeElementProps nodeElementProps = NodeElementProps.newNodeElementProps(UUID.randomUUID())
+        NodeElementProps nodeElementProps = NodeElementProps.newNodeElementProps(UUID.randomUUID().toString())
                 .type("type") //$NON-NLS-1$
                 .targetObjectId("targetObjectId") //$NON-NLS-1$
                 .targetObjectKind("targetObjectKind") //$NON-NLS-1$

--- a/backend/sirius-web-components/pom.xml
+++ b/backend/sirius-web-components/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-components</artifactId>
-	<version>0.5.4</version>
+	<version>0.5.5</version>
 	<name>sirius-web-components</name>
 	<description>Sirius Web Components</description>
 
@@ -52,7 +52,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend/sirius-web-core-api/pom.xml
+++ b/backend/sirius-web-core-api/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-core-api</artifactId>
-	<version>0.5.4</version>
+	<version>0.5.5</version>
 	<name>sirius-web-core-api</name>
 	<description>Sirius Web Core API</description>
 
@@ -47,17 +47,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-annotations</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-representations</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend/sirius-web-core-api/src/main/java/org/eclipse/sirius/web/core/api/IEditService.java
+++ b/backend/sirius-web-core-api/src/main/java/org/eclipse/sirius/web/core/api/IEditService.java
@@ -23,13 +23,13 @@ import java.util.UUID;
  */
 public interface IEditService {
 
-    Optional<Object> findClass(UUID editingContextId, String classId);
+    Optional<Object> findClass(String editingContextId, String classId);
 
-    List<Domain> getDomains(UUID editingContextId);
+    List<Domain> getDomains(String editingContextId);
 
-    List<ChildCreationDescription> getRootCreationDescriptions(UUID editingContextId, String domainId, boolean suggested);
+    List<ChildCreationDescription> getRootCreationDescriptions(String editingContextId, String domainId, boolean suggested);
 
-    List<ChildCreationDescription> getChildCreationDescriptions(UUID editingContextId, String classId);
+    List<ChildCreationDescription> getChildCreationDescriptions(String editingContextId, String classId);
 
     Optional<Object> createChild(IEditingContext editingContext, Object object, String childCreationDescriptionId);
 
@@ -47,22 +47,22 @@ public interface IEditService {
     class NoOp implements IEditService {
 
         @Override
-        public Optional<Object> findClass(UUID editingContextId, String classId) {
+        public Optional<Object> findClass(String editingContextId, String classId) {
             return Optional.empty();
         }
 
         @Override
-        public List<Domain> getDomains(UUID editingContextId) {
+        public List<Domain> getDomains(String editingContextId) {
             return List.of();
         }
 
         @Override
-        public List<ChildCreationDescription> getRootCreationDescriptions(UUID editingContextId, String domainId, boolean suggested) {
+        public List<ChildCreationDescription> getRootCreationDescriptions(String editingContextId, String domainId, boolean suggested) {
             return List.of();
         }
 
         @Override
-        public List<ChildCreationDescription> getChildCreationDescriptions(UUID editingContextId, String classId) {
+        public List<ChildCreationDescription> getChildCreationDescriptions(String editingContextId, String classId) {
             return List.of();
         }
 

--- a/backend/sirius-web-core-api/src/main/java/org/eclipse/sirius/web/core/api/IEditingContext.java
+++ b/backend/sirius-web-core-api/src/main/java/org/eclipse/sirius/web/core/api/IEditingContext.java
@@ -12,8 +12,6 @@
  *******************************************************************************/
 package org.eclipse.sirius.web.core.api;
 
-import java.util.UUID;
-
 /**
  * Used to contain the semantic data.
  *
@@ -26,7 +24,7 @@ public interface IEditingContext {
      */
     String EDITING_CONTEXT = "editingContext"; //$NON-NLS-1$
 
-    UUID getId();
+    String getId();
 
     /**
      * Implementation which does nothing, used for mocks in unit tests.
@@ -36,7 +34,7 @@ public interface IEditingContext {
     class NoOp implements IEditingContext {
 
         @Override
-        public UUID getId() {
+        public String getId() {
             return null;
         }
 

--- a/backend/sirius-web-core-api/src/main/java/org/eclipse/sirius/web/core/api/IEditingContextSearchService.java
+++ b/backend/sirius-web-core-api/src/main/java/org/eclipse/sirius/web/core/api/IEditingContextSearchService.java
@@ -13,7 +13,6 @@
 package org.eclipse.sirius.web.core.api;
 
 import java.util.Optional;
-import java.util.UUID;
 
 /**
  * Interface used to determine if an editing context exist and to retrieve it.
@@ -22,8 +21,8 @@ import java.util.UUID;
  */
 public interface IEditingContextSearchService {
 
-    boolean existsById(UUID editingContextId);
+    boolean existsById(String editingContextId);
 
-    Optional<IEditingContext> findById(UUID editingContextId);
+    Optional<IEditingContext> findById(String editingContextId);
 
 }

--- a/backend/sirius-web-core-api/src/main/java/org/eclipse/sirius/web/core/api/IRepresentationInput.java
+++ b/backend/sirius-web-core-api/src/main/java/org/eclipse/sirius/web/core/api/IRepresentationInput.java
@@ -12,13 +12,11 @@
  *******************************************************************************/
 package org.eclipse.sirius.web.core.api;
 
-import java.util.UUID;
-
 /**
  * Common interface of all the input used to interact with a representation.
  *
  * @author sbegaudeau
  */
 public interface IRepresentationInput extends IInput {
-    UUID getRepresentationId();
+    String getRepresentationId();
 }

--- a/backend/sirius-web-diagrams-layout-api/pom.xml
+++ b/backend/sirius-web-diagrams-layout-api/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-diagrams-layout-api</artifactId>
-	<version>0.5.4</version>
+	<version>0.5.5</version>
 	<name>sirius-web-diagrams-layout-api</name>
 	<description>Sirius Web Diagrams Layout API</description>
 
@@ -42,12 +42,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-diagrams</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-core-api</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 	</dependencies>
 

--- a/backend/sirius-web-diagrams-layout/pom.xml
+++ b/backend/sirius-web-diagrams-layout/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-diagrams-layout</artifactId>
-	<version>0.5.4</version>
+	<version>0.5.5</version>
 	<name>sirius-web-diagrams-layout</name>
 	<description>Sirius Web Diagrams layout</description>
 
@@ -65,17 +65,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-annotations</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-core-api</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-diagrams-layout-api</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.elk</groupId>
@@ -112,7 +112,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -127,12 +127,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-diagrams</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-diagrams-tests</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/LayoutService.java
+++ b/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/LayoutService.java
@@ -15,7 +15,6 @@ package org.eclipse.sirius.web.diagrams.layout;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.UUID;
 
 import org.eclipse.elk.alg.layered.options.LayeredOptions;
 import org.eclipse.elk.core.IGraphLayoutEngine;
@@ -129,7 +128,7 @@ public class LayoutService implements ILayoutService {
         }
         this.incrementalLayoutEngine.layout(optionalDiagramElementEvent, diagramLayoutData, layoutConfigurator);
 
-        Map<UUID, ILayoutData> id2LayoutData = convertedDiagram.getId2LayoutData();
+        Map<String, ILayoutData> id2LayoutData = convertedDiagram.getId2LayoutData();
         return this.incrementalLayoutedDiagramProvider.getLayoutedDiagram(newDiagram, diagramLayoutData, id2LayoutData);
     }
 

--- a/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/TextBoundsService.java
+++ b/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/TextBoundsService.java
@@ -61,7 +61,7 @@ public class TextBoundsService {
                     .color("#000000") //$NON-NLS-1$
                     .iconURL("") //$NON-NLS-1$
                     .build();
-            Label label = Label.newLabel(UUID.randomUUID())
+            Label label = Label.newLabel(UUID.randomUUID().toString())
                     .type("labelType") //$NON-NLS-1$
                     .position(Position.UNDEFINED)
                     .size(Size.UNDEFINED)

--- a/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/incremental/IncrementalLayoutConvertedDiagram.java
+++ b/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/incremental/IncrementalLayoutConvertedDiagram.java
@@ -14,7 +14,6 @@ package org.eclipse.sirius.web.diagrams.layout.incremental;
 
 import java.util.Map;
 import java.util.Objects;
-import java.util.UUID;
 
 import org.eclipse.sirius.web.diagrams.layout.incremental.data.DiagramLayoutData;
 import org.eclipse.sirius.web.diagrams.layout.incremental.data.ILayoutData;
@@ -29,9 +28,9 @@ public class IncrementalLayoutConvertedDiagram {
 
     private final DiagramLayoutData diagramLayoutData;
 
-    private final Map<UUID, ILayoutData> id2LayoutData;
+    private final Map<String, ILayoutData> id2LayoutData;
 
-    public IncrementalLayoutConvertedDiagram(DiagramLayoutData diagramLayoutData, Map<UUID, ILayoutData> id2LayoutData) {
+    public IncrementalLayoutConvertedDiagram(DiagramLayoutData diagramLayoutData, Map<String, ILayoutData> id2LayoutData) {
         this.diagramLayoutData = Objects.requireNonNull(diagramLayoutData);
         this.id2LayoutData = Objects.requireNonNull(id2LayoutData);
     }
@@ -40,7 +39,7 @@ public class IncrementalLayoutConvertedDiagram {
         return this.diagramLayoutData;
     }
 
-    public Map<UUID, ILayoutData> getId2LayoutData() {
+    public Map<String, ILayoutData> getId2LayoutData() {
         return this.id2LayoutData;
     }
 }

--- a/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/incremental/IncrementalLayoutDiagramConverter.java
+++ b/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/incremental/IncrementalLayoutDiagramConverter.java
@@ -16,7 +16,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 
 import org.eclipse.sirius.web.diagrams.CustomizableProperties;
 import org.eclipse.sirius.web.diagrams.Diagram;
@@ -42,10 +41,10 @@ import org.springframework.stereotype.Service;
 public class IncrementalLayoutDiagramConverter {
 
     public IncrementalLayoutConvertedDiagram convert(Diagram diagram) {
-        Map<UUID, ILayoutData> id2LayoutData = new HashMap<>();
+        Map<String, ILayoutData> id2LayoutData = new HashMap<>();
 
         DiagramLayoutData layoutData = new DiagramLayoutData();
-        UUID id = diagram.getId();
+        String id = diagram.getId();
         layoutData.setId(id);
         id2LayoutData.put(id, layoutData);
 
@@ -67,9 +66,9 @@ public class IncrementalLayoutDiagramConverter {
         return new IncrementalLayoutConvertedDiagram(layoutData, id2LayoutData);
     }
 
-    private NodeLayoutData convertNode(Node node, IContainerLayoutData parent, Map<UUID, ILayoutData> id2LayoutData) {
+    private NodeLayoutData convertNode(Node node, IContainerLayoutData parent, Map<String, ILayoutData> id2LayoutData) {
         NodeLayoutData layoutData = new NodeLayoutData();
-        UUID id = node.getId();
+        String id = node.getId();
         layoutData.setId(id);
         id2LayoutData.put(id, layoutData);
 
@@ -100,9 +99,9 @@ public class IncrementalLayoutDiagramConverter {
         return layoutData;
     }
 
-    private EdgeLayoutData convertEdge(Edge edge, Map<UUID, ILayoutData> id2LayoutData) {
+    private EdgeLayoutData convertEdge(Edge edge, Map<String, ILayoutData> id2LayoutData) {
         EdgeLayoutData layoutData = new EdgeLayoutData();
-        UUID id = edge.getId();
+        String id = edge.getId();
         layoutData.setId(id);
         id2LayoutData.put(id, layoutData);
 
@@ -123,9 +122,9 @@ public class IncrementalLayoutDiagramConverter {
         return layoutData;
     }
 
-    private LabelLayoutData convertLabel(Label label, Map<UUID, ILayoutData> id2LayoutData) {
+    private LabelLayoutData convertLabel(Label label, Map<String, ILayoutData> id2LayoutData) {
         LabelLayoutData layoutData = new LabelLayoutData();
-        UUID id = label.getId();
+        String id = label.getId();
         layoutData.setId(id);
         id2LayoutData.put(id, layoutData);
 

--- a/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/incremental/IncrementalLayoutedDiagramProvider.java
+++ b/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/incremental/IncrementalLayoutedDiagramProvider.java
@@ -17,7 +17,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.UUID;
 import java.util.stream.Collectors;
 
 import org.eclipse.sirius.web.diagrams.CustomizableProperties;
@@ -41,7 +40,7 @@ import org.springframework.stereotype.Service;
 @Service
 public class IncrementalLayoutedDiagramProvider {
 
-    public Diagram getLayoutedDiagram(Diagram diagram, DiagramLayoutData diagramLayoutData, Map<UUID, ILayoutData> id2LayoutData) {
+    public Diagram getLayoutedDiagram(Diagram diagram, DiagramLayoutData diagramLayoutData, Map<String, ILayoutData> id2LayoutData) {
         List<Node> nodes = this.getLayoutedNodes(diagram.getNodes(), id2LayoutData);
         List<Edge> edges = this.getLayoutedEdges(diagram.getEdges(), id2LayoutData);
 
@@ -55,7 +54,7 @@ public class IncrementalLayoutedDiagramProvider {
         // @formatter:on
     }
 
-    private List<Node> getLayoutedNodes(List<Node> nodes, Map<UUID, ILayoutData> id2LayoutData) {
+    private List<Node> getLayoutedNodes(List<Node> nodes, Map<String, ILayoutData> id2LayoutData) {
         // @formatter:off
         return nodes.stream().flatMap(node -> {
             return Optional.ofNullable(id2LayoutData.get(node.getId()))
@@ -67,7 +66,7 @@ public class IncrementalLayoutedDiagramProvider {
         // @formatter:on
     }
 
-    private Node getLayoutedNode(Node node, NodeLayoutData nodeLayoutData, Map<UUID, ILayoutData> id2LayoutData) {
+    private Node getLayoutedNode(Node node, NodeLayoutData nodeLayoutData, Map<String, ILayoutData> id2LayoutData) {
         Label label = this.getLayoutedLabel(node.getLabel(), id2LayoutData);
 
         List<Node> childNodes = this.getLayoutedNodes(node.getChildNodes(), id2LayoutData);
@@ -89,7 +88,7 @@ public class IncrementalLayoutedDiagramProvider {
         // @formatter:on
     }
 
-    private List<Edge> getLayoutedEdges(List<Edge> edges, Map<UUID, ILayoutData> id2LayoutData) {
+    private List<Edge> getLayoutedEdges(List<Edge> edges, Map<String, ILayoutData> id2LayoutData) {
         // @formatter:off
         return edges.stream().flatMap(edge -> {
             return Optional.ofNullable(id2LayoutData.get(edge.getId()))
@@ -101,7 +100,7 @@ public class IncrementalLayoutedDiagramProvider {
         // @formatter:on
     }
 
-    private Edge getLayoutedEdge(Edge edge, EdgeLayoutData edgeLayoutData, Map<UUID, ILayoutData> id2LayoutData) {
+    private Edge getLayoutedEdge(Edge edge, EdgeLayoutData edgeLayoutData, Map<String, ILayoutData> id2LayoutData) {
         Label beginLabel = edge.getBeginLabel();
         if (beginLabel != null) {
             beginLabel = this.getLayoutedLabel(beginLabel, id2LayoutData);
@@ -125,7 +124,7 @@ public class IncrementalLayoutedDiagramProvider {
         // @formatter:on
     }
 
-    private Label getLayoutedLabel(Label label, Map<UUID, ILayoutData> id2LayoutData) {
+    private Label getLayoutedLabel(Label label, Map<String, ILayoutData> id2LayoutData) {
         Label layoutedLabel = label;
         var optionalLabelLayoutData = Optional.of(id2LayoutData.get(label.getId())).filter(LabelLayoutData.class::isInstance).map(LabelLayoutData.class::cast);
         if (optionalLabelLayoutData.isPresent()) {

--- a/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/incremental/data/DiagramLayoutData.java
+++ b/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/incremental/data/DiagramLayoutData.java
@@ -13,7 +13,6 @@
 package org.eclipse.sirius.web.diagrams.layout.incremental.data;
 
 import java.util.List;
-import java.util.UUID;
 
 import org.eclipse.sirius.web.diagrams.Position;
 import org.eclipse.sirius.web.diagrams.Size;
@@ -25,7 +24,7 @@ import org.eclipse.sirius.web.diagrams.Size;
  */
 public class DiagramLayoutData implements IContainerLayoutData {
 
-    private UUID id;
+    private String id;
 
     private Position position;
 
@@ -36,11 +35,11 @@ public class DiagramLayoutData implements IContainerLayoutData {
     private List<EdgeLayoutData> edges;
 
     @Override
-    public UUID getId() {
+    public String getId() {
         return this.id;
     }
 
-    public void setId(UUID id) {
+    public void setId(String id) {
         this.id = id;
     }
 

--- a/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/incremental/data/EdgeLayoutData.java
+++ b/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/incremental/data/EdgeLayoutData.java
@@ -13,7 +13,6 @@
 package org.eclipse.sirius.web.diagrams.layout.incremental.data;
 
 import java.util.List;
-import java.util.UUID;
 
 import org.eclipse.sirius.web.diagrams.Position;
 
@@ -36,14 +35,14 @@ public class EdgeLayoutData implements ILayoutData {
 
     private LabelLayoutData endLabel;
 
-    private UUID id;
+    private String id;
 
     @Override
-    public UUID getId() {
+    public String getId() {
         return this.id;
     }
 
-    public void setId(UUID id) {
+    public void setId(String id) {
         this.id = id;
     }
 

--- a/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/incremental/data/ILayoutData.java
+++ b/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/incremental/data/ILayoutData.java
@@ -12,8 +12,6 @@
  *******************************************************************************/
 package org.eclipse.sirius.web.diagrams.layout.incremental.data;
 
-import java.util.UUID;
-
 /**
  * The definition of a layout data structure.
  *
@@ -21,6 +19,6 @@ import java.util.UUID;
  */
 public interface ILayoutData {
 
-    UUID getId();
+    String getId();
 
 }

--- a/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/incremental/data/LabelLayoutData.java
+++ b/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/incremental/data/LabelLayoutData.java
@@ -12,8 +12,6 @@
  *******************************************************************************/
 package org.eclipse.sirius.web.diagrams.layout.incremental.data;
 
-import java.util.UUID;
-
 import org.eclipse.sirius.web.diagrams.Position;
 import org.eclipse.sirius.web.diagrams.TextBounds;
 
@@ -30,14 +28,14 @@ public class LabelLayoutData implements ILayoutData {
 
     private String labelType;
 
-    private UUID id;
+    private String id;
 
     @Override
-    public UUID getId() {
+    public String getId() {
         return this.id;
     }
 
-    public void setId(UUID id) {
+    public void setId(String id) {
         this.id = id;
     }
 

--- a/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/incremental/data/NodeLayoutData.java
+++ b/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/incremental/data/NodeLayoutData.java
@@ -13,7 +13,6 @@
 package org.eclipse.sirius.web.diagrams.layout.incremental.data;
 
 import java.util.List;
-import java.util.UUID;
 
 import org.eclipse.sirius.web.diagrams.INodeStyle;
 import org.eclipse.sirius.web.diagrams.Position;
@@ -26,7 +25,7 @@ import org.eclipse.sirius.web.diagrams.Size;
  */
 public class NodeLayoutData implements IContainerLayoutData, IConnectable {
 
-    private UUID id;
+    private String id;
 
     private Position position;
 
@@ -51,11 +50,11 @@ public class NodeLayoutData implements IContainerLayoutData, IConnectable {
     private boolean resizedByUser;
 
     @Override
-    public UUID getId() {
+    public String getId() {
         return this.id;
     }
 
-    public void setId(UUID id) {
+    public void setId(String id) {
         this.id = id;
     }
 

--- a/backend/sirius-web-diagrams-layout/src/test/java/org/eclipse/sirius/web/diagrams/layout/incremental/EdgeLabelPositionProviderTests.java
+++ b/backend/sirius-web-diagrams-layout/src/test/java/org/eclipse/sirius/web/diagrams/layout/incremental/EdgeLabelPositionProviderTests.java
@@ -65,7 +65,7 @@ public class EdgeLabelPositionProviderTests {
 
     private DiagramLayoutData createDiagramLayoutData() {
         DiagramLayoutData diagramLayoutData = new DiagramLayoutData();
-        diagramLayoutData.setId(UUID.randomUUID());
+        diagramLayoutData.setId(UUID.randomUUID().toString());
         diagramLayoutData.setPosition(Position.at(0, 0));
         diagramLayoutData.setSize(Size.of(1000, 1000));
 
@@ -74,7 +74,7 @@ public class EdgeLabelPositionProviderTests {
 
     private LabelLayoutData createLabelLayoutData() {
         LabelLayoutData labelLayoutData = new LabelLayoutData();
-        labelLayoutData.setId(UUID.randomUUID());
+        labelLayoutData.setId(UUID.randomUUID().toString());
         labelLayoutData.setPosition(Position.UNDEFINED);
         //@formatter:off
         LabelStyle labelStyle = LabelStyle.newLabelStyle()
@@ -91,7 +91,7 @@ public class EdgeLabelPositionProviderTests {
     private EdgeLayoutData createEdgeLayoutData(DiagramLayoutData diagramLayoutData) {
         EdgeLayoutData edgeLayoutData = new EdgeLayoutData();
         edgeLayoutData.setCenterLabel(this.createLabelLayoutData());
-        edgeLayoutData.setId(UUID.randomUUID());
+        edgeLayoutData.setId(UUID.randomUUID().toString());
         edgeLayoutData.setSource(this.createNodeLayoutData(Position.at(0, 0), Size.of(200, 200), diagramLayoutData));
         edgeLayoutData.setTarget(this.createNodeLayoutData(Position.at(400, 0), Size.of(200, 200), diagramLayoutData));
         List<Position> routingPoints = Arrays.asList(Position.at(200, 100), Position.at(400, 100));
@@ -101,7 +101,7 @@ public class EdgeLabelPositionProviderTests {
 
     private NodeLayoutData createNodeLayoutData(Position position, Size size, IContainerLayoutData parent) {
         NodeLayoutData nodeLayoutData = new NodeLayoutData();
-        nodeLayoutData.setId(UUID.randomUUID());
+        nodeLayoutData.setId(UUID.randomUUID().toString());
         nodeLayoutData.setParent(parent);
         nodeLayoutData.setPosition(position);
         nodeLayoutData.setSize(size);

--- a/backend/sirius-web-diagrams-layout/src/test/java/org/eclipse/sirius/web/diagrams/layout/incremental/EdgeRoutingPointsProviderTests.java
+++ b/backend/sirius-web-diagrams-layout/src/test/java/org/eclipse/sirius/web/diagrams/layout/incremental/EdgeRoutingPointsProviderTests.java
@@ -54,7 +54,7 @@ public class EdgeRoutingPointsProviderTests {
 
     private DiagramLayoutData createDiagramLayoutData() {
         DiagramLayoutData diagramLayoutData = new DiagramLayoutData();
-        diagramLayoutData.setId(UUID.randomUUID());
+        diagramLayoutData.setId(UUID.randomUUID().toString());
         diagramLayoutData.setPosition(Position.at(0, 0));
         diagramLayoutData.setSize(Size.of(1000, 1000));
 
@@ -63,7 +63,7 @@ public class EdgeRoutingPointsProviderTests {
 
     private EdgeLayoutData createEdgeLayoutData(DiagramLayoutData diagramLayoutData) {
         EdgeLayoutData edgeLayoutData = new EdgeLayoutData();
-        edgeLayoutData.setId(UUID.randomUUID());
+        edgeLayoutData.setId(UUID.randomUUID().toString());
         edgeLayoutData.setSource(this.createNodeLayoutData(Position.at(0, 0), Size.of(100, 50), diagramLayoutData));
         edgeLayoutData.setTarget(this.createNodeLayoutData(Position.at(200, 200), Size.of(100, 50), diagramLayoutData));
         List<Position> routingPoints = Arrays.asList(Position.at(200, 100), Position.at(400, 100));
@@ -73,7 +73,7 @@ public class EdgeRoutingPointsProviderTests {
 
     private NodeLayoutData createNodeLayoutData(Position position, Size size, IContainerLayoutData parent) {
         NodeLayoutData nodeLayoutData = new NodeLayoutData();
-        nodeLayoutData.setId(UUID.randomUUID());
+        nodeLayoutData.setId(UUID.randomUUID().toString());
         nodeLayoutData.setParent(parent);
         nodeLayoutData.setPosition(position);
         nodeLayoutData.setSize(size);

--- a/backend/sirius-web-diagrams-layout/src/test/java/org/eclipse/sirius/web/diagrams/layout/incremental/NodeLabelPositionProviderTests.java
+++ b/backend/sirius-web-diagrams-layout/src/test/java/org/eclipse/sirius/web/diagrams/layout/incremental/NodeLabelPositionProviderTests.java
@@ -79,7 +79,7 @@ public class NodeLabelPositionProviderTests {
 
     private DiagramLayoutData createDiagramLayoutData() {
         DiagramLayoutData diagramLayoutData = new DiagramLayoutData();
-        diagramLayoutData.setId(UUID.randomUUID());
+        diagramLayoutData.setId(UUID.randomUUID().toString());
         diagramLayoutData.setPosition(Position.at(0, 0));
         diagramLayoutData.setSize(Size.of(1000, 1000));
 
@@ -88,7 +88,7 @@ public class NodeLabelPositionProviderTests {
 
     private LabelLayoutData createLabelLayoutData() {
         LabelLayoutData labelLayoutData = new LabelLayoutData();
-        labelLayoutData.setId(UUID.randomUUID());
+        labelLayoutData.setId(UUID.randomUUID().toString());
         labelLayoutData.setPosition(Position.UNDEFINED);
         //@formatter:off
         LabelStyle labelStyle = LabelStyle.newLabelStyle()
@@ -104,7 +104,7 @@ public class NodeLabelPositionProviderTests {
 
     private NodeLayoutData createNodeLayoutData(Position position, Size size, IContainerLayoutData parent, String nodeType) {
         NodeLayoutData nodeLayoutData = new NodeLayoutData();
-        nodeLayoutData.setId(UUID.randomUUID());
+        nodeLayoutData.setId(UUID.randomUUID().toString());
         nodeLayoutData.setParent(parent);
         nodeLayoutData.setPosition(position);
         nodeLayoutData.setSize(size);

--- a/backend/sirius-web-diagrams-layout/src/test/java/org/eclipse/sirius/web/diagrams/layout/incremental/NodePositionProviderTests.java
+++ b/backend/sirius-web-diagrams-layout/src/test/java/org/eclipse/sirius/web/diagrams/layout/incremental/NodePositionProviderTests.java
@@ -267,7 +267,7 @@ public class NodePositionProviderTests {
 
     private DiagramLayoutData createDiagramLayoutData() {
         DiagramLayoutData diagramLayoutData = new DiagramLayoutData();
-        diagramLayoutData.setId(UUID.randomUUID());
+        diagramLayoutData.setId(UUID.randomUUID().toString());
         diagramLayoutData.setPosition(Position.at(0, 0));
         diagramLayoutData.setSize(Size.of(1000, 1000));
 
@@ -276,7 +276,7 @@ public class NodePositionProviderTests {
 
     private NodeLayoutData createNodeLayoutData(Position position, Size size, IContainerLayoutData parent, String nodeType) {
         NodeLayoutData nodeLayoutData = new NodeLayoutData();
-        nodeLayoutData.setId(UUID.randomUUID());
+        nodeLayoutData.setId(UUID.randomUUID().toString());
         nodeLayoutData.setParent(parent);
         nodeLayoutData.setPosition(position);
         nodeLayoutData.setSize(size);

--- a/backend/sirius-web-diagrams-layout/src/test/java/org/eclipse/sirius/web/diagrams/layout/incremental/NodeSizeProviderTests.java
+++ b/backend/sirius-web-diagrams-layout/src/test/java/org/eclipse/sirius/web/diagrams/layout/incremental/NodeSizeProviderTests.java
@@ -82,7 +82,7 @@ public class NodeSizeProviderTests {
         TestDiagramBuilder testDiagramBuilder = new TestDiagramBuilder();
 
         NodeLayoutData nodeLayoutData = new NodeLayoutData();
-        nodeLayoutData.setId(UUID.randomUUID());
+        nodeLayoutData.setId(UUID.randomUUID().toString());
         nodeLayoutData.setSize(size);
         nodeLayoutData.setNodeType(NodeType.NODE_RECTANGLE);
         nodeLayoutData.setStyle(testDiagramBuilder.getRectangularNodeStyle());

--- a/backend/sirius-web-diagrams-layout/src/test/java/org/eclipse/sirius/web/diagrams/layout/services/DiagramConverterTests.java
+++ b/backend/sirius-web-diagrams-layout/src/test/java/org/eclipse/sirius/web/diagrams/layout/services/DiagramConverterTests.java
@@ -53,15 +53,15 @@ public class DiagramConverterTests {
 
     private static final double IMAGE_HEIGHT = 100;
 
-    private static final UUID DIAGRAM_ID = UUID.randomUUID();
+    private static final String DIAGRAM_ID = UUID.randomUUID().toString();
 
-    private static final UUID FIRST_NODE_ID = UUID.randomUUID();
+    private static final String FIRST_NODE_ID = UUID.randomUUID().toString();
 
-    private static final UUID SECOND_NODE_ID = UUID.randomUUID();
+    private static final String SECOND_NODE_ID = UUID.randomUUID().toString();
 
-    private static final UUID THIRD_NODE_ID = UUID.randomUUID();
+    private static final String THIRD_NODE_ID = UUID.randomUUID().toString();
 
-    private static final UUID FIRST_EDGE_ID = UUID.randomUUID();
+    private static final String FIRST_EDGE_ID = UUID.randomUUID().toString();
 
     private TextBoundsService textBoundsService = new TextBoundsService() {
         @Override

--- a/backend/sirius-web-diagrams-layout/src/test/java/org/eclipse/sirius/web/diagrams/layout/services/LayoutedDiagramProviderTests.java
+++ b/backend/sirius-web-diagrams-layout/src/test/java/org/eclipse/sirius/web/diagrams/layout/services/LayoutedDiagramProviderTests.java
@@ -64,11 +64,11 @@ public class LayoutedDiagramProviderTests {
 
     private static final double EDGE_BENDPOINT_Y = 600;
 
-    private static final UUID DIAGRAM_ID = UUID.randomUUID();
+    private static final String DIAGRAM_ID = UUID.randomUUID().toString();
 
-    private static final UUID FIRST_NODE_ID = UUID.randomUUID();
+    private static final String FIRST_NODE_ID = UUID.randomUUID().toString();
 
-    private static final UUID FIRST_EDGE_ID = UUID.randomUUID();
+    private static final String FIRST_EDGE_ID = UUID.randomUUID().toString();
 
     @Test
     public void testLayoutedDiagramProvider() {
@@ -120,7 +120,7 @@ public class LayoutedDiagramProviderTests {
 
         id2ElkGraphElements.put(elkNode.getIdentifier(), elkNode);
 
-        UUID edgeId = originalDiagram.getEdges().get(0).getId();
+        String edgeId = originalDiagram.getEdges().get(0).getId();
 
         ElkEdge elkEdge = ElkGraphFactory.eINSTANCE.createElkEdge();
         elkEdge.setIdentifier(edgeId.toString());

--- a/backend/sirius-web-diagrams-tests/pom.xml
+++ b/backend/sirius-web-diagrams-tests/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-diagrams-tests</artifactId>
-	<version>0.5.4</version>
+	<version>0.5.5</version>
 	<name>sirius-web-diagrams-tests</name>
 	<description>Sirius Web Diagrams Tests</description>
 
@@ -42,7 +42,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-diagrams</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.assertj</groupId>

--- a/backend/sirius-web-diagrams-tests/src/main/java/org/eclipse/sirius/web/diagrams/tests/TestDiagramBuilder.java
+++ b/backend/sirius-web-diagrams-tests/src/main/java/org/eclipse/sirius/web/diagrams/tests/TestDiagramBuilder.java
@@ -44,7 +44,7 @@ public class TestDiagramBuilder {
 
     public static final String TOOL_LABEL = "toolLabel"; //$NON-NLS-1$
 
-    public Diagram getDiagram(UUID id) {
+    public Diagram getDiagram(String id) {
         // @formatter:off
         return Diagram.newDiagram(id)
                 .label("diagramLabel") //$NON-NLS-1$
@@ -78,14 +78,14 @@ public class TestDiagramBuilder {
         // @formatter:on
     }
 
-    public Node getNode(UUID id) {
+    public Node getNode(String id) {
         // @formatter:off
         LabelStyle labelStyle = LabelStyle.newLabelStyle()
                 .color("#000000") //$NON-NLS-1$
                 .fontSize(16)
                 .iconURL("") //$NON-NLS-1$
                 .build();
-        Label label = Label.newLabel(UUID.randomUUID())
+        Label label = Label.newLabel(UUID.randomUUID().toString())
                 .type("labelType") //$NON-NLS-1$
                 .text("text") //$NON-NLS-1$
                 .position(Position.UNDEFINED)
@@ -110,7 +110,7 @@ public class TestDiagramBuilder {
         // @formatter:on
     }
 
-    public Edge getEdge(UUID id, UUID sourceId, UUID targetId) {
+    public Edge getEdge(String id, String sourceId, String targetId) {
         // @formatter:off
         EdgeStyle style = EdgeStyle.newEdgeStyle()
                 .size(1)

--- a/backend/sirius-web-diagrams/pom.xml
+++ b/backend/sirius-web-diagrams/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-diagrams</artifactId>
-	<version>0.5.4</version>
+	<version>0.5.5</version>
 	<name>sirius-web-diagrams</name>
 	<description>Sirius Web Diagrams</description>
 
@@ -42,12 +42,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-components</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-representations</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -57,7 +57,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/Diagram.java
+++ b/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/Diagram.java
@@ -36,7 +36,7 @@ public final class Diagram implements IRepresentation, ISemanticRepresentation {
 
     public static final String KIND = "Diagram"; //$NON-NLS-1$
 
-    private UUID id;
+    private String id;
 
     private String kind;
 
@@ -62,7 +62,7 @@ public final class Diagram implements IRepresentation, ISemanticRepresentation {
     @GraphQLID
     @GraphQLField
     @GraphQLNonNull
-    public UUID getId() {
+    public String getId() {
         return this.id;
     }
 
@@ -120,7 +120,7 @@ public final class Diagram implements IRepresentation, ISemanticRepresentation {
         return this.edges;
     }
 
-    public static Builder newDiagram(UUID id) {
+    public static Builder newDiagram(String id) {
         return new Builder(id);
     }
 
@@ -141,7 +141,7 @@ public final class Diagram implements IRepresentation, ISemanticRepresentation {
      */
     @SuppressWarnings("checkstyle:HiddenField")
     public static final class Builder {
-        private UUID id;
+        private String id;
 
         private String kind = KIND;
 
@@ -159,7 +159,7 @@ public final class Diagram implements IRepresentation, ISemanticRepresentation {
 
         private List<Edge> edges;
 
-        private Builder(UUID id) {
+        private Builder(String id) {
             this.id = Objects.requireNonNull(id);
         }
 

--- a/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/Edge.java
+++ b/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/Edge.java
@@ -32,7 +32,7 @@ import org.eclipse.sirius.web.annotations.graphql.GraphQLObjectType;
 @Immutable
 @GraphQLObjectType
 public final class Edge {
-    private UUID id;
+    private String id;
 
     private String type;
 
@@ -50,9 +50,9 @@ public final class Edge {
 
     private Label endLabel;
 
-    private UUID sourceId;
+    private String sourceId;
 
-    private UUID targetId;
+    private String targetId;
 
     private EdgeStyle style;
 
@@ -65,7 +65,7 @@ public final class Edge {
     @GraphQLID
     @GraphQLField
     @GraphQLNonNull
-    public UUID getId() {
+    public String getId() {
         return this.id;
     }
 
@@ -118,14 +118,14 @@ public final class Edge {
     @GraphQLID
     @GraphQLField
     @GraphQLNonNull
-    public UUID getSourceId() {
+    public String getSourceId() {
         return this.sourceId;
     }
 
     @GraphQLID
     @GraphQLField
     @GraphQLNonNull
-    public UUID getTargetId() {
+    public String getTargetId() {
         return this.targetId;
     }
 
@@ -141,7 +141,7 @@ public final class Edge {
         return this.routingPoints;
     }
 
-    public static Builder newEdge(UUID id) {
+    public static Builder newEdge(String id) {
         return new Builder(id);
     }
 
@@ -163,7 +163,7 @@ public final class Edge {
      */
     @SuppressWarnings("checkstyle:HiddenField")
     public static final class Builder {
-        private UUID id;
+        private String id;
 
         private String type;
 
@@ -181,15 +181,15 @@ public final class Edge {
 
         private Label endLabel;
 
-        private UUID sourceId;
+        private String sourceId;
 
-        private UUID targetId;
+        private String targetId;
 
         private EdgeStyle style;
 
         private List<Position> routingPoints;
 
-        private Builder(UUID id) {
+        private Builder(String id) {
             this.id = Objects.requireNonNull(id);
         }
 
@@ -249,12 +249,12 @@ public final class Edge {
             return this;
         }
 
-        public Builder sourceId(UUID sourceId) {
+        public Builder sourceId(String sourceId) {
             this.sourceId = Objects.requireNonNull(sourceId);
             return this;
         }
 
-        public Builder targetId(UUID targetId) {
+        public Builder targetId(String targetId) {
             this.targetId = Objects.requireNonNull(targetId);
             return this;
         }

--- a/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/Label.java
+++ b/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/Label.java
@@ -14,7 +14,6 @@ package org.eclipse.sirius.web.diagrams;
 
 import java.text.MessageFormat;
 import java.util.Objects;
-import java.util.UUID;
 
 import org.eclipse.sirius.web.annotations.Immutable;
 import org.eclipse.sirius.web.annotations.graphql.GraphQLField;
@@ -31,7 +30,7 @@ import org.eclipse.sirius.web.annotations.graphql.GraphQLObjectType;
 @Immutable
 @GraphQLObjectType
 public final class Label {
-    private UUID id;
+    private String id;
 
     private String type;
 
@@ -52,7 +51,7 @@ public final class Label {
     @GraphQLID
     @GraphQLField
     @GraphQLNonNull
-    public UUID getId() {
+    public String getId() {
         return this.id;
     }
 
@@ -92,7 +91,7 @@ public final class Label {
         return this.style;
     }
 
-    public static Builder newLabel(UUID id) {
+    public static Builder newLabel(String id) {
         return new Builder(id);
     }
 
@@ -113,7 +112,7 @@ public final class Label {
      */
     @SuppressWarnings("checkstyle:HiddenField")
     public static final class Builder {
-        private UUID id;
+        private String id;
 
         private String type;
 
@@ -127,7 +126,7 @@ public final class Label {
 
         private LabelStyle style;
 
-        private Builder(UUID id) {
+        private Builder(String id) {
             this.id = Objects.requireNonNull(id);
         }
 

--- a/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/Node.java
+++ b/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/Node.java
@@ -36,7 +36,7 @@ public final class Node {
 
     public static final String SELECTED_NODE = "selectedNode"; //$NON-NLS-1$
 
-    private UUID id;
+    private String id;
 
     private String type;
 
@@ -71,7 +71,7 @@ public final class Node {
     @GraphQLID
     @GraphQLField
     @GraphQLNonNull
-    public UUID getId() {
+    public String getId() {
         return this.id;
     }
 
@@ -150,7 +150,7 @@ public final class Node {
         return this.customizedProperties;
     }
 
-    public static Builder newNode(UUID id) {
+    public static Builder newNode(String id) {
         return new Builder(id);
     }
 
@@ -172,7 +172,7 @@ public final class Node {
      */
     @SuppressWarnings("checkstyle:HiddenField")
     public static final class Builder {
-        private UUID id;
+        private String id;
 
         private String type;
 
@@ -200,7 +200,7 @@ public final class Node {
 
         private Set<CustomizableProperties> customizedProperties = Set.of();
 
-        private Builder(UUID id) {
+        private Builder(String id) {
             this.id = Objects.requireNonNull(id);
         }
 

--- a/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/ViewCreationRequest.java
+++ b/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/ViewCreationRequest.java
@@ -26,7 +26,7 @@ import org.eclipse.sirius.web.annotations.Immutable;
 @Immutable
 public final class ViewCreationRequest {
 
-    private UUID parentElementId;
+    private String parentElementId;
 
     private UUID descriptionId;
 
@@ -41,7 +41,7 @@ public final class ViewCreationRequest {
      *
      * @return the diagram element identifier
      */
-    public UUID getParentElementId() {
+    public String getParentElementId() {
         return this.parentElementId;
     }
 
@@ -80,7 +80,7 @@ public final class ViewCreationRequest {
      */
     @SuppressWarnings("checkstyle:HiddenField")
     public static final class Builder {
-        private UUID parentElementId;
+        private String parentElementId;
 
         private UUID descriptionId;
 
@@ -90,7 +90,7 @@ public final class ViewCreationRequest {
             // Prevent instantiation
         }
 
-        public Builder parentElementId(UUID parentElementId) {
+        public Builder parentElementId(String parentElementId) {
             this.parentElementId = Objects.requireNonNull(parentElementId);
             return this;
         }

--- a/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/ViewDeletionRequest.java
+++ b/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/ViewDeletionRequest.java
@@ -14,7 +14,6 @@ package org.eclipse.sirius.web.diagrams;
 
 import java.text.MessageFormat;
 import java.util.Objects;
-import java.util.UUID;
 
 import org.eclipse.sirius.web.annotations.Immutable;
 
@@ -26,13 +25,13 @@ import org.eclipse.sirius.web.annotations.Immutable;
 @Immutable
 public final class ViewDeletionRequest {
 
-    private UUID elementId;
+    private String elementId;
 
     private ViewDeletionRequest() {
         // Prevent instantiation
     }
 
-    public UUID getElementId() {
+    public String getElementId() {
         return this.elementId;
     }
 
@@ -54,13 +53,13 @@ public final class ViewDeletionRequest {
     @SuppressWarnings("checkstyle:HiddenField")
     public static final class Builder {
 
-        private UUID elementId;
+        private String elementId;
 
         private Builder() {
             // Prevent instantiation
         }
 
-        public Builder elementId(UUID elementId) {
+        public Builder elementId(String elementId) {
             this.elementId = Objects.requireNonNull(elementId);
             return this;
         }

--- a/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/components/DiagramComponent.java
+++ b/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/components/DiagramComponent.java
@@ -48,7 +48,7 @@ public class DiagramComponent implements IComponent {
 
         String label = diagramDescription.getLabelProvider().apply(variableManager);
 
-        UUID diagramId = optionalPreviousDiagram.map(Diagram::getId).orElseGet(UUID::randomUUID);
+        String diagramId = optionalPreviousDiagram.map(Diagram::getId).orElseGet(() -> UUID.randomUUID().toString());
         String targetObjectId = diagramDescription.getTargetObjectIdProvider().apply(variableManager);
 
         DiagramRenderingCache cache = new DiagramRenderingCache();

--- a/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/components/EdgeComponent.java
+++ b/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/components/EdgeComponent.java
@@ -89,7 +89,7 @@ public class EdgeComponent implements IComponent {
 
                     for (Element sourceNode : sourceNodes) {
                         for (Element targetNode : targetNodes) {
-                            UUID id = this.computeEdgeId(edgeDescription, sourceNode, targetNode, count);
+                            String id = this.computeEdgeId(edgeDescription, sourceNode, targetNode, count);
                             var optionalPreviousEdge = edgesRequestor.getById(id);
                             var edgeInstanceVariableManager = edgeVariableManager.createChild();
                             edgeInstanceVariableManager.put(EdgeDescription.SEMANTIC_EDGE_SOURCE, cache.getNodeToObject().get(sourceNode));
@@ -102,8 +102,8 @@ public class EdgeComponent implements IComponent {
                             if (shouldRender) {
                                 EdgeStyle style = edgeDescription.getStyleProvider().apply(edgeInstanceVariableManager);
 
-                                UUID sourceId = this.getId(sourceNode);
-                                UUID targetId = this.getId(targetNode);
+                                String sourceId = this.getId(sourceNode);
+                                String targetId = this.getId(targetNode);
 
                                 // @formatter:off
                                 String edgeType = optionalPreviousEdge
@@ -140,7 +140,7 @@ public class EdgeComponent implements IComponent {
         return new Fragment(fragmentProps);
     }
 
-    private List<Element> getLabelsChildren(EdgeDescription edgeDescription, VariableManager edgeVariableManager, Optional<Edge> optionalPreviousEdge, UUID edgeId, List<Position> routingPoints) {
+    private List<Element> getLabelsChildren(EdgeDescription edgeDescription, VariableManager edgeVariableManager, Optional<Edge> optionalPreviousEdge, String edgeId, List<Position> routingPoints) {
         List<Element> edgeChildren = new ArrayList<>();
 
         VariableManager labelVariableManager = edgeVariableManager.createChild();
@@ -167,25 +167,23 @@ public class EdgeComponent implements IComponent {
         return edgeChildren;
     }
 
-    private UUID computeEdgeId(EdgeDescription edgeDescription, Element sourceNode, Element targetNode, int count) {
+    private String computeEdgeId(EdgeDescription edgeDescription, Element sourceNode, Element targetNode, int count) {
         var descriptionId = edgeDescription.getId().toString();
         // @formatter:off
         var sourceId = Optional.of(sourceNode.getProps())
                 .filter(NodeElementProps.class::isInstance)
                 .map(NodeElementProps.class::cast)
                 .map(NodeElementProps::getId)
-                .map(UUID::toString)
                 .orElse(INVALID_NODE_ID);
 
         var targetId = Optional.of(targetNode.getProps())
                 .filter(NodeElementProps.class::isInstance)
                 .map(NodeElementProps.class::cast)
                 .map(NodeElementProps::getId)
-                .map(UUID::toString)
                 .orElse(INVALID_NODE_ID);
         // @formatter:on
         String rawIdentifier = descriptionId + ": " + sourceId + " --> " + targetId + " - " + count; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-        return UUID.nameUUIDFromBytes(rawIdentifier.getBytes());
+        return UUID.nameUUIDFromBytes(rawIdentifier.getBytes()).toString();
     }
 
     private boolean hasNodeCandidates(List<NodeDescription> nodeDescriptions, DiagramRenderingCache cache) {
@@ -200,13 +198,13 @@ public class EdgeComponent implements IComponent {
         // @formatter:on
     }
 
-    private UUID getId(Element nodeElement) {
+    private String getId(Element nodeElement) {
         // @formatter:off
         return Optional.of(nodeElement.getProps())
                 .filter(NodeElementProps.class::isInstance)
                 .map(NodeElementProps.class::cast)
                 .map(NodeElementProps::getId)
-                .orElse(UUID.randomUUID());
+                .orElse(UUID.randomUUID().toString());
         // @formatter:on
     }
 

--- a/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/components/EdgesRequestor.java
+++ b/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/components/EdgesRequestor.java
@@ -15,7 +15,6 @@ package org.eclipse.sirius.web.diagrams.components;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -28,7 +27,7 @@ import org.eclipse.sirius.web.diagrams.Edge;
  */
 public class EdgesRequestor implements IEdgesRequestor {
 
-    private final Map<UUID, Edge> edgeId2Edges;
+    private final Map<String, Edge> edgeId2Edges;
 
     public EdgesRequestor(List<Edge> previousEdges) {
         // @formatter:off
@@ -38,7 +37,7 @@ public class EdgesRequestor implements IEdgesRequestor {
     }
 
     @Override
-    public Optional<Edge> getById(UUID edgeId) {
+    public Optional<Edge> getById(String edgeId) {
         return Optional.ofNullable(this.edgeId2Edges.get(edgeId));
     }
 

--- a/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/components/IEdgesRequestor.java
+++ b/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/components/IEdgesRequestor.java
@@ -13,7 +13,6 @@
 package org.eclipse.sirius.web.diagrams.components;
 
 import java.util.Optional;
-import java.util.UUID;
 
 import org.eclipse.sirius.web.diagrams.Edge;
 
@@ -23,5 +22,5 @@ import org.eclipse.sirius.web.diagrams.Edge;
  * @author sbegaudeau
  */
 public interface IEdgesRequestor {
-    Optional<Edge> getById(UUID edgeId);
+    Optional<Edge> getById(String edgeId);
 }

--- a/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/components/LabelComponent.java
+++ b/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/components/LabelComponent.java
@@ -14,7 +14,6 @@ package org.eclipse.sirius.web.diagrams.components;
 
 import java.util.Objects;
 import java.util.Optional;
-import java.util.UUID;
 
 import org.eclipse.sirius.web.components.Element;
 import org.eclipse.sirius.web.components.IComponent;
@@ -46,8 +45,7 @@ public class LabelComponent implements IComponent {
         LabelDescription labelDescription = this.props.getLabelDescription();
         Optional<Label> optionalPreviousLabel = this.props.getPreviousLabel();
         String type = this.props.getType();
-        String idFromProvider = labelDescription.getIdProvider().apply(variableManager);
-        UUID id = UUID.nameUUIDFromBytes(idFromProvider.getBytes());
+        String id = labelDescription.getIdProvider().apply(variableManager);
         String text = labelDescription.getTextProvider().apply(variableManager);
 
         LabelStyleDescription labelStyleDescription = labelDescription.getStyleDescriptionProvider().apply(variableManager);

--- a/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/components/NodeComponent.java
+++ b/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/components/NodeComponent.java
@@ -100,7 +100,7 @@ public class NodeComponent implements IComponent {
     }
 
     private boolean existsViewCreationRequested(String targetObjectId) {
-        UUID parentElementId = this.props.getParentElementId();
+        String parentElementId = this.props.getParentElementId();
         UUID nodeDescriptionId = this.props.getNodeDescription().getId();
         // @formatter:off
         return this.props.getViewCreationRequests().stream()
@@ -110,7 +110,7 @@ public class NodeComponent implements IComponent {
         // @formatter:on
     }
 
-    private boolean existsViewDeletionRequested(UUID elementId) {
+    private boolean existsViewDeletionRequested(String elementId) {
         // @formatter:off
         return this.props.getViewDeletionRequests().stream()
                 .anyMatch(viewDeletionRequest -> Objects.equals(viewDeletionRequest.getElementId(), elementId));
@@ -121,7 +121,7 @@ public class NodeComponent implements IComponent {
         NodeDescription nodeDescription = this.props.getNodeDescription();
         NodeContainmentKind containmentKind = this.props.getContainmentKind();
 
-        UUID nodeId = optionalPreviousNode.map(Node::getId).orElseGet(() -> this.computeNodeId(targetObjectId));
+        String nodeId = optionalPreviousNode.map(Node::getId).orElseGet(() -> this.computeNodeId(targetObjectId));
         Optional<Label> optionalPreviousLabel = optionalPreviousNode.map(Node::getLabel);
         String type = nodeDescription.getTypeProvider().apply(nodeVariableManager);
         String targetObjectKind = nodeDescription.getTargetObjectKindProvider().apply(nodeVariableManager);
@@ -213,7 +213,7 @@ public class NodeComponent implements IComponent {
         return size;
     }
 
-    private List<Element> getBorderNodes(Optional<Node> optionalPreviousNode, VariableManager nodeVariableManager, UUID nodeId) {
+    private List<Element> getBorderNodes(Optional<Node> optionalPreviousNode, VariableManager nodeVariableManager, String nodeId) {
         NodeDescription nodeDescription = this.props.getNodeDescription();
         DiagramRenderingCache cache = this.props.getCache();
 
@@ -236,7 +236,7 @@ public class NodeComponent implements IComponent {
         }).collect(Collectors.toList());
     }
 
-    private List<Element> getChildNodes(Optional<Node> optionalPreviousNode, VariableManager nodeVariableManager, UUID nodeId) {
+    private List<Element> getChildNodes(Optional<Node> optionalPreviousNode, VariableManager nodeVariableManager, String nodeId) {
         NodeDescription nodeDescription = this.props.getNodeDescription();
         DiagramRenderingCache cache = this.props.getCache();
 
@@ -260,13 +260,12 @@ public class NodeComponent implements IComponent {
         }).collect(Collectors.toList());
     }
 
-    private UUID computeNodeId(String targetObjectId) {
-        UUID parentElementId = this.props.getParentElementId();
+    private String computeNodeId(String targetObjectId) {
+        String parentElementId = this.props.getParentElementId();
         NodeDescription nodeDescription = this.props.getNodeDescription();
         NodeContainmentKind containmentKind = this.props.getContainmentKind();
-
         String rawIdentifier = parentElementId.toString() + containmentKind.toString() + nodeDescription.getId().toString() + targetObjectId;
-        return UUID.nameUUIDFromBytes(rawIdentifier.getBytes());
+        return UUID.nameUUIDFromBytes(rawIdentifier.getBytes()).toString();
     }
 
 }

--- a/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/components/NodeComponentProps.java
+++ b/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/components/NodeComponentProps.java
@@ -14,7 +14,6 @@ package org.eclipse.sirius.web.diagrams.components;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.UUID;
 
 import org.eclipse.sirius.web.annotations.Immutable;
 import org.eclipse.sirius.web.components.IProps;
@@ -46,7 +45,7 @@ public final class NodeComponentProps implements IProps {
 
     private List<ViewDeletionRequest> viewDeletionRequests;
 
-    private UUID parentElementId;
+    private String parentElementId;
 
     private NodeComponentProps() {
         // Prevent instantiation
@@ -80,7 +79,7 @@ public final class NodeComponentProps implements IProps {
         return this.viewDeletionRequests;
     }
 
-    public UUID getParentElementId() {
+    public String getParentElementId() {
         return this.parentElementId;
     }
 
@@ -109,7 +108,7 @@ public final class NodeComponentProps implements IProps {
 
         private List<ViewDeletionRequest> viewDeletionRequests;
 
-        private UUID parentElementId;
+        private String parentElementId;
 
         public Builder variableManager(VariableManager variableManager) {
             this.variableManager = Objects.requireNonNull(variableManager);
@@ -146,7 +145,7 @@ public final class NodeComponentProps implements IProps {
             return this;
         }
 
-        public Builder parentElementId(UUID parentElementId) {
+        public Builder parentElementId(String parentElementId) {
             this.parentElementId = Objects.requireNonNull(parentElementId);
             return this;
         }

--- a/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/elements/DiagramElementProps.java
+++ b/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/elements/DiagramElementProps.java
@@ -32,7 +32,7 @@ import org.eclipse.sirius.web.diagrams.Size;
 public final class DiagramElementProps implements IProps {
     public static final String TYPE = "Diagram"; //$NON-NLS-1$
 
-    private UUID id;
+    private String id;
 
     private String targetObjectId;
 
@@ -50,7 +50,7 @@ public final class DiagramElementProps implements IProps {
         // Prevent instantiation
     }
 
-    public UUID getId() {
+    public String getId() {
         return this.id;
     }
 
@@ -79,7 +79,7 @@ public final class DiagramElementProps implements IProps {
         return this.children;
     }
 
-    public static Builder newDiagramElementProps(UUID id) {
+    public static Builder newDiagramElementProps(String id) {
         return new Builder(id);
     }
 
@@ -96,7 +96,7 @@ public final class DiagramElementProps implements IProps {
      */
     @SuppressWarnings("checkstyle:HiddenField")
     public static final class Builder {
-        private UUID id;
+        private String id;
 
         private String targetObjectId;
 
@@ -110,7 +110,7 @@ public final class DiagramElementProps implements IProps {
 
         private List<Element> children;
 
-        private Builder(UUID id) {
+        private Builder(String id) {
             this.id = Objects.requireNonNull(id);
         }
 

--- a/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/elements/EdgeElementProps.java
+++ b/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/elements/EdgeElementProps.java
@@ -34,7 +34,7 @@ public final class EdgeElementProps implements IProps {
 
     public static final String TYPE = "Edge"; //$NON-NLS-1$
 
-    private UUID id;
+    private String id;
 
     private String type;
 
@@ -46,9 +46,9 @@ public final class EdgeElementProps implements IProps {
 
     private UUID descriptionId;
 
-    private UUID sourceId;
+    private String sourceId;
 
-    private UUID targetId;
+    private String targetId;
 
     private EdgeStyle style;
 
@@ -60,7 +60,7 @@ public final class EdgeElementProps implements IProps {
         // Prevent instantiation
     }
 
-    public UUID getId() {
+    public String getId() {
         return this.id;
     }
 
@@ -84,11 +84,11 @@ public final class EdgeElementProps implements IProps {
         return this.descriptionId;
     }
 
-    public UUID getSourceId() {
+    public String getSourceId() {
         return this.sourceId;
     }
 
-    public UUID getTargetId() {
+    public String getTargetId() {
         return this.targetId;
     }
 
@@ -105,7 +105,7 @@ public final class EdgeElementProps implements IProps {
         return this.children;
     }
 
-    public static Builder newEdgeElementProps(UUID id) {
+    public static Builder newEdgeElementProps(String id) {
         return new Builder(id);
     }
 
@@ -122,7 +122,7 @@ public final class EdgeElementProps implements IProps {
      */
     @SuppressWarnings("checkstyle:HiddenField")
     public static final class Builder {
-        private UUID id;
+        private String id;
 
         private String type;
 
@@ -134,9 +134,9 @@ public final class EdgeElementProps implements IProps {
 
         private UUID descriptionId;
 
-        private UUID sourceId;
+        private String sourceId;
 
-        private UUID targetId;
+        private String targetId;
 
         private EdgeStyle style;
 
@@ -144,7 +144,7 @@ public final class EdgeElementProps implements IProps {
 
         private List<Element> children = new ArrayList<>();
 
-        private Builder(UUID id) {
+        private Builder(String id) {
             this.id = Objects.requireNonNull(id);
         }
 
@@ -173,12 +173,12 @@ public final class EdgeElementProps implements IProps {
             return this;
         }
 
-        public Builder sourceId(UUID sourceId) {
+        public Builder sourceId(String sourceId) {
             this.sourceId = Objects.requireNonNull(sourceId);
             return this;
         }
 
-        public Builder targetId(UUID targetId) {
+        public Builder targetId(String targetId) {
             this.targetId = Objects.requireNonNull(targetId);
             return this;
         }

--- a/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/elements/LabelElementProps.java
+++ b/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/elements/LabelElementProps.java
@@ -14,7 +14,6 @@ package org.eclipse.sirius.web.diagrams.elements;
 
 import java.text.MessageFormat;
 import java.util.Objects;
-import java.util.UUID;
 
 import org.eclipse.sirius.web.annotations.Immutable;
 import org.eclipse.sirius.web.components.IProps;
@@ -32,7 +31,7 @@ public final class LabelElementProps implements IProps {
 
     public static final String TYPE = "Label"; //$NON-NLS-1$
 
-    private UUID id;
+    private String id;
 
     private String type;
 
@@ -50,7 +49,7 @@ public final class LabelElementProps implements IProps {
         // Prevent instantiation
     }
 
-    public UUID getId() {
+    public String getId() {
         return this.id;
     }
 
@@ -78,7 +77,7 @@ public final class LabelElementProps implements IProps {
         return this.style;
     }
 
-    public static Builder newLabelElementProps(UUID id) {
+    public static Builder newLabelElementProps(String id) {
         return new Builder(id);
     }
 
@@ -95,7 +94,7 @@ public final class LabelElementProps implements IProps {
      */
     @SuppressWarnings("checkstyle:HiddenField")
     public static final class Builder {
-        private UUID id;
+        private String id;
 
         private String type;
 
@@ -109,7 +108,7 @@ public final class LabelElementProps implements IProps {
 
         private LabelStyle style;
 
-        private Builder(UUID id) {
+        private Builder(String id) {
             this.id = Objects.requireNonNull(id);
         }
 

--- a/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/elements/NodeElementProps.java
+++ b/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/elements/NodeElementProps.java
@@ -36,7 +36,7 @@ public final class NodeElementProps implements IProps {
 
     public static final String TYPE = "Node"; //$NON-NLS-1$
 
-    private UUID id;
+    private String id;
 
     private String type;
 
@@ -64,7 +64,7 @@ public final class NodeElementProps implements IProps {
         // Prevent instantiation
     }
 
-    public UUID getId() {
+    public String getId() {
         return this.id;
     }
 
@@ -108,7 +108,7 @@ public final class NodeElementProps implements IProps {
         return this.customizableProperties;
     }
 
-    public static Builder newNodeElementProps(UUID id) {
+    public static Builder newNodeElementProps(String id) {
         return new Builder(id);
     }
 
@@ -130,7 +130,7 @@ public final class NodeElementProps implements IProps {
      */
     @SuppressWarnings("checkstyle:HiddenField")
     public static final class Builder {
-        private UUID id;
+        private String id;
 
         private String type;
 
@@ -154,7 +154,7 @@ public final class NodeElementProps implements IProps {
 
         private List<Element> children;
 
-        private Builder(UUID id) {
+        private Builder(String id) {
             this.id = Objects.requireNonNull(id);
         }
 

--- a/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/events/MoveEvent.java
+++ b/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/events/MoveEvent.java
@@ -13,7 +13,6 @@
 package org.eclipse.sirius.web.diagrams.events;
 
 import java.util.Objects;
-import java.util.UUID;
 
 import org.eclipse.sirius.web.diagrams.Position;
 
@@ -24,16 +23,16 @@ import org.eclipse.sirius.web.diagrams.Position;
  */
 public class MoveEvent implements IDiagramEvent {
 
-    private final UUID nodeId;
+    private final String nodeId;
 
     private final Position newPosition;
 
-    public MoveEvent(UUID nodeId, Position newPosition) {
+    public MoveEvent(String nodeId, Position newPosition) {
         this.nodeId = Objects.requireNonNull(nodeId);
         this.newPosition = Objects.requireNonNull(newPosition);
     }
 
-    public UUID getNodeId() {
+    public String getNodeId() {
         return this.nodeId;
     }
 

--- a/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/events/ResizeEvent.java
+++ b/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/events/ResizeEvent.java
@@ -13,7 +13,6 @@
 package org.eclipse.sirius.web.diagrams.events;
 
 import java.util.Objects;
-import java.util.UUID;
 
 import org.eclipse.sirius.web.diagrams.Position;
 import org.eclipse.sirius.web.diagrams.Size;
@@ -25,19 +24,19 @@ import org.eclipse.sirius.web.diagrams.Size;
  */
 public class ResizeEvent implements IDiagramEvent {
 
-    private final UUID nodeId;
+    private final String nodeId;
 
     private final Position positionDelta;
 
     private final Size newSize;
 
-    public ResizeEvent(UUID nodeId, Position positionDelta, Size newSize) {
+    public ResizeEvent(String nodeId, Position positionDelta, Size newSize) {
         this.nodeId = Objects.requireNonNull(nodeId);
         this.positionDelta = Objects.requireNonNull(positionDelta);
         this.newSize = Objects.requireNonNull(newSize);
     }
 
-    public UUID getNodeId() {
+    public String getNodeId() {
         return this.nodeId;
     }
 

--- a/backend/sirius-web-diagrams/src/test/java/org/eclipse/sirius/web/diagrams/renderer/DiagramRendererNodeTests.java
+++ b/backend/sirius-web-diagrams/src/test/java/org/eclipse/sirius/web/diagrams/renderer/DiagramRendererNodeTests.java
@@ -95,7 +95,7 @@ public class DiagramRendererNodeTests {
         assertThat(diagram.getNodes()).extracting(Node::getBorderNodes).allMatch(List::isEmpty);
         assertThat(diagram.getNodes()).extracting(Node::getStyle).allMatch(s -> s instanceof RectangularNodeStyle);
         assertThat(diagram.getNodes()).extracting(Node::getSize).allMatch(s -> s.getHeight() == -1 && s.getWidth() == -1);
-        assertThat(diagram.getNodes()).extracting(Node::getLabel).extracting(Label::getId).allMatch(id -> UUID.nameUUIDFromBytes(LABEL_ID.getBytes()).equals(id));
+        assertThat(diagram.getNodes()).extracting(Node::getLabel).extracting(Label::getId).allMatch(LABEL_ID::equals);
         assertThat(diagram.getNodes()).extracting(Node::getLabel).extracting(Label::getText).allMatch(text -> LABEL_TEXT.equals(text));
         assertThat(diagram.getNodes()).extracting(Node::getLabel).extracting(Label::getStyle).extracting(LabelStyle::getColor).allMatch(color -> LABEL_COLOR.equals(color));
         assertThat(diagram.getNodes()).extracting(Node::getLabel).extracting(Label::getStyle).extracting(LabelStyle::getFontSize).allMatch(size -> LABEL_FONT_SIZE == size);
@@ -132,7 +132,7 @@ public class DiagramRendererNodeTests {
         assertThat(diagram.getNodes()).extracting(Node::getBorderNodes).allMatch(List::isEmpty);
         assertThat(diagram.getNodes()).extracting(Node::getStyle).allMatch(s -> s instanceof RectangularNodeStyle);
         assertThat(diagram.getNodes()).extracting(Node::getSize).allMatch(s -> s.getHeight() == 200 && s.getWidth() == 10);
-        assertThat(diagram.getNodes()).extracting(Node::getLabel).extracting(Label::getId).allMatch(id -> UUID.nameUUIDFromBytes(LABEL_ID.getBytes()).equals(id));
+        assertThat(diagram.getNodes()).extracting(Node::getLabel).extracting(Label::getId).allMatch(LABEL_ID::equals);
         assertThat(diagram.getNodes()).extracting(Node::getLabel).extracting(Label::getText).allMatch(text -> LABEL_TEXT.equals(text));
         assertThat(diagram.getNodes()).extracting(Node::getLabel).extracting(Label::getStyle).extracting(LabelStyle::getColor).allMatch(color -> LABEL_COLOR.equals(color));
         assertThat(diagram.getNodes()).extracting(Node::getLabel).extracting(Label::getStyle).extracting(LabelStyle::getFontSize).allMatch(size -> LABEL_FONT_SIZE == size);

--- a/backend/sirius-web-diagrams/src/test/java/org/eclipse/sirius/web/diagrams/renderer/UnsynchronizedDiagramTests.java
+++ b/backend/sirius-web-diagrams/src/test/java/org/eclipse/sirius/web/diagrams/renderer/UnsynchronizedDiagramTests.java
@@ -129,7 +129,7 @@ public class UnsynchronizedDiagramTests {
         Diagram refreshedDiagramAfterNodeCreation = this.render(diagramDescription, List.of(viewCreationRequest), List.of(), Optional.of(initialDiagram));
         assertThat(refreshedDiagramAfterNodeCreation.getNodes()).hasSize(2);
 
-        UUID nodeIdToDelete = refreshedDiagramAfterNodeCreation.getNodes().get(0).getId();
+        String nodeIdToDelete = refreshedDiagramAfterNodeCreation.getNodes().get(0).getId();
 
         // @formatter:off
         ViewDeletionRequest viewDeletionRequest = ViewDeletionRequest.newViewDeletionRequest()
@@ -165,7 +165,7 @@ public class UnsynchronizedDiagramTests {
         // @formatter:on
         Diagram diagramAfterFirstNodeCreation = this.render(diagramDescription, List.of(viewCreationRequest), List.of(), Optional.of(initialDiagram));
         UUID descriptionId = diagramDescription.getNodeDescriptions().get(0).getChildNodeDescriptions().get(0).getId();
-        UUID parentNodeId = diagramAfterFirstNodeCreation.getNodes().get(0).getId();
+        String parentNodeId = diagramAfterFirstNodeCreation.getNodes().get(0).getId();
         // @formatter:off
         ViewCreationRequest childViewCreationRequest = ViewCreationRequest.newViewCreationRequest()
             .descriptionId(descriptionId)
@@ -210,7 +210,7 @@ public class UnsynchronizedDiagramTests {
         // @formatter:on
         Diagram diagramAfterFirstNodeCreation = this.render(diagramDescription, List.of(viewCreationRequest), List.of(), Optional.of(initialDiagram));
         UUID descriptionId = diagramDescription.getNodeDescriptions().get(0).getChildNodeDescriptions().get(0).getId();
-        UUID parentNodeId = diagramAfterFirstNodeCreation.getNodes().get(0).getId();
+        String parentNodeId = diagramAfterFirstNodeCreation.getNodes().get(0).getId();
         // @formatter:off
         ViewCreationRequest childViewCreationRequest = ViewCreationRequest.newViewCreationRequest()
             .descriptionId(descriptionId)
@@ -219,7 +219,7 @@ public class UnsynchronizedDiagramTests {
             .build();
         // @formatter:on
         Diagram diagramAfterSecondNodeCreation = this.render(diagramDescription, List.of(childViewCreationRequest), List.of(), Optional.of(diagramAfterFirstNodeCreation));
-        UUID nodeIdToDelete = diagramAfterSecondNodeCreation.getNodes().get(0).getChildNodes().get(0).getId();
+        String nodeIdToDelete = diagramAfterSecondNodeCreation.getNodes().get(0).getChildNodes().get(0).getId();
         // @formatter:off
         ViewDeletionRequest viewDeletionRequest = ViewDeletionRequest.newViewDeletionRequest()
             .elementId(nodeIdToDelete)

--- a/backend/sirius-web-domain-design/pom.xml
+++ b/backend/sirius-web-domain-design/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-domain-design</artifactId>
-	<version>0.5.4</version>
+	<version>0.5.5</version>
 	<name>sirius-web-domain-design</name>
 	<description>Sirius Web Domain Definition DSL - Graphical Modeler Definition</description>
 
@@ -64,7 +64,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-domain</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 	</dependencies>
 	

--- a/backend/sirius-web-domain-edit/pom.xml
+++ b/backend/sirius-web-domain-edit/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-domain-edit</artifactId>
-	<version>0.5.4</version>
+	<version>0.5.5</version>
 	<name>sirius-web-domain-edit</name>
 	<description>Sirius Web Domain Definition DSL - Edit Support</description>
 
@@ -64,7 +64,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-domain</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 	</dependencies>
 	

--- a/backend/sirius-web-domain/pom.xml
+++ b/backend/sirius-web-domain/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-domain</artifactId>
-	<version>0.5.4</version>
+	<version>0.5.5</version>
 	<name>sirius-web-domain</name>
 	<description>Sirius Web Domain Definition DSL</description>
 

--- a/backend/sirius-web-emf/pom.xml
+++ b/backend/sirius-web-emf/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-emf</artifactId>
-	<version>0.5.4</version>
+	<version>0.5.5</version>
 	<name>sirius-web-emf</name>
 	<description>Sirius Web EMF</description>
 
@@ -66,52 +66,52 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-graphql-api</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-collaborative</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-collaborative-diagrams</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-collaborative-forms</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-collaborative-trees</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-collaborative-validation</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-compatibility</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-interpreter</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-domain</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-view</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.emf</groupId>
@@ -160,13 +160,13 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-tests</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/modeloperations/CreateViewOperationHandler.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/modeloperations/CreateViewOperationHandler.java
@@ -69,7 +69,7 @@ public class CreateViewOperationHandler implements IModelOperationHandler {
         String containerViewExpression = this.createView.getContainerViewExpression();
 
         var optionalParentElementId = this.interpreter.evaluateExpression(variables, containerViewExpression).asObject().flatMap(parentElement -> {
-            Optional<UUID> optionalElementId = Optional.empty();
+            Optional<String> optionalElementId = Optional.empty();
             if (parentElement instanceof Diagram) {
                 Diagram diagram = (Diagram) parentElement;
                 optionalElementId = Optional.of(diagram.getId());

--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/modeloperations/DeleteViewOperationHandler.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/compatibility/modeloperations/DeleteViewOperationHandler.java
@@ -17,7 +17,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.UUID;
 
 import org.eclipse.sirius.viewpoint.description.tool.DeleteView;
 import org.eclipse.sirius.viewpoint.description.tool.ModelOperation;
@@ -62,7 +61,7 @@ public class DeleteViewOperationHandler implements IModelOperationHandler {
     public IStatus handle(Map<String, Object> variables) {
         Object self = variables.get(VariableManager.SELF);
         if (self instanceof Node) {
-            UUID elementId = ((Node) self).getId();
+            String elementId = ((Node) self).getId();
             // @formatter:off
             ViewDeletionRequest viewDeletionRequest = ViewDeletionRequest.newViewDeletionRequest()
                     .elementId(elementId)

--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/services/EditService.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/services/EditService.java
@@ -76,7 +76,7 @@ public class EditService implements IEditService {
     }
 
     @Override
-    public Optional<Object> findClass(UUID editingContextId, String classId) {
+    public Optional<Object> findClass(String editingContextId, String classId) {
         EPackage.Registry ePackageRegistry = this.getPackageRegistry(editingContextId);
         return this.getEClass(ePackageRegistry, classId).map(Object.class::cast);
     }
@@ -94,7 +94,7 @@ public class EditService implements IEditService {
         // @formatter:on
     }
 
-    private EPackage.Registry getPackageRegistry(UUID editingContextId) {
+    private EPackage.Registry getPackageRegistry(String editingContextId) {
         EPackageRegistryImpl ePackageRegistry = new EPackageRegistryImpl();
         this.globalEPackageRegistry.forEach(ePackageRegistry::put);
         List<EPackage> additionalEPackages = this.editingContextEPackageService.getEPackages(editingContextId);
@@ -103,7 +103,7 @@ public class EditService implements IEditService {
     }
 
     @Override
-    public List<ChildCreationDescription> getChildCreationDescriptions(UUID editingContextId, String classId) {
+    public List<ChildCreationDescription> getChildCreationDescriptions(String editingContextId, String classId) {
         List<ChildCreationDescription> childCreationDescriptions = new ArrayList<>();
 
         EPackage.Registry ePackageRegistry = this.getPackageRegistry(editingContextId);
@@ -221,7 +221,7 @@ public class EditService implements IEditService {
     }
 
     @Override
-    public List<Domain> getDomains(UUID editingContextId) {
+    public List<Domain> getDomains(String editingContextId) {
         Map<String, EPackage> nsURI2EPackages = new LinkedHashMap<>();
 
         this.globalEPackageRegistry.keySet().forEach(nsURI -> nsURI2EPackages.put(nsURI, this.globalEPackageRegistry.getEPackage(nsURI)));
@@ -238,7 +238,7 @@ public class EditService implements IEditService {
     }
 
     @Override
-    public List<ChildCreationDescription> getRootCreationDescriptions(UUID editingContextId, String domainId, boolean suggested) {
+    public List<ChildCreationDescription> getRootCreationDescriptions(String editingContextId, String domainId, boolean suggested) {
         List<ChildCreationDescription> rootObjectCreationDescription = new ArrayList<>();
 
         EPackage.Registry ePackageRegistry = this.getPackageRegistry(editingContextId);
@@ -307,7 +307,7 @@ public class EditService implements IEditService {
         return createdObjectOptional;
     }
 
-    private Optional<EClass> getMatchingEClass(UUID editingContextId, String domainId, String rootObjectCreationDescriptionId) {
+    private Optional<EClass> getMatchingEClass(String editingContextId, String domainId, String rootObjectCreationDescriptionId) {
         EPackage.Registry ePackageRegistry = this.getPackageRegistry(editingContextId);
 
         // @formatter:off

--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/services/EditingContext.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/services/EditingContext.java
@@ -13,7 +13,6 @@
 package org.eclipse.sirius.web.emf.services;
 
 import java.util.Objects;
-import java.util.UUID;
 
 import org.eclipse.emf.edit.domain.AdapterFactoryEditingDomain;
 import org.eclipse.sirius.web.core.api.IEditingContext;
@@ -25,18 +24,18 @@ import org.eclipse.sirius.web.core.api.IEditingContext;
  */
 public class EditingContext implements IEditingContext {
 
-    private final UUID projectId;
+    private final String id;
 
     private final AdapterFactoryEditingDomain editingDomain;
 
-    public EditingContext(UUID projectId, AdapterFactoryEditingDomain editingDomain) {
-        this.projectId = Objects.requireNonNull(projectId);
+    public EditingContext(String id, AdapterFactoryEditingDomain editingDomain) {
+        this.id = Objects.requireNonNull(id);
         this.editingDomain = Objects.requireNonNull(editingDomain);
     }
 
     @Override
-    public UUID getId() {
-        return this.projectId;
+    public String getId() {
+        return this.id;
     }
 
     public AdapterFactoryEditingDomain getDomain() {

--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/services/IEditingContextEPackageService.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/services/IEditingContextEPackageService.java
@@ -13,7 +13,6 @@
 package org.eclipse.sirius.web.emf.services;
 
 import java.util.List;
-import java.util.UUID;
 
 import org.eclipse.emf.ecore.EPackage;
 
@@ -23,5 +22,5 @@ import org.eclipse.emf.ecore.EPackage;
  * @author sbegaudeau
  */
 public interface IEditingContextEPackageService {
-    List<EPackage> getEPackages(UUID editingContextId);
+    List<EPackage> getEPackages(String editingContextId);
 }

--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/view/ICustomImageSearchService.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/view/ICustomImageSearchService.java
@@ -13,7 +13,6 @@
 package org.eclipse.sirius.web.emf.view;
 
 import java.util.List;
-import java.util.UUID;
 
 /**
  * Service used to find existing custom images.
@@ -21,7 +20,7 @@ import java.util.UUID;
  * @author pcdavid
  */
 public interface ICustomImageSearchService {
-    List<CustomImage> getAvailableImages(UUID editingContextId);
+    List<CustomImage> getAvailableImages(String editingContextId);
 
     /**
      * Implementation which does nothing, used for mocks in unit tests.
@@ -31,7 +30,7 @@ public interface ICustomImageSearchService {
     class NoOp implements ICustomImageSearchService {
 
         @Override
-        public List<CustomImage> getAvailableImages(UUID editingContextId) {
+        public List<CustomImage> getAvailableImages(String editingContextId) {
             return List.of();
         }
 

--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/view/StylesFactory.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/view/StylesFactory.java
@@ -13,7 +13,6 @@
 package org.eclipse.sirius.web.emf.view;
 
 import java.util.Optional;
-import java.util.UUID;
 
 import org.eclipse.sirius.web.diagrams.ArrowStyle;
 import org.eclipse.sirius.web.diagrams.EdgeStyle;
@@ -89,7 +88,7 @@ public final class StylesFactory {
         return type;
     }
 
-    public INodeStyle createNodeStyle(NodeStyle nodeStyle, Optional<UUID> optionalEditingContextId) {
+    public INodeStyle createNodeStyle(NodeStyle nodeStyle, Optional<String> optionalEditingContextId) {
         INodeStyle result = null;
         switch (this.getNodeType(nodeStyle)) {
         case NodeType.NODE_IMAGE:

--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/view/ViewConverter.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/view/ViewConverter.java
@@ -219,7 +219,7 @@ public class ViewConverter {
                     .map(NodeStyle.class::cast)
                     .findFirst()
                     .orElseGet(viewNodeDescription::getStyle);
-            Optional<UUID> optionalEditingContextId = variableManager.get(IEditingContext.EDITING_CONTEXT, IEditingContext.class)
+            Optional<String> optionalEditingContextId = variableManager.get(IEditingContext.EDITING_CONTEXT, IEditingContext.class)
                                                                      .map(IEditingContext::getId);
             // @formatter:on
             return this.stylesFactory.createNodeStyle(effectiveStyle, optionalEditingContextId);

--- a/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/compatibility/operations/CreateInstanceOperationHandlerTests.java
+++ b/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/compatibility/operations/CreateInstanceOperationHandlerTests.java
@@ -76,7 +76,7 @@ public class CreateInstanceOperationHandlerTests {
         resourceSet.setPackageRegistry(ePackageRegistry);
 
         AdapterFactoryEditingDomain editingDomain = new AdapterFactoryEditingDomain(composedAdapterFactory, new BasicCommandStack(), resourceSet);
-        EditingContext editingContext = new EditingContext(UUID.randomUUID(), editingDomain);
+        EditingContext editingContext = new EditingContext(UUID.randomUUID().toString(), editingDomain);
         this.operationTestContext.getVariables().put(IEditingContext.EDITING_CONTEXT, editingContext);
 
         this.createInstanceOperation = ToolFactory.eINSTANCE.createCreateInstance();

--- a/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/compatibility/operations/CreateViewOperationHandlerTests.java
+++ b/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/compatibility/operations/CreateViewOperationHandlerTests.java
@@ -104,7 +104,7 @@ public class CreateViewOperationHandlerTests {
                 .edgeDescriptions(List.of())
                 .build();
 
-        Diagram diagram = Diagram.newDiagram(UUID.randomUUID())
+        Diagram diagram = Diagram.newDiagram(UUID.randomUUID().toString())
                 .descriptionId(diagramDescription.getId())
                 .targetObjectId(UUID.randomUUID().toString())
                 .label("DiagramTest") //$NON-NLS-1$
@@ -124,7 +124,7 @@ public class CreateViewOperationHandlerTests {
         // @formatter:on
 
         AdapterFactoryEditingDomain editingDomain = new AdapterFactoryEditingDomain(composedAdapterFactory, new BasicCommandStack(), resourceSet);
-        EditingContext editingContext = new EditingContext(UUID.randomUUID(), editingDomain);
+        EditingContext editingContext = new EditingContext(UUID.randomUUID().toString(), editingDomain);
         this.operationTestContext.getVariables().put(IEditingContext.EDITING_CONTEXT, editingContext);
         this.operationTestContext.getVariables().put(CONTAINER_VIEW, diagram);
         this.createViewOperation = org.eclipse.sirius.diagram.description.tool.ToolFactory.eINSTANCE.createCreateView();

--- a/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/compatibility/operations/DeleteViewOperationHandlerTests.java
+++ b/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/compatibility/operations/DeleteViewOperationHandlerTests.java
@@ -105,13 +105,13 @@ public class DeleteViewOperationHandlerTests {
                 .edgeDescriptions(List.of())
                 .build();
 
-        Node node = Node.newNode(UUID.randomUUID())
+        Node node = Node.newNode(UUID.randomUUID().toString())
                 .descriptionId(UUID.randomUUID())
                 .type("Node") //$NON-NLS-1$
                 .targetObjectId(UUID.randomUUID().toString())
                 .targetObjectKind("ecore::EPackage") //$NON-NLS-1$
                 .targetObjectLabel(OperationTestContext.ROOT_PACKAGE_NAME)
-                .label(Label.newLabel(UUID.randomUUID())
+                .label(Label.newLabel(UUID.randomUUID().toString())
                         .type("Label") //$NON-NLS-1$
                         .text(OperationTestContext.ROOT_PACKAGE_NAME)
                         .position(Position.at(0, 0))
@@ -126,7 +126,7 @@ public class DeleteViewOperationHandlerTests {
                 .childNodes(List.of())
                 .build();
 
-        Diagram diagram = Diagram.newDiagram(UUID.randomUUID())
+        Diagram diagram = Diagram.newDiagram(UUID.randomUUID().toString())
                 .descriptionId(diagramDescription.getId())
                 .targetObjectId(UUID.randomUUID().toString())
                 .label("DiagramTest") //$NON-NLS-1$
@@ -146,7 +146,7 @@ public class DeleteViewOperationHandlerTests {
         // @formatter:on
 
         AdapterFactoryEditingDomain editingDomain = new AdapterFactoryEditingDomain(composedAdapterFactory, new BasicCommandStack(), resourceSet);
-        EditingContext editingContext = new EditingContext(UUID.randomUUID(), editingDomain);
+        EditingContext editingContext = new EditingContext(UUID.randomUUID().toString(), editingDomain);
         this.operationTestContext.getVariables().put(IEditingContext.EDITING_CONTEXT, editingContext);
         this.operationTestContext.getVariables().put(CONTAINER_VIEW, diagram);
         this.operationTestContext.getVariables().put(VariableManager.SELF, diagram.getNodes().get(0));

--- a/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/query/EMFQueryServiceTests.java
+++ b/backend/sirius-web-emf/src/test/java/org/eclipse/sirius/web/emf/query/EMFQueryServiceTests.java
@@ -57,7 +57,7 @@ public class EMFQueryServiceTests {
 
         IEditingContextEPackageService editingContextEPackageService = new IEditingContextEPackageService() {
             @Override
-            public List<EPackage> getEPackages(UUID editingContextId) {
+            public List<EPackage> getEPackages(String editingContextId) {
                 return List.of(EcorePackage.eINSTANCE);
             }
         };
@@ -76,7 +76,7 @@ public class EMFQueryServiceTests {
         IEditingContextEPackageService editingContextEPackageService = new IEditingContextEPackageService() {
 
             @Override
-            public List<EPackage> getEPackages(UUID editingContextId) {
+            public List<EPackage> getEPackages(String editingContextId) {
                 return List.of(EcorePackage.eINSTANCE);
             }
         };
@@ -94,7 +94,7 @@ public class EMFQueryServiceTests {
 
         IEditingContextEPackageService editingContextEPackageService = new IEditingContextEPackageService() {
             @Override
-            public List<EPackage> getEPackages(UUID editingContextId) {
+            public List<EPackage> getEPackages(String editingContextId) {
                 return List.of(EcorePackage.eINSTANCE);
             }
         };
@@ -129,7 +129,7 @@ public class EMFQueryServiceTests {
         Resource resource = this.createResourceWith4Elements();
         Resource resource2 = this.createResourceWith4Elements();
         AdapterFactoryEditingDomain editingDomain = new EditingDomainFactory().create(resource, resource2);
-        return new EditingContext(UUID.randomUUID(), editingDomain);
+        return new EditingContext(UUID.randomUUID().toString(), editingDomain);
     }
 
     private Resource createResourceWith4Elements() {

--- a/backend/sirius-web-forms-tests/pom.xml
+++ b/backend/sirius-web-forms-tests/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-forms-tests</artifactId>
-	<version>0.5.4</version>
+	<version>0.5.5</version>
 	<name>sirius-web-forms-tests</name>
 	<description>Sirius Web Forms Tests</description>
 
@@ -42,7 +42,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-forms</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.assertj</groupId>

--- a/backend/sirius-web-forms/pom.xml
+++ b/backend/sirius-web-forms/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-forms</artifactId>
-	<version>0.5.4</version>
+	<version>0.5.5</version>
 	<name>sirius-web-forms</name>
 	<description>Sirius Web Forms</description>
 
@@ -46,17 +46,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-annotations</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-components</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-representations</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -66,7 +66,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/Form.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/Form.java
@@ -37,7 +37,7 @@ public final class Form implements IRepresentation, ISemanticRepresentation {
 
     public static final String KIND = "Form"; //$NON-NLS-1$
 
-    private UUID id;
+    private String id;
 
     private String kind;
 
@@ -57,7 +57,7 @@ public final class Form implements IRepresentation, ISemanticRepresentation {
     @GraphQLID
     @GraphQLField
     @GraphQLNonNull
-    public UUID getId() {
+    public String getId() {
         return this.id;
     }
 
@@ -97,7 +97,7 @@ public final class Form implements IRepresentation, ISemanticRepresentation {
         return this.pages;
     }
 
-    public static Builder newForm(UUID id) {
+    public static Builder newForm(String id) {
         return new Builder(id);
     }
 
@@ -114,7 +114,7 @@ public final class Form implements IRepresentation, ISemanticRepresentation {
      */
     @SuppressWarnings("checkstyle:HiddenField")
     public static final class Builder {
-        private UUID id;
+        private String id;
 
         private String kind = KIND;
 
@@ -126,7 +126,7 @@ public final class Form implements IRepresentation, ISemanticRepresentation {
 
         private List<Page> pages;
 
-        private Builder(UUID id) {
+        private Builder(String id) {
             this.id = Objects.requireNonNull(id);
         }
 

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/components/FormComponent.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/components/FormComponent.java
@@ -13,7 +13,6 @@
 package org.eclipse.sirius.web.forms.components;
 
 import java.util.List;
-import java.util.UUID;
 import java.util.stream.Collectors;
 
 import org.eclipse.sirius.web.components.Element;
@@ -41,7 +40,7 @@ public class FormComponent implements IComponent {
         VariableManager variableManager = this.props.getVariableManager();
         FormDescription formDescription = this.props.getFormDescription();
 
-        UUID id = formDescription.getIdProvider().apply(variableManager);
+        String id = formDescription.getIdProvider().apply(variableManager);
         String label = formDescription.getLabelProvider().apply(variableManager);
         String targetObjectId = formDescription.getTargetObjectIdProvider().apply(variableManager);
         List<PageDescription> pageDescriptions = formDescription.getPageDescriptions();

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/description/FormDescription.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/description/FormDescription.java
@@ -42,7 +42,7 @@ public final class FormDescription implements IRepresentationDescription {
 
     private String label;
 
-    private Function<VariableManager, UUID> idProvider;
+    private Function<VariableManager, String> idProvider;
 
     private Function<VariableManager, String> labelProvider;
 
@@ -73,7 +73,7 @@ public final class FormDescription implements IRepresentationDescription {
         return this.label;
     }
 
-    public Function<VariableManager, UUID> getIdProvider() {
+    public Function<VariableManager, String> getIdProvider() {
         return this.idProvider;
     }
 
@@ -119,7 +119,7 @@ public final class FormDescription implements IRepresentationDescription {
 
         private String label;
 
-        private Function<VariableManager, UUID> idProvider;
+        private Function<VariableManager, String> idProvider;
 
         private Function<VariableManager, String> labelProvider;
 
@@ -140,7 +140,7 @@ public final class FormDescription implements IRepresentationDescription {
             return this;
         }
 
-        public Builder idProvider(Function<VariableManager, UUID> idProvider) {
+        public Builder idProvider(Function<VariableManager, String> idProvider) {
             this.idProvider = Objects.requireNonNull(idProvider);
             return this;
         }

--- a/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/elements/FormElementProps.java
+++ b/backend/sirius-web-forms/src/main/java/org/eclipse/sirius/web/forms/elements/FormElementProps.java
@@ -30,7 +30,7 @@ import org.eclipse.sirius.web.components.IProps;
 public final class FormElementProps implements IProps {
     public static final String TYPE = "Form"; //$NON-NLS-1$
 
-    private UUID id;
+    private String id;
 
     private String label;
 
@@ -44,7 +44,7 @@ public final class FormElementProps implements IProps {
         // Prevent instantiation
     }
 
-    public UUID getId() {
+    public String getId() {
         return this.id;
     }
 
@@ -65,7 +65,7 @@ public final class FormElementProps implements IProps {
         return this.children;
     }
 
-    public static Builder newFormElementProps(UUID id) {
+    public static Builder newFormElementProps(String id) {
         return new Builder(id);
     }
 
@@ -82,7 +82,7 @@ public final class FormElementProps implements IProps {
      */
     @SuppressWarnings("checkstyle:HiddenField")
     public static final class Builder {
-        private UUID id;
+        private String id;
 
         private String label;
 
@@ -92,7 +92,7 @@ public final class FormElementProps implements IProps {
 
         private List<Element> children;
 
-        private Builder(UUID id) {
+        private Builder(String id) {
             this.id = Objects.requireNonNull(id);
         }
 

--- a/backend/sirius-web-graphiql/pom.xml
+++ b/backend/sirius-web-graphiql/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-graphiql</artifactId>
-	<version>0.5.4</version>
+	<version>0.5.5</version>
 	<name>sirius-web-graphiql</name>
 	<description>Sirius Web Graphiql support. This project contribute a GraphQL query tool on the /graphiql/index.html URI.</description>
 

--- a/backend/sirius-web-graphql-utils/pom.xml
+++ b/backend/sirius-web-graphql-utils/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-graphql-utils</artifactId>
-	<version>0.5.4</version>
+	<version>0.5.5</version>
 	<name>sirius-web-graphql-utils</name>
 	<description>Sirius Web GraphQL Utils</description>
 
@@ -43,7 +43,7 @@
 		<dependency>
         	<groupId>org.eclipse.sirius.web</groupId>
         	<artifactId>sirius-web-annotations</artifactId>
-        	<version>0.5.4</version>
+        	<version>0.5.5</version>
     	</dependency>
 		<dependency>
         	<groupId>com.graphql-java</groupId>
@@ -53,7 +53,7 @@
     	<dependency>
    			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 			<scope>test</scope>
     	</dependency>
     	<dependency>

--- a/backend/sirius-web-graphql-voyager/pom.xml
+++ b/backend/sirius-web-graphql-voyager/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-graphql-voyager</artifactId>
-	<version>0.5.4</version>
+	<version>0.5.5</version>
 	<name>sirius-web-graphql-voyager</name>
 	<description>Sirius Web Graph Voyager. This project contribute a GraphQL API UX thanks to the https://github.com/APIs-guru/graphql-voyager project.</description>
 

--- a/backend/sirius-web-interpreter/pom.xml
+++ b/backend/sirius-web-interpreter/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-interpreter</artifactId>
-	<version>0.5.4</version>
+	<version>0.5.5</version>
 	<name>sirius-web-interpreter</name>
 	<description>Sirius Web Intepreter</description>
 

--- a/backend/sirius-web-representations/pom.xml
+++ b/backend/sirius-web-representations/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-representations</artifactId>
-	<version>0.5.4</version>
+	<version>0.5.5</version>
 	<name>sirius-web-representations</name>
 	<description>Sirius Web Representations</description>
 
@@ -42,7 +42,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-annotations</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 	</dependencies>
 

--- a/backend/sirius-web-representations/src/main/java/org/eclipse/sirius/web/representations/GetOrCreateRandomIdProvider.java
+++ b/backend/sirius-web-representations/src/main/java/org/eclipse/sirius/web/representations/GetOrCreateRandomIdProvider.java
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.sirius.web.representations;
 
-import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Function;
 
@@ -22,17 +21,15 @@ import java.util.function.Function;
  *
  * @author sbegaudeau
  */
-public class GetOrCreateRandomIdProvider implements Function<VariableManager, UUID> {
+public class GetOrCreateRandomIdProvider implements Function<VariableManager, String> {
 
     public static final String PREVIOUS_REPRESENTATION_ID = "previousRepresentationId"; //$NON-NLS-1$
 
     @Override
-    public UUID apply(VariableManager variableManager) {
+    public String apply(VariableManager variableManager) {
         // @formatter:off
-        return Optional.ofNullable(variableManager.getVariables().get(PREVIOUS_REPRESENTATION_ID))
-                .filter(UUID.class::isInstance)
-                .map(UUID.class::cast)
-                .orElseGet(UUID::randomUUID);
+        return variableManager.get(PREVIOUS_REPRESENTATION_ID, String.class)
+        .orElseGet(() -> UUID.randomUUID().toString());
         // @formatter:on
     }
 

--- a/backend/sirius-web-representations/src/main/java/org/eclipse/sirius/web/representations/IRepresentation.java
+++ b/backend/sirius-web-representations/src/main/java/org/eclipse/sirius/web/representations/IRepresentation.java
@@ -23,7 +23,7 @@ import org.eclipse.sirius.web.annotations.graphql.GraphQLInterfaceType;
  */
 @GraphQLInterfaceType(name = "Representation")
 public interface IRepresentation {
-    UUID getId();
+    String getId();
 
     UUID getDescriptionId();
 

--- a/backend/sirius-web-selection/pom.xml
+++ b/backend/sirius-web-selection/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-selection</artifactId>
-	<version>0.5.4</version>
+	<version>0.5.5</version>
 	<name>sirius-web-selection</name>
 	<description>Sirius Web Selection</description>
 
@@ -42,17 +42,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-annotations</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-representations</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend/sirius-web-selection/src/main/java/org/eclipse/sirius/web/selection/Selection.java
+++ b/backend/sirius-web-selection/src/main/java/org/eclipse/sirius/web/selection/Selection.java
@@ -36,7 +36,7 @@ public final class Selection implements IRepresentation, ISemanticRepresentation
 
     public static final String KIND = "Selection"; //$NON-NLS-1$
 
-    private UUID id;
+    private String id;
 
     private String kind;
 
@@ -58,7 +58,7 @@ public final class Selection implements IRepresentation, ISemanticRepresentation
     @GraphQLID
     @GraphQLField
     @GraphQLNonNull
-    public UUID getId() {
+    public String getId() {
         return this.id;
     }
 
@@ -102,7 +102,7 @@ public final class Selection implements IRepresentation, ISemanticRepresentation
         return this.objects;
     }
 
-    public static Builder newSelection(UUID id) {
+    public static Builder newSelection(String id) {
         return new Builder(id);
     }
 
@@ -119,7 +119,7 @@ public final class Selection implements IRepresentation, ISemanticRepresentation
      */
     @SuppressWarnings("checkstyle:HiddenField")
     public static final class Builder {
-        private UUID id;
+        private String id;
 
         private String kind = KIND;
 
@@ -133,7 +133,7 @@ public final class Selection implements IRepresentation, ISemanticRepresentation
 
         private List<SelectionObject> objects;
 
-        private Builder(UUID id) {
+        private Builder(String id) {
             this.id = Objects.requireNonNull(id);
         }
 

--- a/backend/sirius-web-selection/src/main/java/org/eclipse/sirius/web/selection/description/SelectionDescription.java
+++ b/backend/sirius-web-selection/src/main/java/org/eclipse/sirius/web/selection/description/SelectionDescription.java
@@ -40,7 +40,7 @@ public final class SelectionDescription implements IRepresentationDescription {
 
     private String label;
 
-    private Function<VariableManager, UUID> idProvider;
+    private Function<VariableManager, String> idProvider;
 
     private Function<VariableManager, String> labelProvider;
 
@@ -75,7 +75,7 @@ public final class SelectionDescription implements IRepresentationDescription {
         return this.label;
     }
 
-    public Function<VariableManager, UUID> getIdProvider() {
+    public Function<VariableManager, String> getIdProvider() {
         return this.idProvider;
     }
 
@@ -129,7 +129,7 @@ public final class SelectionDescription implements IRepresentationDescription {
 
         private String label;
 
-        private Function<VariableManager, UUID> idProvider;
+        private Function<VariableManager, String> idProvider;
 
         private Function<VariableManager, String> labelProvider;
 
@@ -154,7 +154,7 @@ public final class SelectionDescription implements IRepresentationDescription {
             return this;
         }
 
-        public Builder idProvider(Function<VariableManager, UUID> idProvider) {
+        public Builder idProvider(Function<VariableManager, String> idProvider) {
             this.idProvider = Objects.requireNonNull(idProvider);
             return this;
         }

--- a/backend/sirius-web-selection/src/main/java/org/eclipse/sirius/web/selection/renderer/SelectionRenderer.java
+++ b/backend/sirius-web-selection/src/main/java/org/eclipse/sirius/web/selection/renderer/SelectionRenderer.java
@@ -39,7 +39,7 @@ public class SelectionRenderer {
     }
 
     public Selection render() {
-        UUID id = this.selectionDescription.getIdProvider().apply(this.variableManager);
+        String id = this.selectionDescription.getIdProvider().apply(this.variableManager);
         String label = this.selectionDescription.getLabelProvider().apply(this.variableManager);
         String message = this.selectionDescription.getMessageProvider().apply(this.variableManager);
         String targetObjectId = this.selectionDescription.getTargetObjectIdProvider().apply(this.variableManager);

--- a/backend/sirius-web-spring-collaborative-diagrams/pom.xml
+++ b/backend/sirius-web-spring-collaborative-diagrams/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-spring-collaborative-diagrams</artifactId>
-	<version>0.5.4</version>
+	<version>0.5.5</version>
 	<name>sirius-web-spring-collaborative-diagrams</name>
 	<description>Sirius Web Spring Collaborative Diagrams</description>
 
@@ -50,39 +50,39 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-api</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-diagrams</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-collaborative</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-diagrams-layout</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 		<dependency>
     		<groupId>org.eclipse.sirius.web</groupId>
     		<artifactId>sirius-web-tests</artifactId>
-    		<version>0.5.4</version>
+    		<version>0.5.5</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius.web</groupId>
     		<artifactId>sirius-web-spring-tests</artifactId>
-    		<version>0.5.4</version>
+    		<version>0.5.5</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-diagrams-tests</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/DiagramQueryService.java
+++ b/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/DiagramQueryService.java
@@ -33,7 +33,7 @@ import org.springframework.stereotype.Service;
 public class DiagramQueryService implements IDiagramQueryService {
 
     @Override
-    public Optional<Node> findNodeById(Diagram diagram, UUID nodeId) {
+    public Optional<Node> findNodeById(Diagram diagram, String nodeId) {
         return this.findNode(node -> Objects.equals(node.getId(), nodeId), diagram.getNodes());
     }
 
@@ -58,7 +58,7 @@ public class DiagramQueryService implements IDiagramQueryService {
     }
 
     @Override
-    public Optional<Edge> findEdgeById(Diagram diagram, UUID edgeId) {
+    public Optional<Edge> findEdgeById(Diagram diagram, String edgeId) {
         return diagram.getEdges().stream().filter(edge -> Objects.equals(edgeId, edge.getId())).findFirst();
     }
 

--- a/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/api/DiagramConfiguration.java
+++ b/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/api/DiagramConfiguration.java
@@ -13,7 +13,6 @@
 package org.eclipse.sirius.web.spring.collaborative.diagrams.api;
 
 import java.util.Objects;
-import java.util.UUID;
 
 import org.eclipse.sirius.web.spring.collaborative.api.IRepresentationConfiguration;
 
@@ -24,14 +23,14 @@ import org.eclipse.sirius.web.spring.collaborative.api.IRepresentationConfigurat
  */
 public class DiagramConfiguration implements IRepresentationConfiguration {
 
-    private final UUID diagramId;
+    private final String diagramId;
 
-    public DiagramConfiguration(UUID diagramId) {
+    public DiagramConfiguration(String diagramId) {
         this.diagramId = Objects.requireNonNull(diagramId);
     }
 
     @Override
-    public UUID getId() {
+    public String getId() {
         return this.diagramId;
     }
 

--- a/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/api/IDiagramQueryService.java
+++ b/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/api/IDiagramQueryService.java
@@ -26,11 +26,11 @@ import org.eclipse.sirius.web.diagrams.Node;
  */
 public interface IDiagramQueryService {
 
-    Optional<Node> findNodeById(Diagram diagram, UUID nodeId);
+    Optional<Node> findNodeById(Diagram diagram, String nodeId);
 
     Optional<Node> findNodeByLabelId(Diagram diagram, UUID labelId);
 
-    Optional<Edge> findEdgeById(Diagram diagram, UUID edgeId);
+    Optional<Edge> findEdgeById(Diagram diagram, String edgeId);
 
     Optional<Edge> findEdgeByLabelId(Diagram diagram, UUID labelId);
 

--- a/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/dto/ArrangeAllInput.java
+++ b/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/dto/ArrangeAllInput.java
@@ -31,9 +31,9 @@ public final class ArrangeAllInput implements IDiagramInput {
 
     private UUID id;
 
-    private UUID editingContextId;
+    private String editingContextId;
 
-    private UUID representationId;
+    private String representationId;
 
     @Override
     @GraphQLID
@@ -47,14 +47,14 @@ public final class ArrangeAllInput implements IDiagramInput {
     @GraphQLID
     @GraphQLField
     @GraphQLNonNull
-    public UUID getRepresentationId() {
+    public String getRepresentationId() {
         return this.representationId;
     }
 
     @GraphQLID
     @GraphQLField
     @GraphQLNonNull
-    public UUID getEditingContextId() {
+    public String getEditingContextId() {
         return this.editingContextId;
     }
 

--- a/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/dto/DeleteFromDiagramInput.java
+++ b/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/dto/DeleteFromDiagramInput.java
@@ -32,13 +32,13 @@ import org.eclipse.sirius.web.spring.collaborative.diagrams.api.IDiagramInput;
 public final class DeleteFromDiagramInput implements IDiagramInput {
     private UUID id;
 
-    private UUID editingContextId;
+    private String editingContextId;
 
-    private UUID representationId;
+    private String representationId;
 
-    private List<UUID> nodeIds;
+    private List<String> nodeIds;
 
-    private List<UUID> edgeIds;
+    private List<String> edgeIds;
 
     @Override
     @GraphQLID
@@ -51,7 +51,7 @@ public final class DeleteFromDiagramInput implements IDiagramInput {
     @GraphQLID
     @GraphQLField
     @GraphQLNonNull
-    public UUID getEditingContextId() {
+    public String getEditingContextId() {
         return this.editingContextId;
     }
 
@@ -59,19 +59,19 @@ public final class DeleteFromDiagramInput implements IDiagramInput {
     @GraphQLID
     @GraphQLField
     @GraphQLNonNull
-    public UUID getRepresentationId() {
+    public String getRepresentationId() {
         return this.representationId;
     }
 
     @GraphQLField
     @GraphQLNonNull
-    public List<@GraphQLNonNull @GraphQLID UUID> getNodeIds() {
+    public List<@GraphQLNonNull @GraphQLID String> getNodeIds() {
         return this.nodeIds;
     }
 
     @GraphQLField
     @GraphQLNonNull
-    public List<@GraphQLNonNull @GraphQLID UUID> getEdgeIds() {
+    public List<@GraphQLNonNull @GraphQLID String> getEdgeIds() {
         return this.edgeIds;
     }
 

--- a/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/dto/DiagramEventInput.java
+++ b/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/dto/DiagramEventInput.java
@@ -31,15 +31,15 @@ import org.eclipse.sirius.web.core.api.IInput;
 public final class DiagramEventInput implements IInput {
     private UUID id;
 
-    private UUID editingContextId;
+    private String editingContextId;
 
-    private UUID diagramId;
+    private String diagramId;
 
     public DiagramEventInput() {
         // Used by Jackson
     }
 
-    public DiagramEventInput(UUID id, UUID editingContextId, UUID diagramId) {
+    public DiagramEventInput(UUID id, String editingContextId, String diagramId) {
         this.id = Objects.requireNonNull(id);
         this.editingContextId = Objects.requireNonNull(editingContextId);
         this.diagramId = Objects.requireNonNull(diagramId);
@@ -56,14 +56,14 @@ public final class DiagramEventInput implements IInput {
     @GraphQLID
     @GraphQLField
     @GraphQLNonNull
-    public UUID getEditingContextId() {
+    public String getEditingContextId() {
         return this.editingContextId;
     }
 
     @GraphQLID
     @GraphQLField
     @GraphQLNonNull
-    public UUID getDiagramId() {
+    public String getDiagramId() {
         return this.diagramId;
     }
 

--- a/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/dto/EditLabelInput.java
+++ b/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/dto/EditLabelInput.java
@@ -30,9 +30,9 @@ import org.eclipse.sirius.web.spring.collaborative.diagrams.api.IDiagramInput;
 public final class EditLabelInput implements IDiagramInput {
     private UUID id;
 
-    private UUID editingContextId;
+    private String editingContextId;
 
-    private UUID representationId;
+    private String representationId;
 
     private String labelId;
 
@@ -49,7 +49,7 @@ public final class EditLabelInput implements IDiagramInput {
     @GraphQLID
     @GraphQLField
     @GraphQLNonNull
-    public UUID getEditingContextId() {
+    public String getEditingContextId() {
         return this.editingContextId;
     }
 
@@ -57,7 +57,7 @@ public final class EditLabelInput implements IDiagramInput {
     @GraphQLID
     @GraphQLField
     @GraphQLNonNull
-    public UUID getRepresentationId() {
+    public String getRepresentationId() {
         return this.representationId;
     }
 

--- a/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/dto/InvokeDeleteToolOnDiagramInput.java
+++ b/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/dto/InvokeDeleteToolOnDiagramInput.java
@@ -30,11 +30,11 @@ import org.eclipse.sirius.web.spring.collaborative.diagrams.api.IDiagramInput;
 public final class InvokeDeleteToolOnDiagramInput implements IDiagramInput {
     private UUID id;
 
-    private UUID editingContextId;
+    private String editingContextId;
 
-    private UUID representationId;
+    private String representationId;
 
-    private UUID diagramElementId;
+    private String diagramElementId;
 
     private String toolId;
 
@@ -49,7 +49,7 @@ public final class InvokeDeleteToolOnDiagramInput implements IDiagramInput {
     @GraphQLID
     @GraphQLField
     @GraphQLNonNull
-    public UUID getEditingContextId() {
+    public String getEditingContextId() {
         return this.editingContextId;
     }
 
@@ -57,14 +57,14 @@ public final class InvokeDeleteToolOnDiagramInput implements IDiagramInput {
     @GraphQLID
     @GraphQLField
     @GraphQLNonNull
-    public UUID getRepresentationId() {
+    public String getRepresentationId() {
         return this.representationId;
     }
 
     @GraphQLID
     @GraphQLField
     @GraphQLNonNull
-    public UUID getDiagramElementId() {
+    public String getDiagramElementId() {
         return this.diagramElementId;
     }
 

--- a/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/dto/InvokeEdgeToolOnDiagramInput.java
+++ b/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/dto/InvokeEdgeToolOnDiagramInput.java
@@ -31,13 +31,13 @@ import org.eclipse.sirius.web.spring.collaborative.diagrams.api.IDiagramInput;
 public final class InvokeEdgeToolOnDiagramInput implements IDiagramInput {
     private UUID id;
 
-    private UUID editingContextId;
+    private String editingContextId;
 
-    private UUID representationId;
+    private String representationId;
 
-    private UUID diagramSourceElementId;
+    private String diagramSourceElementId;
 
-    private UUID diagramTargetElementId;
+    private String diagramTargetElementId;
 
     private String toolId;
 
@@ -52,7 +52,7 @@ public final class InvokeEdgeToolOnDiagramInput implements IDiagramInput {
     @GraphQLID
     @GraphQLField
     @GraphQLNonNull
-    public UUID getEditingContextId() {
+    public String getEditingContextId() {
         return this.editingContextId;
     }
 
@@ -60,21 +60,21 @@ public final class InvokeEdgeToolOnDiagramInput implements IDiagramInput {
     @GraphQLID
     @GraphQLField
     @GraphQLNonNull
-    public UUID getRepresentationId() {
+    public String getRepresentationId() {
         return this.representationId;
     }
 
     @GraphQLID
     @GraphQLField
     @GraphQLNonNull
-    public UUID getDiagramSourceElementId() {
+    public String getDiagramSourceElementId() {
         return this.diagramSourceElementId;
     }
 
     @GraphQLID
     @GraphQLField
     @GraphQLNonNull
-    public UUID getDiagramTargetElementId() {
+    public String getDiagramTargetElementId() {
         return this.diagramTargetElementId;
     }
 

--- a/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/dto/InvokeNodeToolOnDiagramInput.java
+++ b/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/dto/InvokeNodeToolOnDiagramInput.java
@@ -30,11 +30,11 @@ import org.eclipse.sirius.web.spring.collaborative.diagrams.api.IDiagramInput;
 public final class InvokeNodeToolOnDiagramInput implements IDiagramInput {
     private UUID id;
 
-    private UUID editingContextId;
+    private String editingContextId;
 
-    private UUID representationId;
+    private String representationId;
 
-    private UUID diagramElementId;
+    private String diagramElementId;
 
     private String toolId;
 
@@ -55,7 +55,7 @@ public final class InvokeNodeToolOnDiagramInput implements IDiagramInput {
     @GraphQLID
     @GraphQLField
     @GraphQLNonNull
-    public UUID getEditingContextId() {
+    public String getEditingContextId() {
         return this.editingContextId;
     }
 
@@ -63,14 +63,13 @@ public final class InvokeNodeToolOnDiagramInput implements IDiagramInput {
     @GraphQLID
     @GraphQLField
     @GraphQLNonNull
-    public UUID getRepresentationId() {
+    public String getRepresentationId() {
         return this.representationId;
     }
 
     @GraphQLID
     @GraphQLField
-    @GraphQLNonNull
-    public UUID getDiagramElementId() {
+    public String getDiagramElementId() {
         return this.diagramElementId;
     }
 

--- a/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/dto/RenameDiagramInput.java
+++ b/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/dto/RenameDiagramInput.java
@@ -32,9 +32,9 @@ public final class RenameDiagramInput implements IDiagramInput {
 
     private UUID id;
 
-    private UUID editingContextId;
+    private String editingContextId;
 
-    private UUID diagramId;
+    private String diagramId;
 
     private String newLabel;
 
@@ -42,7 +42,7 @@ public final class RenameDiagramInput implements IDiagramInput {
         // Used by Jackson
     }
 
-    public RenameDiagramInput(UUID id, UUID editingContextId, UUID diagramId, String newLabel) {
+    public RenameDiagramInput(UUID id, String editingContextId, String diagramId, String newLabel) {
         this.id = Objects.requireNonNull(id);
         this.editingContextId = Objects.requireNonNull(editingContextId);
         this.diagramId = Objects.requireNonNull(diagramId);
@@ -60,7 +60,7 @@ public final class RenameDiagramInput implements IDiagramInput {
     @GraphQLID
     @GraphQLField
     @GraphQLNonNull
-    public UUID getEditingContextId() {
+    public String getEditingContextId() {
         return this.editingContextId;
     }
 
@@ -68,7 +68,7 @@ public final class RenameDiagramInput implements IDiagramInput {
     @GraphQLID
     @GraphQLField
     @GraphQLNonNull
-    public UUID getRepresentationId() {
+    public String getRepresentationId() {
         return this.diagramId;
     }
 

--- a/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/dto/UpdateNodeBoundsInput.java
+++ b/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/dto/UpdateNodeBoundsInput.java
@@ -31,11 +31,11 @@ public final class UpdateNodeBoundsInput implements IDiagramInput {
 
     private UUID id;
 
-    private UUID editingContextId;
+    private String editingContextId;
 
-    private UUID representationId;
+    private String representationId;
 
-    private UUID diagramElementId;
+    private String diagramElementId;
 
     private double newPositionX;
 
@@ -56,7 +56,7 @@ public final class UpdateNodeBoundsInput implements IDiagramInput {
     @GraphQLID
     @GraphQLField
     @GraphQLNonNull
-    public UUID getEditingContextId() {
+    public String getEditingContextId() {
         return this.editingContextId;
     }
 
@@ -64,14 +64,14 @@ public final class UpdateNodeBoundsInput implements IDiagramInput {
     @GraphQLID
     @GraphQLField
     @GraphQLNonNull
-    public UUID getRepresentationId() {
+    public String getRepresentationId() {
         return this.representationId;
     }
 
     @GraphQLID
     @GraphQLField
     @GraphQLNonNull
-    public UUID getDiagramElementId() {
+    public String getDiagramElementId() {
         return this.diagramElementId;
     }
 

--- a/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/dto/UpdateNodePositionInput.java
+++ b/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/dto/UpdateNodePositionInput.java
@@ -30,11 +30,11 @@ import org.eclipse.sirius.web.spring.collaborative.diagrams.api.IDiagramInput;
 public final class UpdateNodePositionInput implements IDiagramInput {
     private UUID id;
 
-    private UUID editingContextId;
+    private String editingContextId;
 
-    private UUID representationId;
+    private String representationId;
 
-    private UUID diagramElementId;
+    private String diagramElementId;
 
     private double newPositionX;
 
@@ -51,7 +51,7 @@ public final class UpdateNodePositionInput implements IDiagramInput {
     @GraphQLID
     @GraphQLField
     @GraphQLNonNull
-    public UUID getEditingContextId() {
+    public String getEditingContextId() {
         return this.editingContextId;
     }
 
@@ -59,14 +59,14 @@ public final class UpdateNodePositionInput implements IDiagramInput {
     @GraphQLID
     @GraphQLField
     @GraphQLNonNull
-    public UUID getRepresentationId() {
+    public String getRepresentationId() {
         return this.representationId;
     }
 
     @GraphQLID
     @GraphQLField
     @GraphQLNonNull
-    public UUID getDiagramElementId() {
+    public String getDiagramElementId() {
         return this.diagramElementId;
     }
 

--- a/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/handlers/DeleteFromDiagramEventHandler.java
+++ b/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/handlers/DeleteFromDiagramEventHandler.java
@@ -16,7 +16,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.UUID;
 
 import org.eclipse.sirius.web.core.api.ErrorPayload;
 import org.eclipse.sirius.web.core.api.IEditingContext;
@@ -113,7 +112,7 @@ public class DeleteFromDiagramEventHandler implements IDiagramEventHandler {
         List<String> errors = new ArrayList<>();
         boolean atLeastOneOk = false;
         Diagram diagram = diagramContext.getDiagram();
-        for (UUID edgeId : diagramInput.getEdgeIds()) {
+        for (String edgeId : diagramInput.getEdgeIds()) {
             var optionalElement = this.diagramQueryService.findEdgeById(diagram, edgeId);
             if (optionalElement.isPresent()) {
                 IStatus status = this.invokeDeleteEdgeTool(optionalElement.get(), editingContext, diagramContext);
@@ -125,7 +124,7 @@ public class DeleteFromDiagramEventHandler implements IDiagramEventHandler {
                 errors.add(message);
             }
         }
-        for (UUID nodeId : diagramInput.getNodeIds()) {
+        for (String nodeId : diagramInput.getNodeIds()) {
             var optionalElement = this.diagramQueryService.findNodeById(diagram, nodeId);
             if (optionalElement.isPresent()) {
                 IStatus status = this.invokeDeleteNodeTool(optionalElement.get(), editingContext, diagramContext);

--- a/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/handlers/InvokeDeleteToolOnDiagramEventHandler.java
+++ b/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/handlers/InvokeDeleteToolOnDiagramEventHandler.java
@@ -14,7 +14,6 @@ package org.eclipse.sirius.web.spring.collaborative.diagrams.handlers;
 
 import java.util.Objects;
 import java.util.Optional;
-import java.util.UUID;
 
 import org.eclipse.sirius.web.core.api.ErrorPayload;
 import org.eclipse.sirius.web.core.api.IEditingContext;
@@ -64,8 +63,8 @@ public class InvokeDeleteToolOnDiagramEventHandler implements IDiagramEventHandl
 
     private final Counter counter;
 
-    public InvokeDeleteToolOnDiagramEventHandler(IObjectService objectService, IDiagramQueryService diagramQueryService, IToolService toolService,
-            ICollaborativeDiagramMessageService messageService, MeterRegistry meterRegistry) {
+    public InvokeDeleteToolOnDiagramEventHandler(IObjectService objectService, IDiagramQueryService diagramQueryService, IToolService toolService, ICollaborativeDiagramMessageService messageService,
+            MeterRegistry meterRegistry) {
         this.objectService = Objects.requireNonNull(objectService);
         this.diagramQueryService = Objects.requireNonNull(diagramQueryService);
         this.toolService = Objects.requireNonNull(toolService);
@@ -113,7 +112,7 @@ public class InvokeDeleteToolOnDiagramEventHandler implements IDiagramEventHandl
         changeDescriptionSink.tryEmitNext(changeDescription);
     }
 
-    private IStatus executeTool(IEditingContext editingContext, IDiagramContext diagramContext, UUID diagramElementId, DeleteTool tool) {
+    private IStatus executeTool(IEditingContext editingContext, IDiagramContext diagramContext, String diagramElementId, DeleteTool tool) {
         IStatus result = new Failure(""); //$NON-NLS-1$
         Diagram diagram = diagramContext.getDiagram();
         Optional<Node> node = this.diagramQueryService.findNodeById(diagram, diagramElementId);

--- a/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/handlers/InvokeEdgeToolOnDiagramEventHandler.java
+++ b/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/handlers/InvokeEdgeToolOnDiagramEventHandler.java
@@ -14,7 +14,6 @@ package org.eclipse.sirius.web.spring.collaborative.diagrams.handlers;
 
 import java.util.Objects;
 import java.util.Optional;
-import java.util.UUID;
 
 import org.eclipse.sirius.web.core.api.ErrorPayload;
 import org.eclipse.sirius.web.core.api.IEditingContext;
@@ -113,7 +112,7 @@ public class InvokeEdgeToolOnDiagramEventHandler implements IDiagramEventHandler
         changeDescriptionSink.tryEmitNext(changeDescription);
     }
 
-    private IStatus executeTool(IEditingContext editingContext, IDiagramContext diagramContext, UUID sourceNodeId, UUID targetNodeId, CreateEdgeTool tool) {
+    private IStatus executeTool(IEditingContext editingContext, IDiagramContext diagramContext, String sourceNodeId, String targetNodeId, CreateEdgeTool tool) {
         IStatus result = new Failure(""); //$NON-NLS-1$
         Diagram diagram = diagramContext.getDiagram();
         Optional<Node> sourceNode = this.diagramQueryService.findNodeById(diagram, sourceNodeId);

--- a/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/handlers/RenameDiagramEventHandler.java
+++ b/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/handlers/RenameDiagramEventHandler.java
@@ -14,7 +14,6 @@ package org.eclipse.sirius.web.spring.collaborative.diagrams.handlers;
 
 import java.util.Objects;
 import java.util.Optional;
-import java.util.UUID;
 
 import org.eclipse.sirius.web.core.api.ErrorPayload;
 import org.eclipse.sirius.web.core.api.IEditingContext;
@@ -82,7 +81,7 @@ public class RenameDiagramEventHandler implements IDiagramEventHandler {
 
         if (diagramInput instanceof RenameDiagramInput) {
             RenameDiagramInput renameRepresentationInput = (RenameDiagramInput) diagramInput;
-            UUID representationId = renameRepresentationInput.getRepresentationId();
+            String representationId = renameRepresentationInput.getRepresentationId();
             String newLabel = renameRepresentationInput.getNewLabel();
             Optional<Diagram> optionalDiagram = this.representationSearchService.findById(editingContext, representationId, Diagram.class);
             if (optionalDiagram.isPresent()) {

--- a/backend/sirius-web-spring-collaborative-diagrams/src/test/java/org/eclipse/sirius/web/spring/collaborative/diagrams/handlers/CreateDiagramEventHandlerTests.java
+++ b/backend/sirius-web-spring-collaborative-diagrams/src/test/java/org/eclipse/sirius/web/spring/collaborative/diagrams/handlers/CreateDiagramEventHandlerTests.java
@@ -74,7 +74,7 @@ public class CreateDiagramEventHandlerTests {
             @Override
             public Diagram create(String label, Object targetObject, DiagramDescription diagramDescription, IEditingContext editingContext) {
                 hasBeenCalled.set(true);
-                return new TestDiagramBuilder().getDiagram(UUID.randomUUID());
+                return new TestDiagramBuilder().getDiagram(UUID.randomUUID().toString());
             }
 
         };
@@ -95,13 +95,13 @@ public class CreateDiagramEventHandlerTests {
         CreateDiagramEventHandler handler = new CreateDiagramEventHandler(representationDescriptionSearchService, representationPersistenceService, diagramCreationService, objectService,
                 new NoOpCollaborativeDiagramMessageService(), new SimpleMeterRegistry());
 
-        var input = new CreateRepresentationInput(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), "objectId", "representationName"); //$NON-NLS-1$//$NON-NLS-2$
+        var input = new CreateRepresentationInput(UUID.randomUUID(), UUID.randomUUID().toString(), UUID.randomUUID(), "objectId", "representationName"); //$NON-NLS-1$//$NON-NLS-2$
         assertThat(handler.canHandle(null, input)).isTrue();
 
         Many<ChangeDescription> changeDescriptionSink = Sinks.many().unicast().onBackpressureBuffer();
         One<IPayload> payloadSink = Sinks.one();
 
-        IEditingContext editingContext = () -> UUID.randomUUID();
+        IEditingContext editingContext = () -> UUID.randomUUID().toString();
         handler.handle(payloadSink, changeDescriptionSink, editingContext, input);
         assertThat(hasBeenCalled.get()).isTrue();
 

--- a/backend/sirius-web-spring-collaborative-diagrams/src/test/java/org/eclipse/sirius/web/spring/collaborative/diagrams/handlers/RenameDiagramEventHandlerTests.java
+++ b/backend/sirius-web-spring-collaborative-diagrams/src/test/java/org/eclipse/sirius/web/spring/collaborative/diagrams/handlers/RenameDiagramEventHandlerTests.java
@@ -54,8 +54,8 @@ public class RenameDiagramEventHandlerTests {
 
     @Test
     public void testRenameRepresentation() {
-        UUID projectId = UUID.randomUUID();
-        UUID representationId = UUID.randomUUID();
+        String projectId = UUID.randomUUID().toString();
+        String representationId = UUID.randomUUID().toString();
         UUID targetObjectId = UUID.randomUUID();
 
         DiagramDescription diagramDescription = new TestDiagramDescriptionBuilder().getDiagramDescription(UUID.randomUUID(), List.of(), List.of(), List.of());
@@ -74,7 +74,7 @@ public class RenameDiagramEventHandlerTests {
         IRepresentationSearchService representationSearchService = new IRepresentationSearchService() {
 
             @Override
-            public <T extends IRepresentation> Optional<T> findById(IEditingContext editingContext, UUID representationId, Class<T> representationClass) {
+            public <T extends IRepresentation> Optional<T> findById(IEditingContext editingContext, String representationId, Class<T> representationClass) {
                 return Optional.of(diagram).map(representationClass::cast);
             }
         };

--- a/backend/sirius-web-spring-collaborative-forms/pom.xml
+++ b/backend/sirius-web-spring-collaborative-forms/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-spring-collaborative-forms</artifactId>
-	<version>0.5.4</version>
+	<version>0.5.5</version>
 	<name>sirius-web-spring-collaborative-forms</name>
 	<description>Sirius Web Spring Collaborative Forms</description>
 
@@ -50,28 +50,28 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-api</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-forms</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-collaborative</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 		<dependency>
     		<groupId>org.eclipse.sirius.web</groupId>
     		<artifactId>sirius-web-tests</artifactId>
-    		<version>0.5.4</version>
+    		<version>0.5.5</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius.web</groupId>
     		<artifactId>sirius-web-spring-tests</artifactId>
-    		<version>0.5.4</version>
+    		<version>0.5.5</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>

--- a/backend/sirius-web-spring-collaborative-forms/src/main/java/org/eclipse/sirius/web/spring/collaborative/forms/api/FormConfiguration.java
+++ b/backend/sirius-web-spring-collaborative-forms/src/main/java/org/eclipse/sirius/web/spring/collaborative/forms/api/FormConfiguration.java
@@ -13,7 +13,6 @@
 package org.eclipse.sirius.web.spring.collaborative.forms.api;
 
 import java.util.Objects;
-import java.util.UUID;
 
 import org.eclipse.sirius.web.spring.collaborative.api.IRepresentationConfiguration;
 
@@ -25,14 +24,14 @@ import org.eclipse.sirius.web.spring.collaborative.api.IRepresentationConfigurat
  */
 public class FormConfiguration implements IRepresentationConfiguration {
 
-    private final UUID formId;
+    private final String formId;
 
-    public FormConfiguration(UUID formId) {
+    public FormConfiguration(String formId) {
         this.formId = Objects.requireNonNull(formId);
     }
 
     @Override
-    public UUID getId() {
+    public String getId() {
         return this.formId;
     }
 

--- a/backend/sirius-web-spring-collaborative-forms/src/main/java/org/eclipse/sirius/web/spring/collaborative/forms/api/FormCreationParameters.java
+++ b/backend/sirius-web-spring-collaborative-forms/src/main/java/org/eclipse/sirius/web/spring/collaborative/forms/api/FormCreationParameters.java
@@ -14,7 +14,6 @@ package org.eclipse.sirius.web.spring.collaborative.forms.api;
 
 import java.text.MessageFormat;
 import java.util.Objects;
-import java.util.UUID;
 
 import org.eclipse.sirius.web.annotations.Immutable;
 import org.eclipse.sirius.web.core.api.IEditingContext;
@@ -31,7 +30,7 @@ import org.eclipse.sirius.web.forms.description.FormDescription;
 @Immutable
 public final class FormCreationParameters {
 
-    private UUID id;
+    private String id;
 
     private Object object;
 
@@ -43,7 +42,7 @@ public final class FormCreationParameters {
         // Prevent instantiation
     }
 
-    public UUID getId() {
+    public String getId() {
         return this.id;
     }
 
@@ -59,7 +58,7 @@ public final class FormCreationParameters {
         return this.editingContext;
     }
 
-    public static Builder newFormCreationParameters(UUID id) {
+    public static Builder newFormCreationParameters(String id) {
         return new Builder(id);
     }
 
@@ -85,7 +84,7 @@ public final class FormCreationParameters {
      */
     @SuppressWarnings("checkstyle:HiddenField")
     public static final class Builder {
-        private UUID id;
+        private String id;
 
         private Object object;
 
@@ -93,7 +92,7 @@ public final class FormCreationParameters {
 
         private IEditingContext editingContext;
 
-        private Builder(UUID id) {
+        private Builder(String id) {
             this.id = id;
         }
 

--- a/backend/sirius-web-spring-collaborative-forms/src/main/java/org/eclipse/sirius/web/spring/collaborative/forms/api/PropertiesConfiguration.java
+++ b/backend/sirius-web-spring-collaborative-forms/src/main/java/org/eclipse/sirius/web/spring/collaborative/forms/api/PropertiesConfiguration.java
@@ -26,17 +26,17 @@ public class PropertiesConfiguration implements IRepresentationConfiguration {
 
     private static final String PROPERTIES_PREFIX = "properties:"; //$NON-NLS-1$
 
-    private final UUID formId;
+    private final String formId;
 
     private final String objectId;
 
     public PropertiesConfiguration(String objectId) {
         this.objectId = Objects.requireNonNull(objectId);
-        this.formId = UUID.nameUUIDFromBytes((PROPERTIES_PREFIX + objectId).getBytes());
+        this.formId = UUID.nameUUIDFromBytes((PROPERTIES_PREFIX + objectId).getBytes()).toString();
     }
 
     @Override
-    public UUID getId() {
+    public String getId() {
         return this.formId;
     }
 

--- a/backend/sirius-web-spring-collaborative-forms/src/main/java/org/eclipse/sirius/web/spring/collaborative/forms/api/RepresentationsConfiguration.java
+++ b/backend/sirius-web-spring-collaborative-forms/src/main/java/org/eclipse/sirius/web/spring/collaborative/forms/api/RepresentationsConfiguration.java
@@ -28,15 +28,15 @@ public class RepresentationsConfiguration implements IRepresentationConfiguratio
 
     private final String objectId;
 
-    private UUID formId;
+    private String formId;
 
     public RepresentationsConfiguration(String objectId) {
         this.objectId = Objects.requireNonNull(objectId);
-        this.formId = UUID.nameUUIDFromBytes((REPRESENTATIONS_PREFIX + objectId).getBytes());
+        this.formId = UUID.nameUUIDFromBytes((REPRESENTATIONS_PREFIX + objectId).getBytes()).toString();
     }
 
     @Override
-    public UUID getId() {
+    public String getId() {
         return this.formId;
     }
 

--- a/backend/sirius-web-spring-collaborative-forms/src/main/java/org/eclipse/sirius/web/spring/collaborative/forms/dto/DeleteListItemInput.java
+++ b/backend/sirius-web-spring-collaborative-forms/src/main/java/org/eclipse/sirius/web/spring/collaborative/forms/dto/DeleteListItemInput.java
@@ -31,9 +31,9 @@ import org.eclipse.sirius.web.spring.collaborative.forms.api.IFormInput;
 public final class DeleteListItemInput implements IFormInput {
     private UUID id;
 
-    private UUID representationId;
+    private String representationId;
 
-    private UUID editingContextId;
+    private String editingContextId;
 
     private String listId;
 
@@ -43,7 +43,7 @@ public final class DeleteListItemInput implements IFormInput {
         // Used by Jackson
     }
 
-    public DeleteListItemInput(UUID id, UUID representationId, UUID editingContextId, String listId, String listItemId) {
+    public DeleteListItemInput(UUID id, String representationId, String editingContextId, String listId, String listItemId) {
         this.id = Objects.requireNonNull(id);
         this.representationId = Objects.requireNonNull(representationId);
         this.editingContextId = Objects.requireNonNull(editingContextId);
@@ -63,14 +63,14 @@ public final class DeleteListItemInput implements IFormInput {
     @GraphQLID
     @GraphQLField
     @GraphQLNonNull
-    public UUID getRepresentationId() {
+    public String getRepresentationId() {
         return this.representationId;
     }
 
     @GraphQLID
     @GraphQLField
     @GraphQLNonNull
-    public UUID getEditingContextId() {
+    public String getEditingContextId() {
         return this.editingContextId;
     }
 

--- a/backend/sirius-web-spring-collaborative-forms/src/main/java/org/eclipse/sirius/web/spring/collaborative/forms/dto/EditCheckboxInput.java
+++ b/backend/sirius-web-spring-collaborative-forms/src/main/java/org/eclipse/sirius/web/spring/collaborative/forms/dto/EditCheckboxInput.java
@@ -31,9 +31,9 @@ import org.eclipse.sirius.web.spring.collaborative.forms.api.IFormInput;
 public final class EditCheckboxInput implements IFormInput {
     private UUID id;
 
-    private UUID editingContextId;
+    private String editingContextId;
 
-    private UUID representationId;
+    private String representationId;
 
     private String checkboxId;
 
@@ -43,7 +43,7 @@ public final class EditCheckboxInput implements IFormInput {
         // Used by Jackson
     }
 
-    public EditCheckboxInput(UUID id, UUID editingContextId, UUID representationId, String checkboxId, boolean newValue) {
+    public EditCheckboxInput(UUID id, String editingContextId, String representationId, String checkboxId, boolean newValue) {
         this.id = Objects.requireNonNull(id);
         this.editingContextId = Objects.requireNonNull(editingContextId);
         this.representationId = Objects.requireNonNull(representationId);
@@ -62,7 +62,7 @@ public final class EditCheckboxInput implements IFormInput {
     @GraphQLID
     @GraphQLField
     @GraphQLNonNull
-    public UUID getEditingContextId() {
+    public String getEditingContextId() {
         return this.editingContextId;
     }
 
@@ -70,7 +70,7 @@ public final class EditCheckboxInput implements IFormInput {
     @GraphQLID
     @GraphQLField
     @GraphQLNonNull
-    public UUID getRepresentationId() {
+    public String getRepresentationId() {
         return this.representationId;
     }
 

--- a/backend/sirius-web-spring-collaborative-forms/src/main/java/org/eclipse/sirius/web/spring/collaborative/forms/dto/EditMultiSelectInput.java
+++ b/backend/sirius-web-spring-collaborative-forms/src/main/java/org/eclipse/sirius/web/spring/collaborative/forms/dto/EditMultiSelectInput.java
@@ -31,9 +31,9 @@ import org.eclipse.sirius.web.spring.collaborative.forms.api.IFormInput;
 public final class EditMultiSelectInput implements IFormInput {
     private UUID id;
 
-    private UUID editingContextId;
+    private String editingContextId;
 
-    private UUID representationId;
+    private String representationId;
 
     private String selectId;
 
@@ -50,7 +50,7 @@ public final class EditMultiSelectInput implements IFormInput {
     @GraphQLID
     @GraphQLField
     @GraphQLNonNull
-    public UUID getEditingContextId() {
+    public String getEditingContextId() {
         return this.editingContextId;
     }
 
@@ -58,7 +58,7 @@ public final class EditMultiSelectInput implements IFormInput {
     @GraphQLID
     @GraphQLField
     @GraphQLNonNull
-    public UUID getRepresentationId() {
+    public String getRepresentationId() {
         return this.representationId;
     }
 

--- a/backend/sirius-web-spring-collaborative-forms/src/main/java/org/eclipse/sirius/web/spring/collaborative/forms/dto/EditRadioInput.java
+++ b/backend/sirius-web-spring-collaborative-forms/src/main/java/org/eclipse/sirius/web/spring/collaborative/forms/dto/EditRadioInput.java
@@ -31,9 +31,9 @@ import org.eclipse.sirius.web.spring.collaborative.forms.api.IFormInput;
 public final class EditRadioInput implements IFormInput {
     private UUID id;
 
-    private UUID editingContextId;
+    private String editingContextId;
 
-    private UUID representationId;
+    private String representationId;
 
     private String radioId;
 
@@ -43,7 +43,7 @@ public final class EditRadioInput implements IFormInput {
         // Used by Jackson
     }
 
-    public EditRadioInput(UUID id, UUID editingContextId, UUID representationId, String radioId, String newValue) {
+    public EditRadioInput(UUID id, String editingContextId, String representationId, String radioId, String newValue) {
         this.id = Objects.requireNonNull(id);
         this.editingContextId = Objects.requireNonNull(editingContextId);
         this.representationId = Objects.requireNonNull(representationId);
@@ -62,7 +62,7 @@ public final class EditRadioInput implements IFormInput {
     @GraphQLID
     @GraphQLField
     @GraphQLNonNull
-    public UUID getEditingContextId() {
+    public String getEditingContextId() {
         return this.editingContextId;
     }
 
@@ -70,7 +70,7 @@ public final class EditRadioInput implements IFormInput {
     @GraphQLID
     @GraphQLField
     @GraphQLNonNull
-    public UUID getRepresentationId() {
+    public String getRepresentationId() {
         return this.representationId;
     }
 

--- a/backend/sirius-web-spring-collaborative-forms/src/main/java/org/eclipse/sirius/web/spring/collaborative/forms/dto/EditSelectInput.java
+++ b/backend/sirius-web-spring-collaborative-forms/src/main/java/org/eclipse/sirius/web/spring/collaborative/forms/dto/EditSelectInput.java
@@ -30,9 +30,9 @@ import org.eclipse.sirius.web.spring.collaborative.forms.api.IFormInput;
 public final class EditSelectInput implements IFormInput {
     private UUID id;
 
-    private UUID editingContextId;
+    private String editingContextId;
 
-    private UUID representationId;
+    private String representationId;
 
     private String selectId;
 
@@ -49,7 +49,7 @@ public final class EditSelectInput implements IFormInput {
     @GraphQLID
     @GraphQLField
     @GraphQLNonNull
-    public UUID getEditingContextId() {
+    public String getEditingContextId() {
         return this.editingContextId;
     }
 
@@ -57,7 +57,7 @@ public final class EditSelectInput implements IFormInput {
     @GraphQLID
     @GraphQLField
     @GraphQLNonNull
-    public UUID getRepresentationId() {
+    public String getRepresentationId() {
         return this.representationId;
     }
 

--- a/backend/sirius-web-spring-collaborative-forms/src/main/java/org/eclipse/sirius/web/spring/collaborative/forms/dto/EditTextfieldInput.java
+++ b/backend/sirius-web-spring-collaborative-forms/src/main/java/org/eclipse/sirius/web/spring/collaborative/forms/dto/EditTextfieldInput.java
@@ -32,9 +32,9 @@ public final class EditTextfieldInput implements IFormInput {
 
     private UUID id;
 
-    private UUID editingContextId;
+    private String editingContextId;
 
-    private UUID representationId;
+    private String representationId;
 
     private String textfieldId;
 
@@ -44,7 +44,7 @@ public final class EditTextfieldInput implements IFormInput {
         // Used by Jackson
     }
 
-    public EditTextfieldInput(UUID id, UUID editingContextId, UUID representationId, String textfieldId, String newValue) {
+    public EditTextfieldInput(UUID id, String editingContextId, String representationId, String textfieldId, String newValue) {
         this.id = Objects.requireNonNull(id);
         this.editingContextId = Objects.requireNonNull(editingContextId);
         this.representationId = Objects.requireNonNull(representationId);
@@ -63,7 +63,7 @@ public final class EditTextfieldInput implements IFormInput {
     @GraphQLID
     @GraphQLField
     @GraphQLNonNull
-    public UUID getEditingContextId() {
+    public String getEditingContextId() {
         return this.editingContextId;
     }
 
@@ -71,7 +71,7 @@ public final class EditTextfieldInput implements IFormInput {
     @GraphQLID
     @GraphQLField
     @GraphQLNonNull
-    public UUID getRepresentationId() {
+    public String getRepresentationId() {
         return this.representationId;
     }
 

--- a/backend/sirius-web-spring-collaborative-forms/src/main/java/org/eclipse/sirius/web/spring/collaborative/forms/dto/FormEventInput.java
+++ b/backend/sirius-web-spring-collaborative-forms/src/main/java/org/eclipse/sirius/web/spring/collaborative/forms/dto/FormEventInput.java
@@ -33,15 +33,15 @@ public final class FormEventInput implements IInput {
 
     private UUID id;
 
-    private UUID editingContextId;
+    private String editingContextId;
 
-    private UUID formId;
+    private String formId;
 
     public FormEventInput() {
         // Used by Jackson
     }
 
-    public FormEventInput(UUID id, UUID editingContextId, UUID formId) {
+    public FormEventInput(UUID id, String editingContextId, String formId) {
         this.id = Objects.requireNonNull(id);
         this.editingContextId = Objects.requireNonNull(editingContextId);
         this.formId = Objects.requireNonNull(formId);
@@ -58,14 +58,14 @@ public final class FormEventInput implements IInput {
     @GraphQLID
     @GraphQLField
     @GraphQLNonNull
-    public UUID getEditingContextId() {
+    public String getEditingContextId() {
         return this.editingContextId;
     }
 
     @GraphQLID
     @GraphQLField
     @GraphQLNonNull
-    public UUID getFormId() {
+    public String getFormId() {
         return this.formId;
     }
 

--- a/backend/sirius-web-spring-collaborative-forms/src/main/java/org/eclipse/sirius/web/spring/collaborative/forms/dto/PropertiesEventInput.java
+++ b/backend/sirius-web-spring-collaborative-forms/src/main/java/org/eclipse/sirius/web/spring/collaborative/forms/dto/PropertiesEventInput.java
@@ -30,7 +30,7 @@ import org.eclipse.sirius.web.core.api.IInput;
 public final class PropertiesEventInput implements IInput {
     private UUID id;
 
-    private UUID editingContextId;
+    private String editingContextId;
 
     private String objectId;
 
@@ -45,7 +45,7 @@ public final class PropertiesEventInput implements IInput {
     @GraphQLID
     @GraphQLField
     @GraphQLNonNull
-    public UUID getEditingContextId() {
+    public String getEditingContextId() {
         return this.editingContextId;
     }
 

--- a/backend/sirius-web-spring-collaborative-forms/src/main/java/org/eclipse/sirius/web/spring/collaborative/forms/dto/RepresentationsEventInput.java
+++ b/backend/sirius-web-spring-collaborative-forms/src/main/java/org/eclipse/sirius/web/spring/collaborative/forms/dto/RepresentationsEventInput.java
@@ -31,7 +31,7 @@ public class RepresentationsEventInput implements IInput {
 
     private UUID id;
 
-    private UUID editingContextId;
+    private String editingContextId;
 
     private String objectId;
 
@@ -46,7 +46,7 @@ public class RepresentationsEventInput implements IInput {
     @GraphQLID
     @GraphQLField
     @GraphQLNonNull
-    public UUID getEditingContextId() {
+    public String getEditingContextId() {
         return this.editingContextId;
     }
 

--- a/backend/sirius-web-spring-collaborative-forms/src/main/java/org/eclipse/sirius/web/spring/collaborative/forms/dto/UpdateWidgetFocusInput.java
+++ b/backend/sirius-web-spring-collaborative-forms/src/main/java/org/eclipse/sirius/web/spring/collaborative/forms/dto/UpdateWidgetFocusInput.java
@@ -31,9 +31,9 @@ public final class UpdateWidgetFocusInput implements IFormInput {
 
     private UUID id;
 
-    private UUID editingContextId;
+    private String editingContextId;
 
-    private UUID representationId;
+    private String representationId;
 
     private String widgetId;
 
@@ -50,7 +50,7 @@ public final class UpdateWidgetFocusInput implements IFormInput {
     @GraphQLID
     @GraphQLField
     @GraphQLNonNull
-    public UUID getEditingContextId() {
+    public String getEditingContextId() {
         return this.editingContextId;
     }
 
@@ -58,7 +58,7 @@ public final class UpdateWidgetFocusInput implements IFormInput {
     @GraphQLID
     @GraphQLField
     @GraphQLNonNull
-    public UUID getRepresentationId() {
+    public String getRepresentationId() {
         return this.representationId;
     }
 

--- a/backend/sirius-web-spring-collaborative-forms/src/main/java/org/eclipse/sirius/web/spring/collaborative/forms/handlers/CreateFormEventHandler.java
+++ b/backend/sirius-web-spring-collaborative-forms/src/main/java/org/eclipse/sirius/web/spring/collaborative/forms/handlers/CreateFormEventHandler.java
@@ -106,7 +106,7 @@ public class CreateFormEventHandler implements IEditingContextEventHandler {
                 String targetObjectId = this.objectService.getId(optionalObject.get());
                 if (representationDescription instanceof FormDescription) {
                     // @formatter:off
-                    Form form = Form.newForm(UUID.randomUUID())
+                    Form form = Form.newForm(UUID.randomUUID().toString())
                             .label(createRepresentationInput.getRepresentationName())
                             .targetObjectId(targetObjectId)
                             .descriptionId(representationDescription.getId())

--- a/backend/sirius-web-spring-collaborative-forms/src/test/java/org/eclipse/sirius/web/spring/collaborative/forms/handlers/DeleteListItemEventHandlerTests.java
+++ b/backend/sirius-web-spring-collaborative-forms/src/test/java/org/eclipse/sirius/web/spring/collaborative/forms/handlers/DeleteListItemEventHandlerTests.java
@@ -60,7 +60,7 @@ public class DeleteListItemEventHandlerTests {
 
         Map<String, Object> parameters = new HashMap<>();
         parameters.put(changeDescriptionParameterKey, listItemId);
-        var input = new DeleteListItemInput(UUID.randomUUID(), FORM_ID, UUID.randomUUID(), listId, listItemId);
+        var input = new DeleteListItemInput(UUID.randomUUID(), FORM_ID.toString(), UUID.randomUUID().toString(), listId, listItemId);
 
         AtomicBoolean hasBeenExecuted = new AtomicBoolean();
         Supplier<IStatus> deleteHandler = () -> {
@@ -93,7 +93,7 @@ public class DeleteListItemEventHandlerTests {
                 .groups(Collections.singletonList(group))
                 .build();
 
-        Form form = Form.newForm(FORM_ID)
+        Form form = Form.newForm(FORM_ID.toString())
                 .targetObjectId("targetObjectId") //$NON-NLS-1$
                 .descriptionId(UUID.randomUUID())
                 .label("form label") //$NON-NLS-1$

--- a/backend/sirius-web-spring-collaborative-forms/src/test/java/org/eclipse/sirius/web/spring/collaborative/forms/handlers/EditCheckboxEventHandlerTests.java
+++ b/backend/sirius-web-spring-collaborative-forms/src/test/java/org/eclipse/sirius/web/spring/collaborative/forms/handlers/EditCheckboxEventHandlerTests.java
@@ -47,13 +47,13 @@ import reactor.core.publisher.Sinks.One;
  * @author sbegaudeau
  */
 public class EditCheckboxEventHandlerTests {
-    private static final UUID FORM_ID = UUID.randomUUID();
+    private static final String FORM_ID = UUID.randomUUID().toString();
 
     @Test
     public void testCheckboxEdition() {
         String id = "Checkbox id"; //$NON-NLS-1$
 
-        var input = new EditCheckboxInput(UUID.randomUUID(), UUID.randomUUID(), FORM_ID, id, true);
+        var input = new EditCheckboxInput(UUID.randomUUID(), UUID.randomUUID().toString(), FORM_ID, id, true);
 
         AtomicBoolean hasBeenExecuted = new AtomicBoolean();
         Function<Boolean, IStatus> newValueHandler = newValue -> {

--- a/backend/sirius-web-spring-collaborative-forms/src/test/java/org/eclipse/sirius/web/spring/collaborative/forms/handlers/EditRadioEventHandlerTests.java
+++ b/backend/sirius-web-spring-collaborative-forms/src/test/java/org/eclipse/sirius/web/spring/collaborative/forms/handlers/EditRadioEventHandlerTests.java
@@ -48,13 +48,13 @@ import reactor.core.publisher.Sinks.One;
  * @author sbegaudeau
  */
 public class EditRadioEventHandlerTests {
-    private static final UUID FORM_ID = UUID.randomUUID();
+    private static final String FORM_ID = UUID.randomUUID().toString();
 
     @Test
     public void testRadioEdition() {
         String id = "Radio id"; //$NON-NLS-1$
 
-        var input = new EditRadioInput(UUID.randomUUID(), UUID.randomUUID(), FORM_ID, id, "optionId"); //$NON-NLS-1$
+        var input = new EditRadioInput(UUID.randomUUID(), UUID.randomUUID().toString(), FORM_ID, id, "optionId"); //$NON-NLS-1$
 
         AtomicBoolean hasBeenExecuted = new AtomicBoolean();
         Function<String, IStatus> newValueHandler = newValue -> {

--- a/backend/sirius-web-spring-collaborative-forms/src/test/java/org/eclipse/sirius/web/spring/collaborative/forms/handlers/EditTextfieldEventHandlerTests.java
+++ b/backend/sirius-web-spring-collaborative-forms/src/test/java/org/eclipse/sirius/web/spring/collaborative/forms/handlers/EditTextfieldEventHandlerTests.java
@@ -47,13 +47,13 @@ import reactor.core.publisher.Sinks.One;
  * @author sbegaudeau
  */
 public class EditTextfieldEventHandlerTests {
-    private static final UUID FORM_ID = UUID.randomUUID();
+    private static final String FORM_ID = UUID.randomUUID().toString();
 
     @Test
     public void testTextfieldEdition() {
         String id = "Textfield id"; //$NON-NLS-1$
 
-        var input = new EditTextfieldInput(UUID.randomUUID(), UUID.randomUUID(), FORM_ID, id, "New value"); //$NON-NLS-1$
+        var input = new EditTextfieldInput(UUID.randomUUID(), UUID.randomUUID().toString(), FORM_ID, id, "New value"); //$NON-NLS-1$
 
         AtomicBoolean hasBeenExecuted = new AtomicBoolean();
         Function<String, IStatus> newValueHandler = newValue -> {

--- a/backend/sirius-web-spring-collaborative-selection/pom.xml
+++ b/backend/sirius-web-spring-collaborative-selection/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-spring-collaborative-selection</artifactId>
-	<version>0.5.4</version>
+	<version>0.5.5</version>
 	<name>sirius-web-spring-collaborative-selection</name>
 	<description>Sirius Web Spring Collaborative Selection</description>
 
@@ -43,7 +43,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-selection</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>
@@ -56,23 +56,23 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-api</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-collaborative</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-tests</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/backend/sirius-web-spring-collaborative-selection/src/main/java/org/eclipse/sirius/web/spring/collaborative/selection/SelectionEventProcessor.java
+++ b/backend/sirius-web-spring-collaborative-selection/src/main/java/org/eclipse/sirius/web/spring/collaborative/selection/SelectionEventProcessor.java
@@ -58,7 +58,7 @@ public class SelectionEventProcessor implements ISelectionEventProcessor {
 
     private final SelectionDescription selectionDescription;
 
-    private final UUID id;
+    private final String id;
 
     private final Object object;
 
@@ -72,7 +72,7 @@ public class SelectionEventProcessor implements ISelectionEventProcessor {
 
     private final AtomicReference<Selection> currentSelection = new AtomicReference<>();
 
-    public SelectionEventProcessor(IEditingContext editingContext, SelectionDescription selectionDescription, UUID id, Object object, ISubscriptionManager subscriptionManager,
+    public SelectionEventProcessor(IEditingContext editingContext, SelectionDescription selectionDescription, String id, Object object, ISubscriptionManager subscriptionManager,
             IRepresentationRefreshPolicyRegistry representationRefreshPolicyRegistry) {
         this.logger.trace("Creating the selection event processor {}", id); //$NON-NLS-1$
 

--- a/backend/sirius-web-spring-collaborative-selection/src/main/java/org/eclipse/sirius/web/spring/collaborative/selection/api/SelectionConfiguration.java
+++ b/backend/sirius-web-spring-collaborative-selection/src/main/java/org/eclipse/sirius/web/spring/collaborative/selection/api/SelectionConfiguration.java
@@ -24,20 +24,20 @@ import org.eclipse.sirius.web.spring.collaborative.api.IRepresentationConfigurat
  */
 public class SelectionConfiguration implements IRepresentationConfiguration {
 
-    private final UUID id;
+    private final String id;
 
     private final UUID selectionId;
 
     private final String targetObjectId;
 
-    public SelectionConfiguration(UUID id, UUID selectionId, String targetObjectId) {
+    public SelectionConfiguration(String id, UUID selectionId, String targetObjectId) {
         this.id = Objects.requireNonNull(id);
         this.selectionId = Objects.requireNonNull(selectionId);
         this.targetObjectId = Objects.requireNonNull(targetObjectId);
     }
 
     @Override
-    public UUID getId() {
+    public String getId() {
         return this.id;
     }
 

--- a/backend/sirius-web-spring-collaborative-selection/src/main/java/org/eclipse/sirius/web/spring/collaborative/selection/dto/SelectionEventInput.java
+++ b/backend/sirius-web-spring-collaborative-selection/src/main/java/org/eclipse/sirius/web/spring/collaborative/selection/dto/SelectionEventInput.java
@@ -32,7 +32,7 @@ public final class SelectionEventInput implements IInput {
 
     private UUID id;
 
-    private UUID editingContextId;
+    private String editingContextId;
 
     private UUID selectionId;
 
@@ -42,7 +42,7 @@ public final class SelectionEventInput implements IInput {
         // Used by Jackson
     }
 
-    public SelectionEventInput(UUID id, UUID editingContextId, UUID selectionId, String targetObjectId) {
+    public SelectionEventInput(UUID id, String editingContextId, UUID selectionId, String targetObjectId) {
         this.id = Objects.requireNonNull(id);
         this.editingContextId = Objects.requireNonNull(editingContextId);
         this.selectionId = Objects.requireNonNull(selectionId);
@@ -60,7 +60,7 @@ public final class SelectionEventInput implements IInput {
     @GraphQLID
     @GraphQLField
     @GraphQLNonNull
-    public UUID getEditingContextId() {
+    public String getEditingContextId() {
         return this.editingContextId;
     }
 

--- a/backend/sirius-web-spring-collaborative-trees/pom.xml
+++ b/backend/sirius-web-spring-collaborative-trees/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-spring-collaborative-trees</artifactId>
-	<version>0.5.4</version>
+	<version>0.5.5</version>
 	<name>sirius-web-spring-collaborative-trees</name>
 	<description>Sirius Web Spring Collaborative Trees</description>
 
@@ -42,12 +42,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-collaborative</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-trees</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>
@@ -68,13 +68,13 @@
 		<dependency>
     		<groupId>org.eclipse.sirius.web</groupId>
     		<artifactId>sirius-web-tests</artifactId>
-    		<version>0.5.4</version>
+    		<version>0.5.5</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius.web</groupId>
     		<artifactId>sirius-web-spring-tests</artifactId>
-    		<version>0.5.4</version>
+    		<version>0.5.5</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>

--- a/backend/sirius-web-spring-collaborative-trees/src/main/java/org/eclipse/sirius/web/spring/collaborative/trees/api/TreeConfiguration.java
+++ b/backend/sirius-web-spring-collaborative-trees/src/main/java/org/eclipse/sirius/web/spring/collaborative/trees/api/TreeConfiguration.java
@@ -25,18 +25,18 @@ import org.eclipse.sirius.web.spring.collaborative.api.IRepresentationConfigurat
  */
 public class TreeConfiguration implements IRepresentationConfiguration {
 
-    private final UUID treeId;
+    private final String treeId;
 
     private final List<String> expanded;
 
-    public TreeConfiguration(UUID editingContextId, List<String> expanded) {
-        String uniqueId = editingContextId.toString() + expanded.toString();
-        this.treeId = UUID.nameUUIDFromBytes(uniqueId.getBytes());
+    public TreeConfiguration(String editingContextId, List<String> expanded) {
+        String uniqueId = editingContextId + expanded.toString();
+        this.treeId = UUID.nameUUIDFromBytes(uniqueId.getBytes()).toString();
         this.expanded = Objects.requireNonNull(expanded);
     }
 
     @Override
-    public UUID getId() {
+    public String getId() {
         return this.treeId;
     }
 

--- a/backend/sirius-web-spring-collaborative-trees/src/main/java/org/eclipse/sirius/web/spring/collaborative/trees/api/TreeCreationParameters.java
+++ b/backend/sirius-web-spring-collaborative-trees/src/main/java/org/eclipse/sirius/web/spring/collaborative/trees/api/TreeCreationParameters.java
@@ -15,7 +15,6 @@ package org.eclipse.sirius.web.spring.collaborative.trees.api;
 import java.text.MessageFormat;
 import java.util.List;
 import java.util.Objects;
-import java.util.UUID;
 
 import org.eclipse.sirius.web.annotations.Immutable;
 import org.eclipse.sirius.web.core.api.IEditingContext;
@@ -28,7 +27,7 @@ import org.eclipse.sirius.web.trees.description.TreeDescription;
  */
 @Immutable
 public final class TreeCreationParameters {
-    private UUID id;
+    private String id;
 
     private TreeDescription treeDescription;
 
@@ -40,7 +39,7 @@ public final class TreeCreationParameters {
         // Prevent instantiation
     }
 
-    public UUID getId() {
+    public String getId() {
         return this.id;
     }
 
@@ -56,7 +55,7 @@ public final class TreeCreationParameters {
         return this.editingContext;
     }
 
-    public static Builder newTreeCreationParameters(UUID id) {
+    public static Builder newTreeCreationParameters(String id) {
         return new Builder(id);
     }
 
@@ -73,7 +72,7 @@ public final class TreeCreationParameters {
      */
     @SuppressWarnings("checkstyle:HiddenField")
     public static final class Builder {
-        private UUID id;
+        private String id;
 
         private TreeDescription treeDescription;
 
@@ -81,7 +80,7 @@ public final class TreeCreationParameters {
 
         private IEditingContext editingContext;
 
-        private Builder(UUID id) {
+        private Builder(String id) {
             this.id = id;
         }
 

--- a/backend/sirius-web-spring-collaborative-trees/src/main/java/org/eclipse/sirius/web/spring/collaborative/trees/dto/DeleteTreeItemInput.java
+++ b/backend/sirius-web-spring-collaborative-trees/src/main/java/org/eclipse/sirius/web/spring/collaborative/trees/dto/DeleteTreeItemInput.java
@@ -31,9 +31,9 @@ import org.eclipse.sirius.web.spring.collaborative.trees.api.ITreeInput;
 public final class DeleteTreeItemInput implements ITreeInput {
     private UUID id;
 
-    private UUID editingContextId;
+    private String editingContextId;
 
-    private UUID representationId;
+    private String representationId;
 
     private UUID treeItemId;
 
@@ -41,7 +41,7 @@ public final class DeleteTreeItemInput implements ITreeInput {
         // Used by Jackson
     }
 
-    public DeleteTreeItemInput(UUID id, UUID editingContextId, UUID representationId, UUID treeItemId) {
+    public DeleteTreeItemInput(UUID id, String editingContextId, String representationId, UUID treeItemId) {
         this.id = Objects.requireNonNull(id);
         this.editingContextId = Objects.requireNonNull(editingContextId);
         this.representationId = Objects.requireNonNull(representationId);
@@ -59,14 +59,14 @@ public final class DeleteTreeItemInput implements ITreeInput {
     @GraphQLID
     @GraphQLField
     @GraphQLNonNull
-    public UUID getEditingContextId() {
+    public String getEditingContextId() {
         return this.editingContextId;
     }
 
     @GraphQLID
     @GraphQLField
     @Override
-    public UUID getRepresentationId() {
+    public String getRepresentationId() {
         return this.representationId;
     }
 

--- a/backend/sirius-web-spring-collaborative-trees/src/main/java/org/eclipse/sirius/web/spring/collaborative/trees/dto/RenameTreeItemInput.java
+++ b/backend/sirius-web-spring-collaborative-trees/src/main/java/org/eclipse/sirius/web/spring/collaborative/trees/dto/RenameTreeItemInput.java
@@ -31,9 +31,9 @@ import org.eclipse.sirius.web.spring.collaborative.trees.api.ITreeInput;
 public final class RenameTreeItemInput implements ITreeInput {
     private UUID id;
 
-    private UUID editingContextId;
+    private String editingContextId;
 
-    private UUID representationId;
+    private String representationId;
 
     private UUID treeItemId;
 
@@ -43,7 +43,7 @@ public final class RenameTreeItemInput implements ITreeInput {
         // Used by Jackson
     }
 
-    public RenameTreeItemInput(UUID id, UUID editingContextId, UUID representationId, UUID treeItemId, String newLabel) {
+    public RenameTreeItemInput(UUID id, String editingContextId, String representationId, UUID treeItemId, String newLabel) {
         this.id = Objects.requireNonNull(id);
         this.editingContextId = Objects.requireNonNull(editingContextId);
         this.representationId = Objects.requireNonNull(representationId);
@@ -62,14 +62,14 @@ public final class RenameTreeItemInput implements ITreeInput {
     @GraphQLID
     @GraphQLField
     @GraphQLNonNull
-    public UUID getEditingContextId() {
+    public String getEditingContextId() {
         return this.editingContextId;
     }
 
     @GraphQLID
     @GraphQLField
     @Override
-    public UUID getRepresentationId() {
+    public String getRepresentationId() {
         return this.representationId;
     }
 

--- a/backend/sirius-web-spring-collaborative-trees/src/main/java/org/eclipse/sirius/web/spring/collaborative/trees/dto/TreeEventInput.java
+++ b/backend/sirius-web-spring-collaborative-trees/src/main/java/org/eclipse/sirius/web/spring/collaborative/trees/dto/TreeEventInput.java
@@ -32,7 +32,7 @@ import org.eclipse.sirius.web.core.api.IInput;
 public final class TreeEventInput implements IInput {
     private UUID id;
 
-    private UUID editingContextId;
+    private String editingContextId;
 
     private List<String> expanded;
 
@@ -40,7 +40,7 @@ public final class TreeEventInput implements IInput {
         // Used by Jackson
     }
 
-    public TreeEventInput(UUID id, UUID editingContextId, List<String> expanded) {
+    public TreeEventInput(UUID id, String editingContextId, List<String> expanded) {
         this.id = Objects.requireNonNull(id);
         this.editingContextId = Objects.requireNonNull(editingContextId);
         this.expanded = Objects.requireNonNull(expanded);
@@ -57,7 +57,7 @@ public final class TreeEventInput implements IInput {
     @GraphQLID
     @GraphQLField
     @GraphQLNonNull
-    public UUID getEditingContextId() {
+    public String getEditingContextId() {
         return this.editingContextId;
     }
 

--- a/backend/sirius-web-spring-collaborative-validation/pom.xml
+++ b/backend/sirius-web-spring-collaborative-validation/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-spring-collaborative-validation</artifactId>
-	<version>0.5.4</version>
+	<version>0.5.5</version>
 	<name>sirius-web-spring-collaborative-validation</name>
 	<description>Sirius Web Spring Collaborative Validation</description>
 	
@@ -46,17 +46,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-api</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-collaborative</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-validation</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -66,13 +66,13 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 			<scope>test</scope>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius.web</groupId>
     		<artifactId>sirius-web-spring-tests</artifactId>
-    		<version>0.5.4</version>
+    		<version>0.5.5</version>
     		<scope>test</scope>
     	</dependency>
 	</dependencies>

--- a/backend/sirius-web-spring-collaborative-validation/src/main/java/org/eclipse/sirius/web/spring/collaborative/validation/api/ValidationConfiguration.java
+++ b/backend/sirius-web-spring-collaborative-validation/src/main/java/org/eclipse/sirius/web/spring/collaborative/validation/api/ValidationConfiguration.java
@@ -23,15 +23,15 @@ import org.eclipse.sirius.web.spring.collaborative.api.IRepresentationConfigurat
  */
 public class ValidationConfiguration implements IRepresentationConfiguration {
 
-    private final UUID validationId;
+    private final String validationId;
 
-    public ValidationConfiguration(UUID editingContextId) {
-        String uniqueId = editingContextId.toString() + "validation"; //$NON-NLS-1$
-        this.validationId = UUID.nameUUIDFromBytes(uniqueId.getBytes());
+    public ValidationConfiguration(String editingContextId) {
+        String uniqueId = editingContextId + "validation"; //$NON-NLS-1$
+        this.validationId = UUID.nameUUIDFromBytes(uniqueId.getBytes()).toString();
     }
 
     @Override
-    public UUID getId() {
+    public String getId() {
         return this.validationId;
     }
 

--- a/backend/sirius-web-spring-collaborative-validation/src/main/java/org/eclipse/sirius/web/spring/collaborative/validation/dto/ValidationEventInput.java
+++ b/backend/sirius-web-spring-collaborative-validation/src/main/java/org/eclipse/sirius/web/spring/collaborative/validation/dto/ValidationEventInput.java
@@ -31,7 +31,7 @@ public final class ValidationEventInput implements IInput {
 
     private UUID id;
 
-    private UUID editingContextId;
+    private String editingContextId;
 
     public ValidationEventInput() {
         // Used by Jackson
@@ -48,7 +48,7 @@ public final class ValidationEventInput implements IInput {
     @GraphQLID
     @GraphQLField
     @GraphQLNonNull
-    public UUID getEditingContextId() {
+    public String getEditingContextId() {
         return this.editingContextId;
     }
 

--- a/backend/sirius-web-spring-collaborative/pom.xml
+++ b/backend/sirius-web-spring-collaborative/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-spring-collaborative</artifactId>
-	<version>0.5.4</version>
+	<version>0.5.5</version>
 	<name>sirius-web-spring-collaborative</name>
 	<description>Sirius Web Spring Collaborative</description>
 
@@ -70,23 +70,23 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-core-api</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-representations</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 		<dependency>
     		<groupId>org.eclipse.sirius.web</groupId>
     		<artifactId>sirius-web-tests</artifactId>
-    		<version>0.5.4</version>
+    		<version>0.5.5</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius.web</groupId>
     		<artifactId>sirius-web-spring-tests</artifactId>
-    		<version>0.5.4</version>
+    		<version>0.5.5</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>

--- a/backend/sirius-web-spring-collaborative/src/main/java/org/eclipse/sirius/web/spring/collaborative/api/ChangeDescription.java
+++ b/backend/sirius-web-spring-collaborative/src/main/java/org/eclipse/sirius/web/spring/collaborative/api/ChangeDescription.java
@@ -16,7 +16,6 @@ import java.text.MessageFormat;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-import java.util.UUID;
 
 import org.eclipse.sirius.web.core.api.IInput;
 
@@ -31,17 +30,17 @@ public class ChangeDescription {
 
     private final String kind;
 
-    private final UUID sourceId;
+    private final String sourceId;
 
     private final IInput input;
 
     private final Map<String, Object> parameters;
 
-    public ChangeDescription(String kind, UUID sourceId, IInput input) {
+    public ChangeDescription(String kind, String sourceId, IInput input) {
         this(kind, sourceId, input, new HashMap<>());
     }
 
-    public ChangeDescription(String kind, UUID sourceId, IInput input, Map<String, Object> parameters) {
+    public ChangeDescription(String kind, String sourceId, IInput input, Map<String, Object> parameters) {
         this.kind = Objects.requireNonNull(kind);
         this.sourceId = Objects.requireNonNull(sourceId);
         this.input = Objects.requireNonNull(input);
@@ -52,7 +51,7 @@ public class ChangeDescription {
         return this.kind;
     }
 
-    public UUID getSourceId() {
+    public String getSourceId() {
         return this.sourceId;
     }
 

--- a/backend/sirius-web-spring-collaborative/src/main/java/org/eclipse/sirius/web/spring/collaborative/api/IDanglingRepresentationDeletionService.java
+++ b/backend/sirius-web-spring-collaborative/src/main/java/org/eclipse/sirius/web/spring/collaborative/api/IDanglingRepresentationDeletionService.java
@@ -12,8 +12,6 @@
  *******************************************************************************/
 package org.eclipse.sirius.web.spring.collaborative.api;
 
-import java.util.UUID;
-
 import org.eclipse.sirius.web.core.api.IEditingContext;
 import org.eclipse.sirius.web.representations.IRepresentation;
 
@@ -37,7 +35,7 @@ public interface IDanglingRepresentationDeletionService {
      */
     boolean isDangling(IEditingContext editingContext, IRepresentation representation);
 
-    void deleteDanglingRepresentations(UUID editingContextId);
+    void deleteDanglingRepresentations(String editingContextId);
 
     /**
      * Implementation which does nothing, used for mocks in unit tests.
@@ -52,7 +50,7 @@ public interface IDanglingRepresentationDeletionService {
         }
 
         @Override
-        public void deleteDanglingRepresentations(UUID editingContextId) {
+        public void deleteDanglingRepresentations(String editingContextId) {
         }
 
     }

--- a/backend/sirius-web-spring-collaborative/src/main/java/org/eclipse/sirius/web/spring/collaborative/api/IEditingContextEventProcessor.java
+++ b/backend/sirius-web-spring-collaborative/src/main/java/org/eclipse/sirius/web/spring/collaborative/api/IEditingContextEventProcessor.java
@@ -14,7 +14,6 @@ package org.eclipse.sirius.web.spring.collaborative.api;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
 
 import org.eclipse.sirius.web.core.api.IInput;
 import org.eclipse.sirius.web.core.api.IPayload;
@@ -28,7 +27,7 @@ import reactor.core.publisher.Mono;
  * @author sbegaudeau
  */
 public interface IEditingContextEventProcessor extends IDisposablePublisher {
-    UUID getEditingContextId();
+    String getEditingContextId();
 
     <T extends IRepresentationEventProcessor> Optional<T> acquireRepresentationEventProcessor(Class<T> representationEventProcessorClass, IRepresentationConfiguration configuration, IInput input);
 
@@ -55,7 +54,7 @@ public interface IEditingContextEventProcessor extends IDisposablePublisher {
         }
 
         @Override
-        public UUID getEditingContextId() {
+        public String getEditingContextId() {
             return null;
         }
 

--- a/backend/sirius-web-spring-collaborative/src/main/java/org/eclipse/sirius/web/spring/collaborative/api/IEditingContextEventProcessorRegistry.java
+++ b/backend/sirius-web-spring-collaborative/src/main/java/org/eclipse/sirius/web/spring/collaborative/api/IEditingContextEventProcessorRegistry.java
@@ -14,7 +14,6 @@ package org.eclipse.sirius.web.spring.collaborative.api;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
 
 import org.eclipse.sirius.web.core.api.IInput;
 import org.eclipse.sirius.web.core.api.IPayload;
@@ -29,11 +28,11 @@ import reactor.core.publisher.Mono;
 public interface IEditingContextEventProcessorRegistry {
     List<IEditingContextEventProcessor> getEditingContextEventProcessors();
 
-    Mono<IPayload> dispatchEvent(UUID editingContextId, IInput input);
+    Mono<IPayload> dispatchEvent(String editingContextId, IInput input);
 
-    Optional<IEditingContextEventProcessor> getOrCreateEditingContextEventProcessor(UUID editingContextId);
+    Optional<IEditingContextEventProcessor> getOrCreateEditingContextEventProcessor(String editingContextId);
 
-    void disposeEditingContextEventProcessor(UUID editingContextId);
+    void disposeEditingContextEventProcessor(String editingContextId);
 
     /**
      * Implementation which does nothing, used for mocks in unit tests.
@@ -48,17 +47,17 @@ public interface IEditingContextEventProcessorRegistry {
         }
 
         @Override
-        public Mono<IPayload> dispatchEvent(UUID editingContextId, IInput input) {
+        public Mono<IPayload> dispatchEvent(String editingContextId, IInput input) {
             return Mono.empty();
         }
 
         @Override
-        public Optional<IEditingContextEventProcessor> getOrCreateEditingContextEventProcessor(UUID editingContextId) {
+        public Optional<IEditingContextEventProcessor> getOrCreateEditingContextEventProcessor(String editingContextId) {
             return Optional.empty();
         }
 
         @Override
-        public void disposeEditingContextEventProcessor(UUID editingContextId) {
+        public void disposeEditingContextEventProcessor(String editingContextId) {
         }
 
     }

--- a/backend/sirius-web-spring-collaborative/src/main/java/org/eclipse/sirius/web/spring/collaborative/api/IRepresentationConfiguration.java
+++ b/backend/sirius-web-spring-collaborative/src/main/java/org/eclipse/sirius/web/spring/collaborative/api/IRepresentationConfiguration.java
@@ -12,13 +12,11 @@
  *******************************************************************************/
 package org.eclipse.sirius.web.spring.collaborative.api;
 
-import java.util.UUID;
-
 /**
  * Interface implemented by all the representation configuration.
  *
  * @author sbegaudeau
  */
 public interface IRepresentationConfiguration {
-    UUID getId();
+    String getId();
 }

--- a/backend/sirius-web-spring-collaborative/src/main/java/org/eclipse/sirius/web/spring/collaborative/api/IRepresentationSearchService.java
+++ b/backend/sirius-web-spring-collaborative/src/main/java/org/eclipse/sirius/web/spring/collaborative/api/IRepresentationSearchService.java
@@ -13,7 +13,6 @@
 package org.eclipse.sirius.web.spring.collaborative.api;
 
 import java.util.Optional;
-import java.util.UUID;
 
 import org.eclipse.sirius.web.core.api.IEditingContext;
 import org.eclipse.sirius.web.representations.IRepresentation;
@@ -24,5 +23,5 @@ import org.eclipse.sirius.web.representations.IRepresentation;
  * @author sbegaudeau
  */
 public interface IRepresentationSearchService {
-    <T extends IRepresentation> Optional<T> findById(IEditingContext editingContext, UUID representationId, Class<T> representationClass);
+    <T extends IRepresentation> Optional<T> findById(IEditingContext editingContext, String representationId, Class<T> representationClass);
 }

--- a/backend/sirius-web-spring-collaborative/src/main/java/org/eclipse/sirius/web/spring/collaborative/dto/CreateChildInput.java
+++ b/backend/sirius-web-spring-collaborative/src/main/java/org/eclipse/sirius/web/spring/collaborative/dto/CreateChildInput.java
@@ -31,7 +31,7 @@ import org.eclipse.sirius.web.core.api.IInput;
 public final class CreateChildInput implements IInput {
     private UUID id;
 
-    private UUID editingContextId;
+    private String editingContextId;
 
     private String objectId;
 
@@ -41,7 +41,7 @@ public final class CreateChildInput implements IInput {
         // Used by Jackson
     }
 
-    public CreateChildInput(UUID id, UUID editingContextId, String objectId, String childCreationDescriptionId) {
+    public CreateChildInput(UUID id, String editingContextId, String objectId, String childCreationDescriptionId) {
         this.id = Objects.requireNonNull(id);
         this.editingContextId = Objects.requireNonNull(editingContextId);
         this.objectId = Objects.requireNonNull(objectId);
@@ -59,7 +59,7 @@ public final class CreateChildInput implements IInput {
     @GraphQLID
     @GraphQLField
     @GraphQLNonNull
-    public UUID getEditingContextId() {
+    public String getEditingContextId() {
         return this.editingContextId;
     }
 

--- a/backend/sirius-web-spring-collaborative/src/main/java/org/eclipse/sirius/web/spring/collaborative/dto/CreateDocumentInput.java
+++ b/backend/sirius-web-spring-collaborative/src/main/java/org/eclipse/sirius/web/spring/collaborative/dto/CreateDocumentInput.java
@@ -31,7 +31,7 @@ import org.eclipse.sirius.web.core.api.IInput;
 public final class CreateDocumentInput implements IInput {
     private UUID id;
 
-    private UUID editingContextId;
+    private String editingContextId;
 
     private String name;
 
@@ -41,7 +41,7 @@ public final class CreateDocumentInput implements IInput {
         // Used by Jackson
     }
 
-    public CreateDocumentInput(UUID id, UUID editingContextId, String name, UUID stereotypeDescriptionId) {
+    public CreateDocumentInput(UUID id, String editingContextId, String name, UUID stereotypeDescriptionId) {
         this.id = Objects.requireNonNull(id);
         this.editingContextId = Objects.requireNonNull(editingContextId);
         this.name = Objects.requireNonNull(name);
@@ -59,7 +59,7 @@ public final class CreateDocumentInput implements IInput {
     @GraphQLID
     @GraphQLField
     @GraphQLNonNull
-    public UUID getEditingContextId() {
+    public String getEditingContextId() {
         return this.editingContextId;
     }
 

--- a/backend/sirius-web-spring-collaborative/src/main/java/org/eclipse/sirius/web/spring/collaborative/dto/CreateRepresentationInput.java
+++ b/backend/sirius-web-spring-collaborative/src/main/java/org/eclipse/sirius/web/spring/collaborative/dto/CreateRepresentationInput.java
@@ -32,7 +32,7 @@ public final class CreateRepresentationInput implements IInput {
 
     private UUID id;
 
-    private UUID editingContextId;
+    private String editingContextId;
 
     private UUID representationDescriptionId;
 
@@ -44,7 +44,7 @@ public final class CreateRepresentationInput implements IInput {
         // Used by Jackson
     }
 
-    public CreateRepresentationInput(UUID id, UUID editingContextId, UUID representationDescriptionId, String objectId, String representationName) {
+    public CreateRepresentationInput(UUID id, String editingContextId, UUID representationDescriptionId, String objectId, String representationName) {
         this.id = Objects.requireNonNull(id);
         this.editingContextId = Objects.requireNonNull(editingContextId);
         this.representationDescriptionId = Objects.requireNonNull(representationDescriptionId);
@@ -63,7 +63,7 @@ public final class CreateRepresentationInput implements IInput {
     @GraphQLID
     @GraphQLField
     @GraphQLNonNull
-    public UUID getEditingContextId() {
+    public String getEditingContextId() {
         return this.editingContextId;
     }
 

--- a/backend/sirius-web-spring-collaborative/src/main/java/org/eclipse/sirius/web/spring/collaborative/dto/CreateRootObjectInput.java
+++ b/backend/sirius-web-spring-collaborative/src/main/java/org/eclipse/sirius/web/spring/collaborative/dto/CreateRootObjectInput.java
@@ -31,7 +31,7 @@ import org.eclipse.sirius.web.core.api.IInput;
 public final class CreateRootObjectInput implements IInput {
     private UUID id;
 
-    private UUID editingContextId;
+    private String editingContextId;
 
     private UUID documentId;
 
@@ -43,7 +43,7 @@ public final class CreateRootObjectInput implements IInput {
         // Used by Jackson
     }
 
-    public CreateRootObjectInput(UUID id, UUID editingContextId, UUID documentId, String domainId, String rootObjectCreationDescriptionId) {
+    public CreateRootObjectInput(UUID id, String editingContextId, UUID documentId, String domainId, String rootObjectCreationDescriptionId) {
         this.id = Objects.requireNonNull(id);
         this.editingContextId = Objects.requireNonNull(editingContextId);
         this.documentId = Objects.requireNonNull(documentId);
@@ -62,7 +62,7 @@ public final class CreateRootObjectInput implements IInput {
     @GraphQLID
     @GraphQLField
     @GraphQLNonNull
-    public UUID getEditingContextId() {
+    public String getEditingContextId() {
         return this.editingContextId;
     }
 

--- a/backend/sirius-web-spring-collaborative/src/main/java/org/eclipse/sirius/web/spring/collaborative/dto/DeleteObjectInput.java
+++ b/backend/sirius-web-spring-collaborative/src/main/java/org/eclipse/sirius/web/spring/collaborative/dto/DeleteObjectInput.java
@@ -31,7 +31,7 @@ import org.eclipse.sirius.web.core.api.IInput;
 public final class DeleteObjectInput implements IInput {
     private UUID id;
 
-    private UUID editingContextId;
+    private String editingContextId;
 
     private String objectId;
 
@@ -39,7 +39,7 @@ public final class DeleteObjectInput implements IInput {
         // Used by Jackson
     }
 
-    public DeleteObjectInput(UUID id, UUID editingContextId, String objectId) {
+    public DeleteObjectInput(UUID id, String editingContextId, String objectId) {
         this.id = Objects.requireNonNull(id);
         this.editingContextId = Objects.requireNonNull(editingContextId);
         this.objectId = Objects.requireNonNull(objectId);
@@ -56,7 +56,7 @@ public final class DeleteObjectInput implements IInput {
     @GraphQLID
     @GraphQLField
     @GraphQLNonNull
-    public UUID getEditingContextId() {
+    public String getEditingContextId() {
         return this.editingContextId;
     }
 

--- a/backend/sirius-web-spring-collaborative/src/main/java/org/eclipse/sirius/web/spring/collaborative/dto/DeleteRepresentationInput.java
+++ b/backend/sirius-web-spring-collaborative/src/main/java/org/eclipse/sirius/web/spring/collaborative/dto/DeleteRepresentationInput.java
@@ -31,13 +31,13 @@ import org.eclipse.sirius.web.core.api.IInput;
 public final class DeleteRepresentationInput implements IInput {
     private UUID id;
 
-    private UUID representationId;
+    private String representationId;
 
     public DeleteRepresentationInput() {
         // Used by Jackson
     }
 
-    public DeleteRepresentationInput(UUID id, UUID representationId) {
+    public DeleteRepresentationInput(UUID id, String representationId) {
         this.id = Objects.requireNonNull(id);
         this.representationId = Objects.requireNonNull(representationId);
     }
@@ -53,7 +53,7 @@ public final class DeleteRepresentationInput implements IInput {
     @GraphQLID
     @GraphQLField
     @GraphQLNonNull
-    public UUID getRepresentationId() {
+    public String getRepresentationId() {
         return this.representationId;
     }
 

--- a/backend/sirius-web-spring-collaborative/src/main/java/org/eclipse/sirius/web/spring/collaborative/dto/DeleteRepresentationSuccessPayload.java
+++ b/backend/sirius-web-spring-collaborative/src/main/java/org/eclipse/sirius/web/spring/collaborative/dto/DeleteRepresentationSuccessPayload.java
@@ -32,9 +32,9 @@ public final class DeleteRepresentationSuccessPayload implements IPayload {
 
     private final UUID id;
 
-    private final UUID representationId;
+    private final String representationId;
 
-    public DeleteRepresentationSuccessPayload(UUID id, UUID representationId) {
+    public DeleteRepresentationSuccessPayload(UUID id, String representationId) {
         this.id = Objects.requireNonNull(id);
         this.representationId = Objects.requireNonNull(representationId);
     }
@@ -50,7 +50,7 @@ public final class DeleteRepresentationSuccessPayload implements IPayload {
     @GraphQLID
     @GraphQLField
     @GraphQLNonNull
-    public UUID getRepresentationId() {
+    public String getRepresentationId() {
         return this.representationId;
     }
 

--- a/backend/sirius-web-spring-collaborative/src/main/java/org/eclipse/sirius/web/spring/collaborative/dto/EditingContextEventInput.java
+++ b/backend/sirius-web-spring-collaborative/src/main/java/org/eclipse/sirius/web/spring/collaborative/dto/EditingContextEventInput.java
@@ -31,7 +31,7 @@ public final class EditingContextEventInput implements IInput {
 
     private UUID id;
 
-    private UUID editingContextId;
+    private String editingContextId;
 
     @Override
     @GraphQLID
@@ -44,7 +44,7 @@ public final class EditingContextEventInput implements IInput {
     @GraphQLID
     @GraphQLField
     @GraphQLNonNull
-    public UUID getEditingContextId() {
+    public String getEditingContextId() {
         return this.editingContextId;
     }
 

--- a/backend/sirius-web-spring-collaborative/src/main/java/org/eclipse/sirius/web/spring/collaborative/dto/RenameObjectInput.java
+++ b/backend/sirius-web-spring-collaborative/src/main/java/org/eclipse/sirius/web/spring/collaborative/dto/RenameObjectInput.java
@@ -32,7 +32,7 @@ public final class RenameObjectInput implements IInput {
 
     private UUID id;
 
-    private UUID editingContextId;
+    private String editingContextId;
 
     private String objectId;
 
@@ -42,7 +42,7 @@ public final class RenameObjectInput implements IInput {
         // Used by Jackson
     }
 
-    public RenameObjectInput(UUID id, UUID editingContextId, String objectId, String newName) {
+    public RenameObjectInput(UUID id, String editingContextId, String objectId, String newName) {
         this.id = Objects.requireNonNull(id);
         this.editingContextId = Objects.requireNonNull(editingContextId);
         this.objectId = Objects.requireNonNull(objectId);
@@ -60,7 +60,7 @@ public final class RenameObjectInput implements IInput {
     @GraphQLID
     @GraphQLField
     @GraphQLNonNull
-    public UUID getEditingContextId() {
+    public String getEditingContextId() {
         return this.editingContextId;
     }
 

--- a/backend/sirius-web-spring-collaborative/src/main/java/org/eclipse/sirius/web/spring/collaborative/dto/RenameRepresentationInput.java
+++ b/backend/sirius-web-spring-collaborative/src/main/java/org/eclipse/sirius/web/spring/collaborative/dto/RenameRepresentationInput.java
@@ -32,9 +32,9 @@ public final class RenameRepresentationInput implements IRepresentationInput {
 
     private UUID id;
 
-    private UUID editingContextId;
+    private String editingContextId;
 
-    private UUID representationId;
+    private String representationId;
 
     private String newLabel;
 
@@ -42,7 +42,7 @@ public final class RenameRepresentationInput implements IRepresentationInput {
         // Used by Jackson
     }
 
-    public RenameRepresentationInput(UUID id, UUID editingContextId, UUID representationId, String newLabel) {
+    public RenameRepresentationInput(UUID id, String editingContextId, String representationId, String newLabel) {
         this.id = Objects.requireNonNull(id);
         this.editingContextId = Objects.requireNonNull(editingContextId);
         this.representationId = Objects.requireNonNull(representationId);
@@ -60,7 +60,7 @@ public final class RenameRepresentationInput implements IRepresentationInput {
     @GraphQLID
     @GraphQLField
     @GraphQLNonNull
-    public UUID getEditingContextId() {
+    public String getEditingContextId() {
         return this.editingContextId;
     }
 
@@ -68,7 +68,7 @@ public final class RenameRepresentationInput implements IRepresentationInput {
     @GraphQLID
     @GraphQLField
     @GraphQLNonNull
-    public UUID getRepresentationId() {
+    public String getRepresentationId() {
         return this.representationId;
     }
 

--- a/backend/sirius-web-spring-collaborative/src/main/java/org/eclipse/sirius/web/spring/collaborative/dto/RepresentationRefreshedEvent.java
+++ b/backend/sirius-web-spring-collaborative/src/main/java/org/eclipse/sirius/web/spring/collaborative/dto/RepresentationRefreshedEvent.java
@@ -13,7 +13,6 @@
 package org.eclipse.sirius.web.spring.collaborative.dto;
 
 import java.util.Objects;
-import java.util.UUID;
 
 import org.eclipse.sirius.web.representations.IRepresentation;
 
@@ -23,16 +22,16 @@ import org.eclipse.sirius.web.representations.IRepresentation;
  * @author sbegaudeau
  */
 public class RepresentationRefreshedEvent {
-    private final UUID projectId;
+    private final String projectId;
 
     private final IRepresentation representation;
 
-    public RepresentationRefreshedEvent(UUID projectId, IRepresentation representation) {
+    public RepresentationRefreshedEvent(String projectId, IRepresentation representation) {
         this.projectId = Objects.requireNonNull(projectId);
         this.representation = Objects.requireNonNull(representation);
     }
 
-    public UUID getProjectId() {
+    public String getProjectId() {
         return this.projectId;
     }
 

--- a/backend/sirius-web-spring-collaborative/src/main/java/org/eclipse/sirius/web/spring/collaborative/dto/RepresentationRenamedEventPayload.java
+++ b/backend/sirius-web-spring-collaborative/src/main/java/org/eclipse/sirius/web/spring/collaborative/dto/RepresentationRenamedEventPayload.java
@@ -31,11 +31,11 @@ import org.eclipse.sirius.web.core.api.IPayload;
 public final class RepresentationRenamedEventPayload implements IPayload {
     private final UUID id;
 
-    private final UUID representationId;
+    private final String representationId;
 
     private final String newLabel;
 
-    public RepresentationRenamedEventPayload(UUID id, UUID representationId, String newLabel) {
+    public RepresentationRenamedEventPayload(UUID id, String representationId, String newLabel) {
         this.id = Objects.requireNonNull(id);
         this.representationId = Objects.requireNonNull(representationId);
         this.newLabel = Objects.requireNonNull(newLabel);
@@ -52,7 +52,7 @@ public final class RepresentationRenamedEventPayload implements IPayload {
     @GraphQLID
     @GraphQLField
     @GraphQLNonNull
-    public UUID getRepresentationId() {
+    public String getRepresentationId() {
         return this.representationId;
     }
 

--- a/backend/sirius-web-spring-collaborative/src/main/java/org/eclipse/sirius/web/spring/collaborative/projects/EditingContextEventProcessorRegistry.java
+++ b/backend/sirius-web-spring-collaborative/src/main/java/org/eclipse/sirius/web/spring/collaborative/projects/EditingContextEventProcessorRegistry.java
@@ -17,7 +17,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
@@ -54,7 +53,7 @@ public class EditingContextEventProcessorRegistry implements IEditingContextEven
 
     private final Duration disposeDelay;
 
-    private final Map<UUID, EditingContextEventProcessorEntry> editingContextEventProcessors = new ConcurrentHashMap<>();
+    private final Map<String, EditingContextEventProcessorEntry> editingContextEventProcessors = new ConcurrentHashMap<>();
 
     public EditingContextEventProcessorRegistry(IEditingContextEventProcessorFactory editingContextEventProcessorFactory, IEditingContextSearchService editingContextSearchService,
             @Value("${sirius.components.editingContext.disposeDelay:1s}") Duration disposeDelay) {
@@ -73,12 +72,12 @@ public class EditingContextEventProcessorRegistry implements IEditingContextEven
     }
 
     @Override
-    public Mono<IPayload> dispatchEvent(UUID editingContextId, IInput input) {
+    public Mono<IPayload> dispatchEvent(String editingContextId, IInput input) {
         return this.getOrCreateEditingContextEventProcessor(editingContextId).map(processor -> processor.handle(input)).orElse(Mono.empty());
     }
 
     @Override
-    public synchronized Optional<IEditingContextEventProcessor> getOrCreateEditingContextEventProcessor(UUID editingContextId) {
+    public synchronized Optional<IEditingContextEventProcessor> getOrCreateEditingContextEventProcessor(String editingContextId) {
         Optional<IEditingContextEventProcessor> optionalEditingContextEventProcessor = Optional.empty();
         if (this.editingContextSearchService.existsById(editingContextId)) {
             optionalEditingContextEventProcessor = Optional.ofNullable(this.editingContextEventProcessors.get(editingContextId))
@@ -111,7 +110,7 @@ public class EditingContextEventProcessorRegistry implements IEditingContextEven
     }
 
     @Override
-    public void disposeEditingContextEventProcessor(UUID editingContextId) {
+    public void disposeEditingContextEventProcessor(String editingContextId) {
         Optional.ofNullable(this.editingContextEventProcessors.remove(editingContextId)).ifPresent(EditingContextEventProcessorEntry::dispose);
 
         this.logger.trace("Editing context event processors count: {}", this.editingContextEventProcessors.size()); //$NON-NLS-1$

--- a/backend/sirius-web-spring-collaborative/src/test/java/org/eclipse/sirius/web/spring/collaborative/handlers/CreateChildEventHandlerTests.java
+++ b/backend/sirius-web-spring-collaborative/src/test/java/org/eclipse/sirius/web/spring/collaborative/handlers/CreateChildEventHandlerTests.java
@@ -94,9 +94,9 @@ public class CreateChildEventHandlerTests {
         };
 
         CreateChildEventHandler handler = new CreateChildEventHandler(objectService, editService, new ICollaborativeMessageService.NoOp(), new SimpleMeterRegistry());
-        var input = new CreateChildInput(UUID.randomUUID(), UUID.randomUUID(), "parentObjectId", "childCreationDescriptionId"); //$NON-NLS-1$//$NON-NLS-2$
+        var input = new CreateChildInput(UUID.randomUUID(), UUID.randomUUID().toString(), "parentObjectId", "childCreationDescriptionId"); //$NON-NLS-1$//$NON-NLS-2$
 
-        IEditingContext editingContext = () -> UUID.randomUUID();
+        IEditingContext editingContext = () -> UUID.randomUUID().toString();
         assertThat(handler.canHandle(editingContext, input)).isTrue();
         handler.handle(payloadSink, changeDescriptionSink, editingContext, input);
     }

--- a/backend/sirius-web-spring-collaborative/src/test/java/org/eclipse/sirius/web/spring/collaborative/handlers/CreateRootObjectEventHandlerTests.java
+++ b/backend/sirius-web-spring-collaborative/src/test/java/org/eclipse/sirius/web/spring/collaborative/handlers/CreateRootObjectEventHandlerTests.java
@@ -49,8 +49,8 @@ public class CreateRootObjectEventHandlerTests {
         };
 
         CreateRootObjectEventHandler handler = new CreateRootObjectEventHandler(editService, new ICollaborativeMessageService.NoOp(), new SimpleMeterRegistry());
-        var input = new CreateRootObjectInput(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), "domainId", "rootObjectCreationDescriptionId"); //$NON-NLS-1$//$NON-NLS-2$
-        IEditingContext editingContext = () -> UUID.randomUUID();
+        var input = new CreateRootObjectInput(UUID.randomUUID(), UUID.randomUUID().toString(), UUID.randomUUID(), "domainId", "rootObjectCreationDescriptionId"); //$NON-NLS-1$//$NON-NLS-2$
+        IEditingContext editingContext = () -> UUID.randomUUID().toString();
 
         Many<ChangeDescription> changeDescriptionSink = Sinks.many().unicast().onBackpressureBuffer();
         One<IPayload> payloadSink = Sinks.one();

--- a/backend/sirius-web-spring-collaborative/src/test/java/org/eclipse/sirius/web/spring/collaborative/handlers/DeleteObjectEventHandlerTests.java
+++ b/backend/sirius-web-spring-collaborative/src/test/java/org/eclipse/sirius/web/spring/collaborative/handlers/DeleteObjectEventHandlerTests.java
@@ -58,8 +58,8 @@ public class DeleteObjectEventHandlerTests {
         };
 
         DeleteObjectEventHandler handler = new DeleteObjectEventHandler(objectService, editService, new ICollaborativeMessageService.NoOp(), new SimpleMeterRegistry());
-        var input = new DeleteObjectInput(UUID.randomUUID(), UUID.randomUUID(), "objectId"); //$NON-NLS-1$
-        IEditingContext editingContext = () -> UUID.randomUUID();
+        var input = new DeleteObjectInput(UUID.randomUUID(), UUID.randomUUID().toString(), "objectId"); //$NON-NLS-1$
+        IEditingContext editingContext = () -> UUID.randomUUID().toString();
 
         Many<ChangeDescription> changeDescriptionSink = Sinks.many().unicast().onBackpressureBuffer();
         One<IPayload> payloadSink = Sinks.one();

--- a/backend/sirius-web-spring-collaborative/src/test/java/org/eclipse/sirius/web/spring/collaborative/handlers/QueryBasedBooleanEventHandlerTests.java
+++ b/backend/sirius-web-spring-collaborative/src/test/java/org/eclipse/sirius/web/spring/collaborative/handlers/QueryBasedBooleanEventHandlerTests.java
@@ -91,7 +91,7 @@ public class QueryBasedBooleanEventHandlerTests {
         IInput input = new QueryBasedBooleanInput(UUID.randomUUID(), "", Map.of()); //$NON-NLS-1$
         assertThat(queryBasedBooleanEventHandler.canHandle(new IEditingContext.NoOp(), input)).isTrue();
 
-        IEditingContext editingContext = () -> UUID.randomUUID();
+        IEditingContext editingContext = () -> UUID.randomUUID().toString();
         queryBasedBooleanEventHandler.handle(payloadSink, changeDescriptionSink, editingContext, input);
     }
 }

--- a/backend/sirius-web-spring-collaborative/src/test/java/org/eclipse/sirius/web/spring/collaborative/handlers/QueryBasedIntEventHandlerTests.java
+++ b/backend/sirius-web-spring-collaborative/src/test/java/org/eclipse/sirius/web/spring/collaborative/handlers/QueryBasedIntEventHandlerTests.java
@@ -92,7 +92,7 @@ public class QueryBasedIntEventHandlerTests {
         IInput input = new QueryBasedIntInput(UUID.randomUUID(), "", Map.of()); //$NON-NLS-1$
         assertThat(queryBasedIntEventHandler.canHandle(new IEditingContext.NoOp(), input)).isTrue();
 
-        IEditingContext editingContext = () -> UUID.randomUUID();
+        IEditingContext editingContext = () -> UUID.randomUUID().toString();
         queryBasedIntEventHandler.handle(payloadSink, changeDescriptionSink, editingContext, input);
     }
 }

--- a/backend/sirius-web-spring-collaborative/src/test/java/org/eclipse/sirius/web/spring/collaborative/handlers/QueryBasedObjectEventHandlerTests.java
+++ b/backend/sirius-web-spring-collaborative/src/test/java/org/eclipse/sirius/web/spring/collaborative/handlers/QueryBasedObjectEventHandlerTests.java
@@ -90,7 +90,7 @@ public class QueryBasedObjectEventHandlerTests {
         IInput input = new QueryBasedObjectInput(UUID.randomUUID(), "", Map.of()); //$NON-NLS-1$
         assertThat(queryBasedObjectEventHandler.canHandle(new IEditingContext.NoOp(), input)).isTrue();
 
-        IEditingContext editingContext = () -> UUID.randomUUID();
+        IEditingContext editingContext = () -> UUID.randomUUID().toString();
         queryBasedObjectEventHandler.handle(payloadSink, changeDescriptionSink, editingContext, input);
     }
 }

--- a/backend/sirius-web-spring-collaborative/src/test/java/org/eclipse/sirius/web/spring/collaborative/handlers/QueryBasedObjectsEventHandlerTests.java
+++ b/backend/sirius-web-spring-collaborative/src/test/java/org/eclipse/sirius/web/spring/collaborative/handlers/QueryBasedObjectsEventHandlerTests.java
@@ -91,7 +91,7 @@ public class QueryBasedObjectsEventHandlerTests {
         IInput input = new QueryBasedObjectsInput(UUID.randomUUID(), "", Map.of()); //$NON-NLS-1$
         assertThat(queryBasedObjectsEventHandler.canHandle(new IEditingContext.NoOp(), input)).isTrue();
 
-        IEditingContext editingContext = () -> UUID.randomUUID();
+        IEditingContext editingContext = () -> UUID.randomUUID().toString();
         queryBasedObjectsEventHandler.handle(payloadSink, changeDescriptionSink, editingContext, input);
     }
 }

--- a/backend/sirius-web-spring-collaborative/src/test/java/org/eclipse/sirius/web/spring/collaborative/handlers/QueryBasedStringEventHandlerTests.java
+++ b/backend/sirius-web-spring-collaborative/src/test/java/org/eclipse/sirius/web/spring/collaborative/handlers/QueryBasedStringEventHandlerTests.java
@@ -89,7 +89,7 @@ public class QueryBasedStringEventHandlerTests {
         IInput input = new QueryBasedStringInput(UUID.randomUUID(), "", Map.of()); //$NON-NLS-1$
         assertThat(queryBasedStringEventHandler.canHandle(new IEditingContext.NoOp(), input)).isTrue();
 
-        IEditingContext editingContext = () -> UUID.randomUUID();
+        IEditingContext editingContext = () -> UUID.randomUUID().toString();
         queryBasedStringEventHandler.handle(payloadSink, changeDescriptionSink, editingContext, input);
     }
 }

--- a/backend/sirius-web-spring-collaborative/src/test/java/org/eclipse/sirius/web/spring/collaborative/handlers/RenameObjectEventHandlerTests.java
+++ b/backend/sirius-web-spring-collaborative/src/test/java/org/eclipse/sirius/web/spring/collaborative/handlers/RenameObjectEventHandlerTests.java
@@ -63,8 +63,8 @@ public class RenameObjectEventHandlerTests {
         };
 
         RenameObjectEventHandler handler = new RenameObjectEventHandler(new ICollaborativeMessageService.NoOp(), objectService, editService, new SimpleMeterRegistry());
-        var input = new RenameObjectInput(UUID.randomUUID(), UUID.randomUUID(), "objectId", "newName"); //$NON-NLS-1$ //$NON-NLS-2$
-        IEditingContext editingContext = () -> UUID.randomUUID();
+        var input = new RenameObjectInput(UUID.randomUUID(), UUID.randomUUID().toString(), "objectId", "newName"); //$NON-NLS-1$ //$NON-NLS-2$
+        IEditingContext editingContext = () -> UUID.randomUUID().toString();
 
         assertThat(handler.canHandle(editingContext, input)).isTrue();
 

--- a/backend/sirius-web-spring-graphql-api/pom.xml
+++ b/backend/sirius-web-spring-graphql-api/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-spring-graphql-api</artifactId>
-	<version>0.5.4</version>
+	<version>0.5.5</version>
 	<name>sirius-web-spring-graphql-api</name>
 	<description>Sirius Web Spring GraphQL API</description>
 
@@ -48,7 +48,7 @@
     	<dependency>
         	<groupId>org.eclipse.sirius.web</groupId>
         	<artifactId>sirius-web-annotations-spring</artifactId>
-        	<version>0.5.4</version>
+        	<version>0.5.5</version>
     	</dependency>
 	</dependencies>
 

--- a/backend/sirius-web-spring-graphql/pom.xml
+++ b/backend/sirius-web-spring-graphql/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-spring-graphql</artifactId>
-	<version>0.5.4</version>
+	<version>0.5.5</version>
 	<name>sirius-web-spring-graphql</name>
 	<description>Sirius Web Spring GraphQL</description>
 
@@ -68,28 +68,28 @@
     	<dependency>
     		<groupId>org.eclipse.sirius.web</groupId>
     		<artifactId>sirius-web-annotations</artifactId>
-    		<version>0.5.4</version>
+    		<version>0.5.5</version>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius.web</groupId>
     		<artifactId>sirius-web-graphql-utils</artifactId>
-    		<version>0.5.4</version>
+    		<version>0.5.5</version>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius.web</groupId>
     		<artifactId>sirius-web-spring-graphql-api</artifactId>
-    		<version>0.5.4</version>
+    		<version>0.5.5</version>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius.web</groupId>
     		<artifactId>sirius-web-tests</artifactId>
-    		<version>0.5.4</version>
+    		<version>0.5.5</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius.web</groupId>
     		<artifactId>sirius-web-spring-tests</artifactId>
-    		<version>0.5.4</version>
+    		<version>0.5.5</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>

--- a/backend/sirius-web-spring-starter/pom.xml
+++ b/backend/sirius-web-spring-starter/pom.xml
@@ -15,7 +15,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-spring-starter</artifactId>
-	<version>0.5.4</version>
+	<version>0.5.5</version>
 	<name>sirius-web-spring-starter</name>
 	<description>Sirius Web Spring Starter</description>
 
@@ -47,52 +47,52 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-graphql</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-diagrams-layout</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-collaborative</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-collaborative-diagrams</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-collaborative-forms</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-collaborative-selection</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-collaborative-trees</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-spring-collaborative-validation</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-emf</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-compatibility</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 	</dependencies>
 

--- a/backend/sirius-web-spring-tests/pom.xml
+++ b/backend/sirius-web-spring-tests/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-spring-tests</artifactId>
-	<version>0.5.4</version>
+	<version>0.5.5</version>
 	<name>sirius-web-spring-tests</name>
 	<description>Sirius Web Spring Tests</description>
 
@@ -46,7 +46,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-annotations</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>

--- a/backend/sirius-web-tests/pom.xml
+++ b/backend/sirius-web-tests/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-tests</artifactId>
-	<version>0.5.4</version>
+	<version>0.5.5</version>
 	<name>sirius-web-tests</name>
 	<description>Sirius Web Tests</description>
 
@@ -51,7 +51,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-annotations</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 	</dependencies>
 

--- a/backend/sirius-web-trees/pom.xml
+++ b/backend/sirius-web-trees/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-trees</artifactId>
-	<version>0.5.4</version>
+	<version>0.5.5</version>
 	<name>sirius-web-trees</name>
 	<description>Sirius Web Trees</description>
 
@@ -42,17 +42,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-annotations</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-representations</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/backend/sirius-web-trees/src/main/java/org/eclipse/sirius/web/trees/Tree.java
+++ b/backend/sirius-web-trees/src/main/java/org/eclipse/sirius/web/trees/Tree.java
@@ -35,7 +35,7 @@ public final class Tree implements IRepresentation {
 
     public static final String KIND = "Tree"; //$NON-NLS-1$
 
-    private UUID id;
+    private String id;
 
     private String kind;
 
@@ -53,7 +53,7 @@ public final class Tree implements IRepresentation {
     @GraphQLID
     @GraphQLField
     @GraphQLNonNull
-    public UUID getId() {
+    public String getId() {
         return this.id;
     }
 
@@ -85,7 +85,7 @@ public final class Tree implements IRepresentation {
         return this.children;
     }
 
-    public static Builder newTree(UUID id) {
+    public static Builder newTree(String id) {
         return new Builder(id);
     }
 
@@ -102,7 +102,7 @@ public final class Tree implements IRepresentation {
      */
     @SuppressWarnings("checkstyle:HiddenField")
     public static final class Builder {
-        private UUID id;
+        private String id;
 
         private String kind = KIND;
 
@@ -112,7 +112,7 @@ public final class Tree implements IRepresentation {
 
         private List<TreeItem> children;
 
-        private Builder(UUID id) {
+        private Builder(String id) {
             this.id = Objects.requireNonNull(id);
         }
 

--- a/backend/sirius-web-trees/src/main/java/org/eclipse/sirius/web/trees/description/TreeDescription.java
+++ b/backend/sirius-web-trees/src/main/java/org/eclipse/sirius/web/trees/description/TreeDescription.java
@@ -41,7 +41,7 @@ public final class TreeDescription implements IRepresentationDescription {
 
     private String label;
 
-    private Function<VariableManager, UUID> idProvider;
+    private Function<VariableManager, String> idProvider;
 
     private Function<VariableManager, String> treeItemIdProvider;
 
@@ -86,7 +86,7 @@ public final class TreeDescription implements IRepresentationDescription {
         return this.label;
     }
 
-    public Function<VariableManager, UUID> getIdProvider() {
+    public Function<VariableManager, String> getIdProvider() {
         return this.idProvider;
     }
 
@@ -160,7 +160,7 @@ public final class TreeDescription implements IRepresentationDescription {
 
         private String label;
 
-        private Function<VariableManager, UUID> idProvider;
+        private Function<VariableManager, String> idProvider;
 
         private Function<VariableManager, String> treeItemIdProvider;
 
@@ -195,7 +195,7 @@ public final class TreeDescription implements IRepresentationDescription {
             return this;
         }
 
-        public Builder idProvider(Function<VariableManager, UUID> idProvider) {
+        public Builder idProvider(Function<VariableManager, String> idProvider) {
             this.idProvider = Objects.requireNonNull(idProvider);
             return this;
         }

--- a/backend/sirius-web-trees/src/main/java/org/eclipse/sirius/web/trees/renderer/TreeRenderer.java
+++ b/backend/sirius-web-trees/src/main/java/org/eclipse/sirius/web/trees/renderer/TreeRenderer.java
@@ -15,7 +15,6 @@ package org.eclipse.sirius.web.trees.renderer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.UUID;
 
 import org.eclipse.sirius.web.representations.VariableManager;
 import org.eclipse.sirius.web.trees.Tree;
@@ -41,7 +40,7 @@ public class TreeRenderer {
     }
 
     public Tree render() {
-        UUID treeId = this.treeDescription.getIdProvider().apply(this.variableManager);
+        String treeId = this.treeDescription.getIdProvider().apply(this.variableManager);
         String label = this.treeDescription.getLabelProvider().apply(this.variableManager);
 
         List<TreeItem> childrenItems = new ArrayList<>();

--- a/backend/sirius-web-validation/pom.xml
+++ b/backend/sirius-web-validation/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-validation</artifactId>
-	<version>0.5.4</version>
+	<version>0.5.5</version>
 	<name>sirius-web-validation</name>
 	<description>Sirius Web Validation</description>
 	
@@ -47,17 +47,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-components</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-representations</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-tests</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend/sirius-web-validation/src/main/java/org/eclipse/sirius/web/validation/Validation.java
+++ b/backend/sirius-web-validation/src/main/java/org/eclipse/sirius/web/validation/Validation.java
@@ -35,7 +35,7 @@ public final class Validation implements IRepresentation {
 
     public static final String KIND = "Validation"; //$NON-NLS-1$
 
-    private UUID id;
+    private String id;
 
     private String kind;
 
@@ -53,7 +53,7 @@ public final class Validation implements IRepresentation {
     @GraphQLID
     @GraphQLField
     @GraphQLNonNull
-    public UUID getId() {
+    public String getId() {
         return this.id;
     }
 
@@ -85,7 +85,7 @@ public final class Validation implements IRepresentation {
         return this.diagnostics;
     }
 
-    public static Builder newValidation(UUID id) {
+    public static Builder newValidation(String id) {
         return new Builder(id);
     }
 
@@ -103,7 +103,7 @@ public final class Validation implements IRepresentation {
     @SuppressWarnings("checkstyle:HiddenField")
     public static final class Builder {
 
-        private UUID id;
+        private String id;
 
         private String kind = KIND;
 
@@ -113,7 +113,7 @@ public final class Validation implements IRepresentation {
 
         private List<Diagnostic> diagnostics;
 
-        private Builder(UUID id) {
+        private Builder(String id) {
             this.id = Objects.requireNonNull(id);
         }
 

--- a/backend/sirius-web-validation/src/main/java/org/eclipse/sirius/web/validation/components/ValidationComponent.java
+++ b/backend/sirius-web-validation/src/main/java/org/eclipse/sirius/web/validation/components/ValidationComponent.java
@@ -15,7 +15,6 @@ package org.eclipse.sirius.web.validation.components;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
 
 import org.eclipse.sirius.web.components.Element;
 import org.eclipse.sirius.web.components.IComponent;
@@ -43,7 +42,7 @@ public class ValidationComponent implements IComponent {
         ValidationDescription validationDescription = this.props.getValidationDescription();
         Optional<Validation> optionalPreviousValidation = this.props.getPreviousValidation();
 
-        UUID id = optionalPreviousValidation.map(Validation::getId).orElseGet(() -> UUID.nameUUIDFromBytes("validation".getBytes())); //$NON-NLS-1$
+        String id = optionalPreviousValidation.map(Validation::getId).orElseGet(() -> "validation"); //$NON-NLS-1$
         String label = validationDescription.getLabel();
 
         List<Element> children = new ArrayList<>();

--- a/backend/sirius-web-validation/src/main/java/org/eclipse/sirius/web/validation/elements/ValidationElementProps.java
+++ b/backend/sirius-web-validation/src/main/java/org/eclipse/sirius/web/validation/elements/ValidationElementProps.java
@@ -30,7 +30,7 @@ import org.eclipse.sirius.web.components.IProps;
 public final class ValidationElementProps implements IProps {
     public static final String TYPE = "Validation"; //$NON-NLS-1$
 
-    private UUID id;
+    private String id;
 
     private String label;
 
@@ -42,7 +42,7 @@ public final class ValidationElementProps implements IProps {
         // Prevent instantiation
     }
 
-    public UUID getId() {
+    public String getId() {
         return this.id;
     }
 
@@ -59,7 +59,7 @@ public final class ValidationElementProps implements IProps {
         return this.children;
     }
 
-    public static Builder newValidationElementProps(UUID id) {
+    public static Builder newValidationElementProps(String id) {
         return new Builder(id);
     }
 
@@ -77,7 +77,7 @@ public final class ValidationElementProps implements IProps {
     @SuppressWarnings("checkstyle:HiddenField")
     public static final class Builder {
 
-        private UUID id;
+        private String id;
 
         private String label;
 
@@ -85,7 +85,7 @@ public final class ValidationElementProps implements IProps {
 
         private List<Element> children;
 
-        private Builder(UUID id) {
+        private Builder(String id) {
             this.id = Objects.requireNonNull(id);
         }
 

--- a/backend/sirius-web-view-edit/pom.xml
+++ b/backend/sirius-web-view-edit/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-view-edit</artifactId>
-	<version>0.5.4</version>
+	<version>0.5.5</version>
 	<name>sirius-web-view-edit</name>
 	<description>Sirius Web View Definition DSL - Edit Support</description>
 
@@ -64,7 +64,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius.web</groupId>
 			<artifactId>sirius-web-view</artifactId>
-			<version>0.5.4</version>
+			<version>0.5.5</version>
 		</dependency>
 	</dependencies>
 	

--- a/backend/sirius-web-view/pom.xml
+++ b/backend/sirius-web-view/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>
 	<artifactId>sirius-web-view</artifactId>
-	<version>0.5.4</version>
+	<version>0.5.5</version>
 	<name>sirius-web-view</name>
 	<description>Sirius Web View Definition DSL</description>
 

--- a/doc/adrs/032_relax_our_constraints_on_some_of_our_identifiers.adoc
+++ b/doc/adrs/032_relax_our_constraints_on_some_of_our_identifiers.adoc
@@ -16,7 +16,6 @@ In order to solve this issue, we will relax our constraints on some of our ident
 The following identifier will change their type from an `UUID` to a `String` and we will not make any hypothesis regarding the content of those identifiers in Sirius Components:
 
 - `org.eclipse.sirius.web.representations.IRepresentation.getId()`
-- `org.eclipse.sirius.web.representations.IRepresentationDescription.getId()`
 - `org.eclipse.sirius.web.core.api.IEditingContext.getId()`
 
 This change should be propagated to all the other places where those identifiers are manipulated such as `DiagramConfiguration.getId()`, `FormEventProcessor.formId` or even `InvokeNodeToolOnDiagramInput.representationId`.
@@ -28,7 +27,10 @@ WIP
 
 == Consequences
 
-Projects consuming Sirius Components such as Sirius Web will need to be updated in order to explicitely decide what they will use as identifiers.
+Projects consuming Sirius Components such as Sirius Web will need to be updated in order to explicitly decide what they will use as identifiers.
 Entities in Sirius Web will still use UUID and the transformation from UUID to Strings will be made by Sirius Web code.
 For the moment, we recommend keeping UUID saved as Strings just like in Sirius Web since it is our nominal use case.
 Only advanced projects with complex needs should try to setup their own complex identifiers.
+
+`Node.getId()` and `Edge.getId()` and all of their uses will become a `String`, including services, handlers. That also forces `LayoutData.getId()`, and thus, the `Label.getId()` to also return a `String`.
+In one hand it increases the number of backend changes but, one the other hand the frontend remains unchanged.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@eclipse-sirius/sirius-components",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@eclipse-sirius/sirius-components",
-      "version": "0.5.4",
+      "version": "0.5.5",
       "license": "EPL-2.0",
       "dependencies": {
         "uuid": "8.3.2"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-sirius/sirius-components",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "author": "Eclipse Sirius",
   "license": "EPL-2.0",
   "description": "Reusable components used to build the Sirius Web frontend",


### PR DESCRIPTION
### Type of this PR 

- [ ] Bug fix
- [x] New feature or improvement
- [ ] Documentation
- [ ] Cleanup
- [ ] Test
- [ ] Build/Releng

### Issue(s)

#700

### What does this PR do?

This PR only changes the internal behavior. The type of editing context id and representation id is not constraint to a UUID anymore.
We keep using UUID in string format within sirius-web but other products will be able to use their own id policy for editing context id and representation id.

### How to test this PR?

All existing tests should be OK

### Checklist

- [ ] I have read CONTRIBUTING carefully.
- [ ] I have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [ ] All my commits are signed-off (`-s`) with my mail address of my Eclipse Account.
- [ ] I have covered my changes by unit tests or integration tests or manual tests.
- [ ] All tests pass.
- [ ] I have updated the documentation accordingly
- [ ] New React components are availables in storybook
