### PR TITLE
Add image node sides

### DIFF
--- a/backend/sirius-web-compatibility/src/main/java/org/eclipse/sirius/web/compat/diagrams/ImageNodeSidesConverter.java
+++ b/backend/sirius-web-compatibility/src/main/java/org/eclipse/sirius/web/compat/diagrams/ImageNodeSidesConverter.java
@@ -1,0 +1,29 @@
+package org.eclipse.sirius.web.compat.diagrams;
+
+import com.google.common.collect.Lists;
+
+import java.util.List;
+
+import org.eclipse.sirius.diagram.description.style.Side;
+import org.eclipse.sirius.web.diagrams.ImageNodeSide;
+
+/**
+ * Used to convert Sirius image node forbidden sides
+ * to Sirius Web image node authorized sides.
+ *
+ * @author Koi-tsk
+ */
+public class ImageNodeSidesConverter {
+
+    public List<ImageNodeSide> getAuthorizedSides(List<Side> forbiddenSides) {
+        List<ImageNodeSide> portSides = Lists.newArrayList(ImageNodeSide.NORTH, ImageNodeSide.EAST, ImageNodeSide.SOUTH, ImageNodeSide.WEST);
+        if (forbiddenSides.isEmpty()) {
+            return List.of(ImageNodeSide.UNDEFINED);
+        }
+        for (Side side : forbiddenSides) {
+            portSides.remove(ImageNodeSide.valueOf(side.getName()));
+        }
+        return portSides;
+    }
+
+}

--- a/backend/sirius-web-compatibility/src/main/java/org/eclipse/sirius/web/compat/diagrams/WorkspaceImageDescriptionConverter.java
+++ b/backend/sirius-web-compatibility/src/main/java/org/eclipse/sirius/web/compat/diagrams/WorkspaceImageDescriptionConverter.java
@@ -61,6 +61,7 @@ public class WorkspaceImageDescriptionConverter {
         return ImageNodeStyle.newImageNodeStyle()
                 .imageURL(workspacePath.substring(workspacePath.indexOf('/', 1)))
                 .scalingFactor(scalingFactor)
+                .nodeSides(new ImageNodeSidesConverter().getAuthorizedSides(workspaceImageDescription.getForbiddenSides()))
                 .build();
         // @formatter:on
     }

--- a/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/ELKDiagramConverter.java
+++ b/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/ELKDiagramConverter.java
@@ -23,6 +23,8 @@ import java.util.Optional;
 
 import org.eclipse.elk.core.options.CoreOptions;
 import org.eclipse.elk.core.options.EdgeLabelPlacement;
+import org.eclipse.elk.core.options.PortConstraints;
+import org.eclipse.elk.core.options.PortSide;
 import org.eclipse.elk.graph.ElkConnectableShape;
 import org.eclipse.elk.graph.ElkEdge;
 import org.eclipse.elk.graph.ElkGraphElement;
@@ -336,6 +338,7 @@ public class ELKDiagramConverter {
 
             Size imageSize = this.imageNodeStyleSizeProvider.getSize(imageNodeStyle);
             elkImage.setDimensions(imageSize.getWidth(), imageSize.getHeight());
+            elkNode.setProperty(CoreOptions.PORT_CONSTRAINTS, PortConstraints.FIXED_ORDER);
 
             elkImage.setParent(elkNode);
         }
@@ -365,6 +368,7 @@ public class ELKDiagramConverter {
         if (borderNode.getStyle() instanceof ImageNodeStyle) {
             Size imageSize = this.imageNodeStyleSizeProvider.getSize((ImageNodeStyle) borderNode.getStyle());
             elkPort.setDimensions(imageSize.getWidth(), imageSize.getHeight());
+            ((ImageNodeStyle)borderNode.getStyle()).getImageNodeSides().forEach(imageNodeSide -> elkPort.setProperty(CoreOptions.PORT_SIDE, PortSide.valueOf(imageNodeSide.name())));
         }
 
         this.convertLabel(borderNode.getLabel(), textBounds, elkPort, id2ElkGraphElements, null);

--- a/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/ImageNodeSide.java
+++ b/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/ImageNodeSide.java
@@ -1,0 +1,10 @@
+package org.eclipse.sirius.web.diagrams;
+
+/**
+ * All image node sides
+ *
+ * @author Koi-tsk
+ */
+public enum ImageNodeSide {
+    UNDEFINED, NORTH, EAST, SOUTH, WEST;
+}

--- a/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/ImageNodeStyle.java
+++ b/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/ImageNodeStyle.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Obeo.
+ * Copyright (c) 2019, 2021 Obeo and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -13,6 +13,7 @@
 package org.eclipse.sirius.web.diagrams;
 
 import java.text.MessageFormat;
+import java.util.List;
 import java.util.Objects;
 
 import org.eclipse.sirius.web.annotations.Immutable;
@@ -33,6 +34,8 @@ public final class ImageNodeStyle implements INodeStyle {
 
     private int scalingFactor;
 
+    private List<ImageNodeSide> imageNodeSides;
+
     private ImageNodeStyle() {
         // Prevent instantiation
     }
@@ -49,6 +52,10 @@ public final class ImageNodeStyle implements INodeStyle {
 
     public static Builder newImageNodeStyle() {
         return new Builder();
+    }
+
+    public List<ImageNodeSide> getImageNodeSides() {
+        return imageNodeSides;
     }
 
     @Override
@@ -68,6 +75,8 @@ public final class ImageNodeStyle implements INodeStyle {
 
         private int scalingFactor;
 
+        private List<ImageNodeSide> imageNodeSides;
+
         private Builder() {
             // Prevent instantiation
         }
@@ -82,10 +91,16 @@ public final class ImageNodeStyle implements INodeStyle {
             return this;
         }
 
+        public Builder nodeSides(List<ImageNodeSide> nodeSides) {
+            this.imageNodeSides = Objects.requireNonNull(nodeSides);
+            return this;
+        }
+
         public ImageNodeStyle build() {
             ImageNodeStyle style = new ImageNodeStyle();
             style.imageURL = Objects.requireNonNull(this.imageURL);
             style.scalingFactor = Objects.requireNonNull(this.scalingFactor);
+            style.imageNodeSides = Objects.requireNonNull(this.imageNodeSides);
             return style;
         }
     }


### PR DESCRIPTION
Signed-off-by: Koi-tsk <337023856@qq.com>

### Type of this PR 

- [ ] Bug fix
- [x] New feature or improvement
- [ ] Documentation
- [ ] Cleanup
- [ ] Test
- [ ] Build/Releng

### Issue(s)

I check the Bordered-Image-Advanced-Authorized Sides parameter in the sirius model,but it was not loaded by the web.

### What does this PR do?

Load the image node sides parameter of the sirius model to the web and use in elk.

### Screenshot/screencast of this PR


![微信图片_20211119143357](https://user-images.githubusercontent.com/49364035/142576393-2f2e45b8-a331-438b-8f96-9e3d2a26f2a0.png)
 

### Potential side effects

...

### How to test this PR?

- [ ] Frontend Unit tests
- [ ] Backend Unit tests
- [ ] Cypress : please specify
- [ ] Manual Test : please specify

### Checklist

- [ ] I have read CONTRIBUTING carefully.
- [ ] I have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [ ] All my commits are signed-off (`-s`) with my mail address of my Eclipse Account.
- [ ] I have covered my changes by unit tests or integration tests or manual tests.
- [ ] All tests pass.
- [ ] I have updated the documentation accordingly
- [ ] New React components are availables in storybook
