### PR TITLE
[releng] Add script to check license compatibility

### DIFF
--- a/scripts/check-licenses
+++ b/scripts/check-licenses
@@ -1,0 +1,31 @@
+#!/bin/sh
+#
+# Copyright (c) 2021 Obeo.
+# This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     Obeo - initial API and implementation
+
+DASH_JAR="$1"
+
+[ -f "$DASH_JAR" ] || {
+    echo "Usage: $0 path/to/org.eclipse.dash.licenses.jar"
+    echo "See https://github.com/eclipse/dash-licenses"
+    exit 1
+}
+
+ROOT_DIR="$(dirname "$0")/.."
+
+echo "Checking backend dependencies..."
+MAVEN_DEPS=$(mktemp)
+mvn -q -B verify -f "$ROOT_DIR/backend/pom.xml" dependency:list -DskipTests -Dmaven.javadoc.skip=true -DappendOutput=true -DoutputFile="$MAVEN_DEPS"
+java -jar "$DASH_JAR" "$MAVEN_DEPS"
+
+echo
+echo "Checking frontend dependencies..."
+java -jar "$DASH_JAR" "$ROOT_DIR/frontend/package-lock.json"


### PR DESCRIPTION
Example output:
```
Checking backend dependencies...
[main] INFO Querying Eclipse Foundation for license data for 187 items.
[main] INFO Found 142 items.
[main] INFO Querying ClearlyDefined for license data for 45 items.
[main] INFO Found 45 items.
Vetted license information was found for all content. No further investigation is required.

Checking frontend dependencies...
[main] INFO Querying Eclipse Foundation for license data for 745 items.
[main] INFO Found 33 items.
[main] INFO Querying ClearlyDefined for license data for 713 items.
[main] INFO Found 713 items.
License information could not be automatically verified for the following content:

npm/npmjs/-/jest-junit-reporter/1.1.0
npm/npmjs/-/jsdom/16.7.0
npm/npmjs/-/typescript/4.3.5
npm/npmjs/-/xstate/4.23.1
npm/npmjs/@xstate/react/1.5.1

This content is either not correctly mapped by the system, or requires review.
```

All the frontend dependencies which are not verified automatically are fine:
* npm/npmjs/-/jest-junit-reporter/1.1.0: [MIT](https://www.npmjs.com/package/jest-junit-reporter/v/1.1.0)
* npm/npmjs/-/jsdom/16.7.0: [MIT](https://www.npmjs.com/package/jsdom/v/16.7.0)
* npm/npmjs/-/typescript/4.3.5: [Apache-2.0](https://www.npmjs.com/package/typescript/v/4.3.5)
* npm/npmjs/-/xstate/4.23.1 [MIT](https://www.npmjs.com/package/xstate/v/4.23.1)
* npm/npmjs/@xstate/react/1.5.1  [MIT](https://www.npmjs.com/package/@xstate/react/v/1.5.1)

The JAR needed by the script can be built from https://github.com/eclipse/dash-licenses:

```sh
git clone git@github.com:eclipse/dash-licenses.git
cd dash-license
mvn clean install
cp core/target/org.eclipse.dash.licenses-0.0.1-SNAPSHOT.jar ~
```
