### PR TITLE
[852] Fix regression on label ids

### DIFF
--- a/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/components/LabelComponent.java
+++ b/backend/sirius-web-diagrams/src/main/java/org/eclipse/sirius/web/diagrams/components/LabelComponent.java
@@ -14,6 +14,7 @@ package org.eclipse.sirius.web.diagrams.components;
 
 import java.util.Objects;
 import java.util.Optional;
+import java.util.UUID;
 
 import org.eclipse.sirius.web.components.Element;
 import org.eclipse.sirius.web.components.IComponent;
@@ -45,7 +46,8 @@ public class LabelComponent implements IComponent {
         LabelDescription labelDescription = this.props.getLabelDescription();
         Optional<Label> optionalPreviousLabel = this.props.getPreviousLabel();
         String type = this.props.getType();
-        String id = labelDescription.getIdProvider().apply(variableManager);
+        String idFromProvider = labelDescription.getIdProvider().apply(variableManager);
+        String id = UUID.nameUUIDFromBytes(idFromProvider.getBytes()).toString();
         String text = labelDescription.getTextProvider().apply(variableManager);
 
         LabelStyleDescription labelStyleDescription = labelDescription.getStyleDescriptionProvider().apply(variableManager);

--- a/backend/sirius-web-diagrams/src/test/java/org/eclipse/sirius/web/diagrams/renderer/DiagramRendererNodeTests.java
+++ b/backend/sirius-web-diagrams/src/test/java/org/eclipse/sirius/web/diagrams/renderer/DiagramRendererNodeTests.java
@@ -95,7 +95,7 @@ public class DiagramRendererNodeTests {
         assertThat(diagram.getNodes()).extracting(Node::getBorderNodes).allMatch(List::isEmpty);
         assertThat(diagram.getNodes()).extracting(Node::getStyle).allMatch(s -> s instanceof RectangularNodeStyle);
         assertThat(diagram.getNodes()).extracting(Node::getSize).allMatch(s -> s.getHeight() == -1 && s.getWidth() == -1);
-        assertThat(diagram.getNodes()).extracting(Node::getLabel).extracting(Label::getId).allMatch(LABEL_ID::equals);
+        assertThat(diagram.getNodes()).extracting(Node::getLabel).extracting(Label::getId).allMatch(id -> UUID.nameUUIDFromBytes(LABEL_ID.getBytes()).toString().equals(id));
         assertThat(diagram.getNodes()).extracting(Node::getLabel).extracting(Label::getText).allMatch(text -> LABEL_TEXT.equals(text));
         assertThat(diagram.getNodes()).extracting(Node::getLabel).extracting(Label::getStyle).extracting(LabelStyle::getColor).allMatch(color -> LABEL_COLOR.equals(color));
         assertThat(diagram.getNodes()).extracting(Node::getLabel).extracting(Label::getStyle).extracting(LabelStyle::getFontSize).allMatch(size -> LABEL_FONT_SIZE == size);
@@ -132,7 +132,7 @@ public class DiagramRendererNodeTests {
         assertThat(diagram.getNodes()).extracting(Node::getBorderNodes).allMatch(List::isEmpty);
         assertThat(diagram.getNodes()).extracting(Node::getStyle).allMatch(s -> s instanceof RectangularNodeStyle);
         assertThat(diagram.getNodes()).extracting(Node::getSize).allMatch(s -> s.getHeight() == 200 && s.getWidth() == 10);
-        assertThat(diagram.getNodes()).extracting(Node::getLabel).extracting(Label::getId).allMatch(LABEL_ID::equals);
+        assertThat(diagram.getNodes()).extracting(Node::getLabel).extracting(Label::getId).allMatch(id -> UUID.nameUUIDFromBytes(LABEL_ID.getBytes()).toString().equals(id));
         assertThat(diagram.getNodes()).extracting(Node::getLabel).extracting(Label::getText).allMatch(text -> LABEL_TEXT.equals(text));
         assertThat(diagram.getNodes()).extracting(Node::getLabel).extracting(Label::getStyle).extracting(LabelStyle::getColor).allMatch(color -> LABEL_COLOR.equals(color));
         assertThat(diagram.getNodes()).extracting(Node::getLabel).extracting(Label::getStyle).extracting(LabelStyle::getFontSize).allMatch(size -> LABEL_FONT_SIZE == size);

--- a/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/DiagramQueryService.java
+++ b/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/DiagramQueryService.java
@@ -15,7 +15,6 @@ package org.eclipse.sirius.web.spring.collaborative.diagrams;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.UUID;
 import java.util.function.Predicate;
 
 import org.eclipse.sirius.web.diagrams.Diagram;
@@ -38,7 +37,7 @@ public class DiagramQueryService implements IDiagramQueryService {
     }
 
     @Override
-    public Optional<Node> findNodeByLabelId(Diagram diagram, UUID labelId) {
+    public Optional<Node> findNodeByLabelId(Diagram diagram, String labelId) {
         return this.findNode(node -> Objects.equals(node.getLabel().getId(), labelId), diagram.getNodes());
     }
 
@@ -63,7 +62,7 @@ public class DiagramQueryService implements IDiagramQueryService {
     }
 
     @Override
-    public Optional<Edge> findEdgeByLabelId(Diagram diagram, UUID labelId) {
+    public Optional<Edge> findEdgeByLabelId(Diagram diagram, String labelId) {
         return diagram.getEdges().stream().filter(edge -> Objects.equals(edge.getCenterLabel().getId(), labelId)).findFirst();
     }
 

--- a/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/api/IDiagramQueryService.java
+++ b/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/api/IDiagramQueryService.java
@@ -13,7 +13,6 @@
 package org.eclipse.sirius.web.spring.collaborative.diagrams.api;
 
 import java.util.Optional;
-import java.util.UUID;
 
 import org.eclipse.sirius.web.diagrams.Diagram;
 import org.eclipse.sirius.web.diagrams.Edge;
@@ -28,10 +27,10 @@ public interface IDiagramQueryService {
 
     Optional<Node> findNodeById(Diagram diagram, String nodeId);
 
-    Optional<Node> findNodeByLabelId(Diagram diagram, UUID labelId);
+    Optional<Node> findNodeByLabelId(Diagram diagram, String labelId);
 
     Optional<Edge> findEdgeById(Diagram diagram, String edgeId);
 
-    Optional<Edge> findEdgeByLabelId(Diagram diagram, UUID labelId);
+    Optional<Edge> findEdgeByLabelId(Diagram diagram, String labelId);
 
 }

--- a/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/handlers/EditLabelEventHandler.java
+++ b/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/handlers/EditLabelEventHandler.java
@@ -14,7 +14,6 @@ package org.eclipse.sirius.web.spring.collaborative.diagrams.handlers;
 
 import java.util.Objects;
 import java.util.Optional;
-import java.util.UUID;
 
 import org.eclipse.sirius.web.core.api.ErrorPayload;
 import org.eclipse.sirius.web.core.api.IEditingContext;
@@ -101,14 +100,14 @@ public class EditLabelEventHandler implements IDiagramEventHandler {
         if (diagramInput instanceof EditLabelInput) {
             EditLabelInput input = (EditLabelInput) diagramInput;
             Diagram diagram = diagramContext.getDiagram();
-            var node = this.diagramQueryService.findNodeByLabelId(diagram, UUID.fromString(input.getLabelId()));
+            var node = this.diagramQueryService.findNodeByLabelId(diagram, input.getLabelId());
             if (node.isPresent()) {
                 this.invokeDirectEditTool(node.get(), editingContext, diagram, input.getNewText());
 
                 payload = new EditLabelSuccessPayload(diagramInput.getId(), diagram);
                 changeDescription = new ChangeDescription(ChangeKind.SEMANTIC_CHANGE, diagramInput.getRepresentationId(), diagramInput);
             } else {
-                var edge = this.diagramQueryService.findEdgeByLabelId(diagram, UUID.fromString(input.getLabelId()));
+                var edge = this.diagramQueryService.findEdgeByLabelId(diagram, input.getLabelId());
                 if (edge.isPresent()) {
                     this.invokeDirectEditTool(edge.get(), editingContext, diagram, input.getNewText());
 


### PR DESCRIPTION
Label ids (computed in
AbstractNodeMappingConverter.getLabelIdProvider()) have a suffix
appended to their UUID, so we can not take the resulting string and
parse it directly.

Bug: https://github.com/eclipse-sirius/sirius-components/issues/852
Signed-off-by: Pierre-Charles David <pierre-charles.david@obeo.fr>

### Type of this PR 

- [x] Bug fix
- [ ] New feature or improvement
- [ ] Documentation
- [ ] Cleanup
- [ ] Test
- [ ] Build/Releng

### Issue(s)

...

### What does this PR do?

...

### Screenshot/screencast of this PR

...
 

### Potential side effects

...

### How to test this PR?

- [ ] Frontend Unit tests
- [ ] Backend Unit tests
- [ ] Cypress : please specify
- [ ] Manual Test : please specify

### Checklist

- [x] I have read CONTRIBUTING carefully.
- [x] I have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All my commits are signed-off (`-s`) with my mail address of my Eclipse Account.
- [ ] I have covered my changes by unit tests or integration tests or manual tests.
- [ ] All tests pass.
- [ ] I have updated the documentation accordingly
- [ ] New React components are availables in storybook
