### PR TITLE
[359] Fix border node's size computation

### DIFF
--- a/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/incremental/IncrementalLayoutDiagramConverter.java
+++ b/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/incremental/IncrementalLayoutDiagramConverter.java
@@ -95,6 +95,7 @@ public class IncrementalLayoutDiagramConverter {
         layoutData.setLabel(labelLayoutData);
 
         layoutData.setResizedByUser(node.getCustomizedProperties().contains(CustomizableProperties.Size));
+        layoutData.setBorderNode(node.isBorderNode());
 
         return layoutData;
     }

--- a/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/incremental/data/NodeLayoutData.java
+++ b/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/incremental/data/NodeLayoutData.java
@@ -43,6 +43,8 @@ public class NodeLayoutData implements IContainerLayoutData, IConnectable {
 
     private INodeStyle style;
 
+    private boolean borderNode;
+
     private boolean changed;
 
     private boolean pinned;
@@ -126,6 +128,14 @@ public class NodeLayoutData implements IContainerLayoutData, IConnectable {
 
     public void setNodeType(String nodeType) {
         this.nodeType = nodeType;
+    }
+
+    public boolean isBorderNode() {
+        return borderNode;
+    }
+
+    public void setBorderNode(boolean borderNode) {
+        this.borderNode = borderNode;
     }
 
     @Override

--- a/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/incremental/provider/NodeSizeProvider.java
+++ b/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/incremental/provider/NodeSizeProvider.java
@@ -103,8 +103,12 @@ public class NodeSizeProvider {
         INodeStyle style = node.getStyle();
         if (style instanceof ImageNodeStyle) {
             Size imageSize = new ImageNodeStyleSizeProvider(this.imageSizeProvider).getSize((ImageNodeStyle) style);
-            width = imageSize.getWidth() + ELK_SIZE_DIFF;
-            height = imageSize.getHeight() + ELK_SIZE_DIFF;
+            width = imageSize.getWidth();
+            height = imageSize.getHeight();
+            if (!node.isBorderNode()) {
+                width += ELK_SIZE_DIFF;
+                height += ELK_SIZE_DIFF;
+            }
         } else if (NodeType.NODE_LIST_ITEM.equals(node.getNodeType())) {
             Size nodeItemLabelSize = node.getLabel().getTextBounds().getSize();
             width = nodeItemLabelSize.getWidth() + LayoutOptionValues.NODE_LIST_ELK_NODE_LABELS_PADDING_RIGHT + LayoutOptionValues.NODE_LIST_ELK_NODE_LABELS_PADDING_LEFT;


### PR DESCRIPTION
Signed-off-by: Charles Wu <camork1@gmail.com>

### Type of this PR 

- [x] Bug fix
- [ ] New feature or improvement
- [ ] Documentation
- [ ] Cleanup
- [ ] Test
- [ ] Build/Releng

### Issue(s)

The border node size  is computed incorrectly during incremental layout process.


### What does this PR do?

The border node no need to add padding size, So this PR remove this padding for border node

### Screenshot/screencast of this PR

Below is the screencast that move a node with three border nodes.

https://user-images.githubusercontent.com/19710731/141887023-3a671316-a85f-431d-8192-d923ccde406b.mov


### Potential side effects

...

### How to test this PR?

- [ ] Frontend Unit tests
- [ ] Backend Unit tests
- [ ] Cypress : please specify
- [ ] Manual Test : please specify

### Checklist

- [ ] I have read CONTRIBUTING carefully.
- [ ] I have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [ ] All my commits are signed-off (`-s`) with my mail address of my Eclipse Account.
- [ ] I have covered my changes by unit tests or integration tests or manual tests.
- [ ] All tests pass.
- [ ] I have updated the documentation accordingly
- [ ] New React components are availables in storybook
