### PR TITLE
Setup the Node.SELECTED_NODE and SELECTED OBJECT independently

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -11,10 +11,7 @@
 === Deprecation warning
 
 - https://github.com/eclipse-sirius/sirius-components/issues/818[#818] [workbench] The concept of `Selection` will be restructured, as described in the ADR-036. Every part of the code involved in the manipulation of the selection of the workbench will be impacted. This includes concepts as remote as the representation descriptions which are used to computed fields like `kind`. For example, the behavior of the `TreeDescription#getKindProvider` and `NodeDescription#getTargetObjectKindProvider` will have to be updated for all the providers. Failure to update to the new behavior will make the selection fail in the workbench
-
-=== Deprecation warning
-
-[core] The Success parameterless contructor will be removed soon.
+- [core] The Success parameterless contructor will be removed soon.
 
 === Breaking Changes
 
@@ -31,6 +28,10 @@
 - [core] Add a task to display TypeScript errors in the VS Code problems view
 - https://github.com/eclipse-sirius/sirius-components/issues/773[#773] [compatibility] The synchronization policy of the node descriptions is now properly computed from the `AbstractNodeMapping`
 - https://github.com/eclipse-sirius/sirius-components/issues/694[#694] [core] Data can be provided to Success in order to notify changment made by operation made on the editing context.
+
+=== Bug fixes
+
+- [diagram] The variable `selectedNode` was only available in the variable manager used when executing node tools if a selection dialog was also available. Now the `selectedNode` variable will always be available unless the tool has been invoked on the background of the diagram
 
 
 == v0.5.0

--- a/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/handlers/InvokeNodeToolOnDiagramEventHandler.java
+++ b/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/handlers/InvokeNodeToolOnDiagramEventHandler.java
@@ -136,6 +136,8 @@ public class InvokeNodeToolOnDiagramEventHandler implements IDiagramEventHandler
             variableManager.put(IDiagramContext.DIAGRAM_CONTEXT, diagramContext);
             variableManager.put(IEditingContext.EDITING_CONTEXT, editingContext);
             variableManager.put(VariableManager.SELF, self.get());
+            node.ifPresent(selectedNode -> variableManager.put(Node.SELECTED_NODE, selectedNode));
+
             String selectionDescriptionId = tool.getSelectionDescriptionId();
             if (selectionDescriptionId != null && selectedObjectId != null) {
                 var selectionDescriptionOpt = this.representationDescriptionSearchService.findById(editingContext, UUID.fromString(selectionDescriptionId));
@@ -143,11 +145,7 @@ public class InvokeNodeToolOnDiagramEventHandler implements IDiagramEventHandler
                 if (selectionDescriptionOpt.isPresent() && selectedObjectOpt.isPresent()) {
                     variableManager.put(CreateNodeTool.SELECTED_OBJECT, selectedObjectOpt.get());
                 }
-                if (node.isPresent()) {
-                    variableManager.put(Node.SELECTED_NODE, node.get());
-                }
             }
-
             if (selectionDescriptionId == null || selectedObjectId != null) {
                 result = tool.getHandler().apply(variableManager);
                 Position newPosition = Position.at(startingPositionX, startingPositionY);


### PR DESCRIPTION

The Node.SELECTED_NODE and the NodeTool.SELECTED OBJECT
should be setup independently each other in invokeNodeTool.


### Type of this PR 

- [ ] Bug fix
- [ ] New feature or improvement
- [ ] Documentation
- [x] Cleanup
- [ ] Test
- [ ] Build/Releng

### Issue(s)

...

### What does this PR do?

...

### Screenshot/screencast of this PR

...
 

### Potential side effects

...

### How to test this PR?

- [ ] Frontend Unit tests
- [ ] Backend Unit tests
- [ ] Cypress : please specify
- [ ] Manual Test : please specify

### Checklist

- [ ] I have read CONTRIBUTING carefully.
- [ ] I have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [ ] All my commits are signed-off (`-s`) with my mail address of my Eclipse Account.
- [ ] I have covered my changes by unit tests or integration tests or manual tests.
- [ ] All tests pass.
- [ ] I have updated the documentation accordingly
- [ ] New React components are availables in storybook
