### PR TITLE
Fix border node position computation

### DIFF
--- a/backend/sirius-web-diagrams-layout-api/src/main/java/org/eclipse/sirius/web/diagrams/layout/api/ILayoutService.java
+++ b/backend/sirius-web-diagrams-layout-api/src/main/java/org/eclipse/sirius/web/diagrams/layout/api/ILayoutService.java
@@ -16,6 +16,7 @@ import java.util.Optional;
 
 import org.eclipse.sirius.web.core.api.IEditingContext;
 import org.eclipse.sirius.web.diagrams.Diagram;
+import org.eclipse.sirius.web.diagrams.Node;
 import org.eclipse.sirius.web.diagrams.events.IDiagramEvent;
 
 /**
@@ -25,6 +26,11 @@ import org.eclipse.sirius.web.diagrams.events.IDiagramEvent;
  */
 public interface ILayoutService {
     Diagram layout(IEditingContext editingContext, Diagram diagram);
+
+    /**
+     * Layout the specified node in the diagram.
+     */
+    Node layoutNode(IEditingContext editingContext, Diagram diagram, Node node);
 
     /**
      * A partial layout that layouts only impacted elements.
@@ -50,6 +56,11 @@ public interface ILayoutService {
         @Override
         public Diagram layout(IEditingContext editingContext, Diagram diagram) {
             return diagram;
+        }
+
+        @Override
+        public Node layoutNode(IEditingContext editingContext, Diagram diagram, Node node) {
+            return null;
         }
 
         @Override

--- a/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/ELKDiagramConverter.java
+++ b/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/ELKDiagramConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Obeo.
+ * Copyright (c) 2019, 2021 Obeo and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -78,6 +78,22 @@ public class ELKDiagramConverter {
         this.imageNodeStyleSizeProvider = new ImageNodeStyleSizeProvider(this.imageSizeProvider);
     }
 
+    public ELKConvertedDiagram convert(Diagram diagram, Node parentNode) {
+        List<Node> childNodes = this.initializeNodes(List.of(parentNode));
+
+        Diagram initializedDiagram = Diagram.newDiagram(diagram)
+                .nodes(childNodes)
+                .build();
+
+        ElkNode elkDiagram = this.convertDiagram(initializedDiagram);
+
+        Map<String, ElkGraphElement> id2ElkGraphElements = new HashMap<>();
+        Map<String, ElkConnectableShape> connectableShapeIndex = new LinkedHashMap<>();
+        initializedDiagram.getNodes().forEach(node -> this.convertNode(node, elkDiagram, connectableShapeIndex, id2ElkGraphElements));
+
+        return new ELKConvertedDiagram(elkDiagram, id2ElkGraphElements);
+    }
+
     public ELKConvertedDiagram convert(Diagram diagram) {
         Diagram initializedDiagram = this.initializeDiagram(diagram);
 
@@ -85,8 +101,8 @@ public class ELKDiagramConverter {
 
         Map<String, ElkGraphElement> id2ElkGraphElements = new HashMap<>();
         Map<String, ElkConnectableShape> connectableShapeIndex = new LinkedHashMap<>();
-        initializedDiagram.getNodes().stream().forEach(node -> this.convertNode(node, elkDiagram, connectableShapeIndex, id2ElkGraphElements));
-        initializedDiagram.getEdges().stream().forEach(edge -> this.convertEdge(edge, elkDiagram, connectableShapeIndex, id2ElkGraphElements));
+        initializedDiagram.getNodes().forEach(node -> this.convertNode(node, elkDiagram, connectableShapeIndex, id2ElkGraphElements));
+        initializedDiagram.getEdges().forEach(edge -> this.convertEdge(edge, elkDiagram, connectableShapeIndex, id2ElkGraphElements));
 
         return new ELKConvertedDiagram(elkDiagram, id2ElkGraphElements);
     }


### PR DESCRIPTION
### Type of this PR 

- [x] Bug fix
- [ ] New feature or improvement
- [ ] Documentation
- [ ] Cleanup
- [ ] Test
- [ ] Build/Releng

### Issue(s)

The border node and child nodes are not properly layout after the creation. The border node position should be related to the parent node but it was related to the diagram position.

### What does this PR do?

When a node has an undefined position, use the ELK to layout its contents.

### Screenshot/screencast of this PR

...
 

### Potential side effects

...

### How to test this PR?

- [ ] Frontend Unit tests
- [ ] Backend Unit tests
- [ ] Cypress : please specify
- [ ] Manual Test : please specify

### Checklist

- [ ] I have read CONTRIBUTING carefully.
- [ ] I have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [ ] All my commits are signed-off (`-s`) with my mail address of my Eclipse Account.
- [ ] I have covered my changes by unit tests or integration tests or manual tests.
- [ ] All tests pass.
- [ ] I have updated the documentation accordingly
- [ ] New React components are availables in storybook
