### PR TITLE
[releng] Switch some projects from Spring Boot 2.5.1 to 2.5.6

### DIFF
--- a/backend/sirius-web-selection/pom.xml
+++ b/backend/sirius-web-selection/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.5.1</version>
+		<version>2.5.6</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>

--- a/backend/sirius-web-spring-collaborative-selection/pom.xml
+++ b/backend/sirius-web-spring-collaborative-selection/pom.xml
@@ -18,7 +18,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.5.1</version>
+		<version>2.5.6</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>

--- a/backend/sirius-web-spring-collaborative-validation/pom.xml
+++ b/backend/sirius-web-spring-collaborative-validation/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.5.1</version>
+		<version>2.5.6</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>

--- a/backend/sirius-web-validation/pom.xml
+++ b/backend/sirius-web-validation/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.5.1</version>
+		<version>2.5.6</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>org.eclipse.sirius.web</groupId>


### PR DESCRIPTION
Not all projects had properly been migrated to Spring Boot 2.5.6, this
commit fixes that

Signed-off-by: Stéphane Bégaudeau <stephane.begaudeau@obeo.fr>
