### PR TITLE
[fix] Add support for property groups defined in a different category

### DIFF
--- a/backend/sirius-web-compatibility/src/main/java/org/eclipse/sirius/web/compat/forms/ViewExtensionDescriptionConverter.java
+++ b/backend/sirius-web-compatibility/src/main/java/org/eclipse/sirius/web/compat/forms/ViewExtensionDescriptionConverter.java
@@ -77,7 +77,8 @@ public class ViewExtensionDescriptionConverter implements IViewExtensionDescript
         // @formatter:off
         Map<org.eclipse.sirius.properties.GroupDescription, GroupDescription> siriusGroup2SiriusWebGroup = new HashMap<>();
         List<GroupDescription> groupDescriptions = viewExtensionDescription.getCategories().stream()
-                .flatMap(category -> category.getGroups().stream())
+                .flatMap(category -> category.getPages().stream())
+                .flatMap(page -> page.getGroups().stream())
                 .map(groupDescription -> groupDescriptionConverter.convert(groupDescription, siriusGroup2SiriusWebGroup))
                 .collect(Collectors.toList());
 


### PR DESCRIPTION
Signed-off-by: Denis Nikiforov <denis.nikif@gmail.com>

### Type of this PR 

- [x] Bug fix
- [ ] New feature or improvement
- [ ] Documentation
- [ ] Cleanup
- [ ] Test
- [ ] Build/Releng

### Issue(s)

Property pages in our odesign files use property groups defined in a separate categories. We get NPE for such property groups.

### What does this PR do?

It allows to use property groups defined in a separate categories.

### Screenshot/screencast of this PR

No.

### Potential side effects

No.

### How to test this PR?

- [ ] Frontend Unit tests
- [ ] Backend Unit tests
- [ ] Cypress : please specify
- [x] Manual Test : use odesign file with property pages and property groups defined in a separate categories

### Checklist

- [x] I have read CONTRIBUTING carefully.
- [x] I have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All my commits are signed-off (`-s`) with my mail address of my Eclipse Account.
- [ ] I have covered my changes by unit tests or integration tests or manual tests.
- [ ] All tests pass.
- [ ] I have updated the documentation accordingly
- [ ] New React components are availables in storybook
