### PR TITLE
View DSL: add support for computed size for nodes

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -20,6 +20,10 @@
 
 === New features
 
+- https://github.com/eclipse-sirius/sirius-components/issues/726[#726] [view] Nodes can now have a dynamically computed size (using `sizeComputationExpression`) which depends on the current state of the semantic model.
+If the expression is present and produces a positive integer, it will be used as both the width and height of the node, in pixels.
+Currently it is not possible to compute different values for width and height.
+
 === Improvements
 
 - https://github.com/eclipse-sirius/sirius-components/issues/871[#871] [core] An `IEditingContextEventProcessorExecutorServiceProvider` can be given to the `EditingContextEventProcessor` in order to customize the `ExecutorService` which will be used to handle the processing of the `IInput` received. This will allow consumers to change the thread management policy of Sirius Components

--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/view/ViewPropertiesConfigurer.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/view/ViewPropertiesConfigurer.java
@@ -87,6 +87,10 @@ public class ViewPropertiesConfigurer implements IPropertiesDescriptionRegistryC
                                                                                                      .orElse(null);
 
         List<AbstractControlDescription> controls = List.of(
+                this.createTextField("nodestyle.sizeExpression", "Size Expression", //$NON-NLS-1$ //$NON-NLS-2$
+                        style -> ((NodeStyle) style).getSizeComputationExpression(),
+                        (style, newSizeExpression) -> ((NodeStyle) style).setSizeComputationExpression(newSizeExpression),
+                        ViewPackage.Literals.NODE_STYLE__SIZE_COMPUTATION_EXPRESSION),
                 this.createTextField("conditionalnodestyle.condition", "Condition", //$NON-NLS-1$ //$NON-NLS-2$
                         style -> ((ConditionalNodeStyle) style).getCondition(),
                         (style, newCondition) -> ((ConditionalNodeStyle) style).setCondition(newCondition),
@@ -183,6 +187,10 @@ public class ViewPropertiesConfigurer implements IPropertiesDescriptionRegistryC
                                                                                                      .orElse(null);
 
         List<AbstractControlDescription> controls = List.of(
+                this.createTextField("nodestyle.sizeExpression", "Size Expression", //$NON-NLS-1$ //$NON-NLS-2$
+                        style -> ((NodeStyle) style).getSizeComputationExpression(),
+                        (style, newSizeExpression) -> ((NodeStyle) style).setSizeComputationExpression(newSizeExpression),
+                        ViewPackage.Literals.NODE_STYLE__SIZE_COMPUTATION_EXPRESSION),
                 this.createTextField("nodestyle.labelColor", "Label Color", //$NON-NLS-1$ //$NON-NLS-2$
                         style -> ((NodeStyle) style).getLabelColor(),
                         (style, newLabelColor) -> ((NodeStyle) style).setLabelColor(newLabelColor),

--- a/backend/sirius-web-view-edit/src/main/java/org/eclipse/sirius/web/view/provider/ConditionalNodeStyleItemProvider.java
+++ b/backend/sirius-web-view-edit/src/main/java/org/eclipse/sirius/web/view/provider/ConditionalNodeStyleItemProvider.java
@@ -62,6 +62,7 @@ public class ConditionalNodeStyleItemProvider extends ConditionalItemProvider {
             this.addBoldPropertyDescriptor(object);
             this.addUnderlinePropertyDescriptor(object);
             this.addStrikeThroughPropertyDescriptor(object);
+            this.addSizeComputationExpressionPropertyDescriptor(object);
         }
         return this.itemPropertyDescriptors;
     }
@@ -211,6 +212,19 @@ public class ConditionalNodeStyleItemProvider extends ConditionalItemProvider {
     }
 
     /**
+     * This adds a property descriptor for the Size Computation Expression feature. <!-- begin-user-doc --> <!--
+     * end-user-doc -->
+     *
+     * @generated
+     */
+    protected void addSizeComputationExpressionPropertyDescriptor(Object object) {
+        this.itemPropertyDescriptors.add(this.createItemPropertyDescriptor(((ComposeableAdapterFactory) this.adapterFactory).getRootAdapterFactory(), this.getResourceLocator(),
+                this.getString("_UI_NodeStyle_sizeComputationExpression_feature"), //$NON-NLS-1$
+                this.getString("_UI_PropertyDescriptor_description", "_UI_NodeStyle_sizeComputationExpression_feature", "_UI_NodeStyle_type"), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+                ViewPackage.Literals.NODE_STYLE__SIZE_COMPUTATION_EXPRESSION, true, false, false, ItemPropertyDescriptor.GENERIC_VALUE_IMAGE, null, null));
+    }
+
+    /**
      * This returns ConditionalNodeStyle.gif. <!-- begin-user-doc --> <!-- end-user-doc -->
      *
      * @generated NOT
@@ -266,6 +280,7 @@ public class ConditionalNodeStyleItemProvider extends ConditionalItemProvider {
         case ViewPackage.CONDITIONAL_NODE_STYLE__BOLD:
         case ViewPackage.CONDITIONAL_NODE_STYLE__UNDERLINE:
         case ViewPackage.CONDITIONAL_NODE_STYLE__STRIKE_THROUGH:
+        case ViewPackage.CONDITIONAL_NODE_STYLE__SIZE_COMPUTATION_EXPRESSION:
             this.fireNotifyChanged(new ViewerNotification(notification, notification.getNotifier(), false, true));
             return;
         }

--- a/backend/sirius-web-view-edit/src/main/java/org/eclipse/sirius/web/view/provider/NodeStyleItemProvider.java
+++ b/backend/sirius-web-view-edit/src/main/java/org/eclipse/sirius/web/view/provider/NodeStyleItemProvider.java
@@ -59,6 +59,7 @@ public class NodeStyleItemProvider extends StyleItemProvider {
             this.addBoldPropertyDescriptor(object);
             this.addUnderlinePropertyDescriptor(object);
             this.addStrikeThroughPropertyDescriptor(object);
+            this.addSizeComputationExpressionPropertyDescriptor(object);
         }
         return this.itemPropertyDescriptors;
     }
@@ -172,6 +173,19 @@ public class NodeStyleItemProvider extends StyleItemProvider {
     }
 
     /**
+     * This adds a property descriptor for the Size Computation Expression feature. <!-- begin-user-doc --> <!--
+     * end-user-doc -->
+     *
+     * @generated
+     */
+    protected void addSizeComputationExpressionPropertyDescriptor(Object object) {
+        this.itemPropertyDescriptors.add(this.createItemPropertyDescriptor(((ComposeableAdapterFactory) this.adapterFactory).getRootAdapterFactory(), this.getResourceLocator(),
+                this.getString("_UI_NodeStyle_sizeComputationExpression_feature"), //$NON-NLS-1$
+                this.getString("_UI_PropertyDescriptor_description", "_UI_NodeStyle_sizeComputationExpression_feature", "_UI_NodeStyle_type"), //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+                ViewPackage.Literals.NODE_STYLE__SIZE_COMPUTATION_EXPRESSION, true, false, false, ItemPropertyDescriptor.GENERIC_VALUE_IMAGE, null, null));
+    }
+
+    /**
      * This returns NodeStyle.gif. <!-- begin-user-doc --> <!-- end-user-doc -->
      *
      * @generated NOT
@@ -224,6 +238,7 @@ public class NodeStyleItemProvider extends StyleItemProvider {
         case ViewPackage.NODE_STYLE__BOLD:
         case ViewPackage.NODE_STYLE__UNDERLINE:
         case ViewPackage.NODE_STYLE__STRIKE_THROUGH:
+        case ViewPackage.NODE_STYLE__SIZE_COMPUTATION_EXPRESSION:
             this.fireNotifyChanged(new ViewerNotification(notification, notification.getNotifier(), false, true));
             return;
         }

--- a/backend/sirius-web-view-edit/src/main/resources/plugin.properties
+++ b/backend/sirius-web-view-edit/src/main/resources/plugin.properties
@@ -85,6 +85,7 @@ _UI_NodeStyle_italic_feature = Italic
 _UI_NodeStyle_bold_feature = Bold
 _UI_NodeStyle_underline_feature = Underline
 _UI_NodeStyle_strikeThrough_feature = Strike Through
+_UI_NodeStyle_sizeComputationExpression_feature = Size Computation Expression
 _UI_EdgeStyle_lineStyle_feature = Line Style
 _UI_EdgeStyle_sourceArrowStyle_feature = Source Arrow Style
 _UI_EdgeStyle_targetArrowStyle_feature = Target Arrow Style

--- a/backend/sirius-web-view/src/main/java/org/eclipse/sirius/web/view/NodeStyle.java
+++ b/backend/sirius-web-view/src/main/java/org/eclipse/sirius/web/view/NodeStyle.java
@@ -28,6 +28,8 @@ package org.eclipse.sirius.web.view;
  * <li>{@link org.eclipse.sirius.web.view.NodeStyle#isBold <em>Bold</em>}</li>
  * <li>{@link org.eclipse.sirius.web.view.NodeStyle#isUnderline <em>Underline</em>}</li>
  * <li>{@link org.eclipse.sirius.web.view.NodeStyle#isStrikeThrough <em>Strike Through</em>}</li>
+ * <li>{@link org.eclipse.sirius.web.view.NodeStyle#getSizeComputationExpression <em>Size Computation
+ * Expression</em>}</li>
  * </ul>
  *
  * @see org.eclipse.sirius.web.view.ViewPackage#getNodeStyle()
@@ -240,4 +242,27 @@ public interface NodeStyle extends Style {
      * @generated
      */
     void setStrikeThrough(boolean value);
+
+    /**
+     * Returns the value of the '<em><b>Size Computation Expression</b></em>' attribute. The default value is
+     * <code>"1"</code>. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @return the value of the '<em>Size Computation Expression</em>' attribute.
+     * @see #setSizeComputationExpression(String)
+     * @see org.eclipse.sirius.web.view.ViewPackage#getNodeStyle_SizeComputationExpression()
+     * @model default="1"
+     * @generated
+     */
+    String getSizeComputationExpression();
+
+    /**
+     * Sets the value of the '{@link org.eclipse.sirius.web.view.NodeStyle#getSizeComputationExpression <em>Size
+     * Computation Expression</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @param value
+     *            the new value of the '<em>Size Computation Expression</em>' attribute.
+     * @see #getSizeComputationExpression()
+     * @generated
+     */
+    void setSizeComputationExpression(String value);
 } // NodeStyle

--- a/backend/sirius-web-view/src/main/java/org/eclipse/sirius/web/view/ViewPackage.java
+++ b/backend/sirius-web-view/src/main/java/org/eclipse/sirius/web/view/ViewPackage.java
@@ -732,13 +732,22 @@ public interface ViewPackage extends EPackage {
     int NODE_STYLE__STRIKE_THROUGH = STYLE_FEATURE_COUNT + 8;
 
     /**
+     * The feature id for the '<em><b>Size Computation Expression</b></em>' attribute. <!-- begin-user-doc --> <!--
+     * end-user-doc -->
+     *
+     * @generated
+     * @ordered
+     */
+    int NODE_STYLE__SIZE_COMPUTATION_EXPRESSION = STYLE_FEATURE_COUNT + 9;
+
+    /**
      * The number of structural features of the '<em>Node Style</em>' class. <!-- begin-user-doc --> <!-- end-user-doc
      * -->
      *
      * @generated
      * @ordered
      */
-    int NODE_STYLE_FEATURE_COUNT = STYLE_FEATURE_COUNT + 9;
+    int NODE_STYLE_FEATURE_COUNT = STYLE_FEATURE_COUNT + 10;
 
     /**
      * The number of operations of the '<em>Node Style</em>' class. <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -1498,13 +1507,22 @@ public interface ViewPackage extends EPackage {
     int CONDITIONAL_NODE_STYLE__STRIKE_THROUGH = CONDITIONAL_FEATURE_COUNT + 11;
 
     /**
+     * The feature id for the '<em><b>Size Computation Expression</b></em>' attribute. <!-- begin-user-doc --> <!--
+     * end-user-doc -->
+     *
+     * @generated
+     * @ordered
+     */
+    int CONDITIONAL_NODE_STYLE__SIZE_COMPUTATION_EXPRESSION = CONDITIONAL_FEATURE_COUNT + 12;
+
+    /**
      * The number of structural features of the '<em>Conditional Node Style</em>' class. <!-- begin-user-doc --> <!--
      * end-user-doc -->
      *
      * @generated
      * @ordered
      */
-    int CONDITIONAL_NODE_STYLE_FEATURE_COUNT = CONDITIONAL_FEATURE_COUNT + 12;
+    int CONDITIONAL_NODE_STYLE_FEATURE_COUNT = CONDITIONAL_FEATURE_COUNT + 13;
 
     /**
      * The number of operations of the '<em>Conditional Node Style</em>' class. <!-- begin-user-doc --> <!--
@@ -2125,6 +2143,18 @@ public interface ViewPackage extends EPackage {
      * @generated
      */
     EAttribute getNodeStyle_StrikeThrough();
+
+    /**
+     * Returns the meta object for the attribute
+     * '{@link org.eclipse.sirius.web.view.NodeStyle#getSizeComputationExpression <em>Size Computation
+     * Expression</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @return the meta object for the attribute '<em>Size Computation Expression</em>'.
+     * @see org.eclipse.sirius.web.view.NodeStyle#getSizeComputationExpression()
+     * @see #getNodeStyle()
+     * @generated
+     */
+    EAttribute getNodeStyle_SizeComputationExpression();
 
     /**
      * Returns the meta object for class '{@link org.eclipse.sirius.web.view.EdgeStyle <em>Edge Style</em>}'. <!--
@@ -2870,6 +2900,14 @@ public interface ViewPackage extends EPackage {
          * @generated
          */
         EAttribute NODE_STYLE__STRIKE_THROUGH = eINSTANCE.getNodeStyle_StrikeThrough();
+
+        /**
+         * The meta object literal for the '<em><b>Size Computation Expression</b></em>' attribute feature. <!--
+         * begin-user-doc --> <!-- end-user-doc -->
+         *
+         * @generated
+         */
+        EAttribute NODE_STYLE__SIZE_COMPUTATION_EXPRESSION = eINSTANCE.getNodeStyle_SizeComputationExpression();
 
         /**
          * The meta object literal for the '{@link org.eclipse.sirius.web.view.impl.EdgeStyleImpl <em>Edge Style</em>}'

--- a/backend/sirius-web-view/src/main/java/org/eclipse/sirius/web/view/impl/ConditionalNodeStyleImpl.java
+++ b/backend/sirius-web-view/src/main/java/org/eclipse/sirius/web/view/impl/ConditionalNodeStyleImpl.java
@@ -39,6 +39,8 @@ import org.eclipse.sirius.web.view.ViewPackage;
  * <li>{@link org.eclipse.sirius.web.view.impl.ConditionalNodeStyleImpl#isBold <em>Bold</em>}</li>
  * <li>{@link org.eclipse.sirius.web.view.impl.ConditionalNodeStyleImpl#isUnderline <em>Underline</em>}</li>
  * <li>{@link org.eclipse.sirius.web.view.impl.ConditionalNodeStyleImpl#isStrikeThrough <em>Strike Through</em>}</li>
+ * <li>{@link org.eclipse.sirius.web.view.impl.ConditionalNodeStyleImpl#getSizeComputationExpression <em>Size
+ * Computation Expression</em>}</li>
  * </ul>
  *
  * @generated
@@ -283,6 +285,26 @@ public class ConditionalNodeStyleImpl extends ConditionalImpl implements Conditi
      * @ordered
      */
     protected boolean strikeThrough = STRIKE_THROUGH_EDEFAULT;
+
+    /**
+     * The default value of the '{@link #getSizeComputationExpression() <em>Size Computation Expression</em>}'
+     * attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @see #getSizeComputationExpression()
+     * @generated
+     * @ordered
+     */
+    protected static final String SIZE_COMPUTATION_EXPRESSION_EDEFAULT = "1"; //$NON-NLS-1$
+
+    /**
+     * The cached value of the '{@link #getSizeComputationExpression() <em>Size Computation Expression</em>}' attribute.
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @see #getSizeComputationExpression()
+     * @generated
+     * @ordered
+     */
+    protected String sizeComputationExpression = SIZE_COMPUTATION_EXPRESSION_EDEFAULT;
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -585,6 +607,29 @@ public class ConditionalNodeStyleImpl extends ConditionalImpl implements Conditi
      * @generated
      */
     @Override
+    public String getSizeComputationExpression() {
+        return this.sizeComputationExpression;
+    }
+
+    /**
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     */
+    @Override
+    public void setSizeComputationExpression(String newSizeComputationExpression) {
+        String oldSizeComputationExpression = this.sizeComputationExpression;
+        this.sizeComputationExpression = newSizeComputationExpression;
+        if (this.eNotificationRequired())
+            this.eNotify(new ENotificationImpl(this, Notification.SET, ViewPackage.CONDITIONAL_NODE_STYLE__SIZE_COMPUTATION_EXPRESSION, oldSizeComputationExpression, this.sizeComputationExpression));
+    }
+
+    /**
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     */
+    @Override
     public Object eGet(int featureID, boolean resolve, boolean coreType) {
         switch (featureID) {
         case ViewPackage.CONDITIONAL_NODE_STYLE__COLOR:
@@ -611,6 +656,8 @@ public class ConditionalNodeStyleImpl extends ConditionalImpl implements Conditi
             return this.isUnderline();
         case ViewPackage.CONDITIONAL_NODE_STYLE__STRIKE_THROUGH:
             return this.isStrikeThrough();
+        case ViewPackage.CONDITIONAL_NODE_STYLE__SIZE_COMPUTATION_EXPRESSION:
+            return this.getSizeComputationExpression();
         }
         return super.eGet(featureID, resolve, coreType);
     }
@@ -658,6 +705,9 @@ public class ConditionalNodeStyleImpl extends ConditionalImpl implements Conditi
             return;
         case ViewPackage.CONDITIONAL_NODE_STYLE__STRIKE_THROUGH:
             this.setStrikeThrough((Boolean) newValue);
+            return;
+        case ViewPackage.CONDITIONAL_NODE_STYLE__SIZE_COMPUTATION_EXPRESSION:
+            this.setSizeComputationExpression((String) newValue);
             return;
         }
         super.eSet(featureID, newValue);
@@ -707,6 +757,9 @@ public class ConditionalNodeStyleImpl extends ConditionalImpl implements Conditi
         case ViewPackage.CONDITIONAL_NODE_STYLE__STRIKE_THROUGH:
             this.setStrikeThrough(STRIKE_THROUGH_EDEFAULT);
             return;
+        case ViewPackage.CONDITIONAL_NODE_STYLE__SIZE_COMPUTATION_EXPRESSION:
+            this.setSizeComputationExpression(SIZE_COMPUTATION_EXPRESSION_EDEFAULT);
+            return;
         }
         super.eUnset(featureID);
     }
@@ -743,6 +796,8 @@ public class ConditionalNodeStyleImpl extends ConditionalImpl implements Conditi
             return this.underline != UNDERLINE_EDEFAULT;
         case ViewPackage.CONDITIONAL_NODE_STYLE__STRIKE_THROUGH:
             return this.strikeThrough != STRIKE_THROUGH_EDEFAULT;
+        case ViewPackage.CONDITIONAL_NODE_STYLE__SIZE_COMPUTATION_EXPRESSION:
+            return SIZE_COMPUTATION_EXPRESSION_EDEFAULT == null ? this.sizeComputationExpression != null : !SIZE_COMPUTATION_EXPRESSION_EDEFAULT.equals(this.sizeComputationExpression);
         }
         return super.eIsSet(featureID);
     }
@@ -786,6 +841,8 @@ public class ConditionalNodeStyleImpl extends ConditionalImpl implements Conditi
                 return ViewPackage.NODE_STYLE__UNDERLINE;
             case ViewPackage.CONDITIONAL_NODE_STYLE__STRIKE_THROUGH:
                 return ViewPackage.NODE_STYLE__STRIKE_THROUGH;
+            case ViewPackage.CONDITIONAL_NODE_STYLE__SIZE_COMPUTATION_EXPRESSION:
+                return ViewPackage.NODE_STYLE__SIZE_COMPUTATION_EXPRESSION;
             default:
                 return -1;
             }
@@ -832,6 +889,8 @@ public class ConditionalNodeStyleImpl extends ConditionalImpl implements Conditi
                 return ViewPackage.CONDITIONAL_NODE_STYLE__UNDERLINE;
             case ViewPackage.NODE_STYLE__STRIKE_THROUGH:
                 return ViewPackage.CONDITIONAL_NODE_STYLE__STRIKE_THROUGH;
+            case ViewPackage.NODE_STYLE__SIZE_COMPUTATION_EXPRESSION:
+                return ViewPackage.CONDITIONAL_NODE_STYLE__SIZE_COMPUTATION_EXPRESSION;
             default:
                 return -1;
             }
@@ -874,6 +933,8 @@ public class ConditionalNodeStyleImpl extends ConditionalImpl implements Conditi
         result.append(this.underline);
         result.append(", strikeThrough: "); //$NON-NLS-1$
         result.append(this.strikeThrough);
+        result.append(", sizeComputationExpression: "); //$NON-NLS-1$
+        result.append(this.sizeComputationExpression);
         result.append(')');
         return result.toString();
     }

--- a/backend/sirius-web-view/src/main/java/org/eclipse/sirius/web/view/impl/NodeStyleImpl.java
+++ b/backend/sirius-web-view/src/main/java/org/eclipse/sirius/web/view/impl/NodeStyleImpl.java
@@ -33,6 +33,8 @@ import org.eclipse.sirius.web.view.ViewPackage;
  * <li>{@link org.eclipse.sirius.web.view.impl.NodeStyleImpl#isBold <em>Bold</em>}</li>
  * <li>{@link org.eclipse.sirius.web.view.impl.NodeStyleImpl#isUnderline <em>Underline</em>}</li>
  * <li>{@link org.eclipse.sirius.web.view.impl.NodeStyleImpl#isStrikeThrough <em>Strike Through</em>}</li>
+ * <li>{@link org.eclipse.sirius.web.view.impl.NodeStyleImpl#getSizeComputationExpression <em>Size Computation
+ * Expression</em>}</li>
  * </ul>
  *
  * @generated
@@ -217,6 +219,26 @@ public class NodeStyleImpl extends StyleImpl implements NodeStyle {
      * @ordered
      */
     protected boolean strikeThrough = STRIKE_THROUGH_EDEFAULT;
+
+    /**
+     * The default value of the '{@link #getSizeComputationExpression() <em>Size Computation Expression</em>}'
+     * attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @see #getSizeComputationExpression()
+     * @generated
+     * @ordered
+     */
+    protected static final String SIZE_COMPUTATION_EXPRESSION_EDEFAULT = "1"; //$NON-NLS-1$
+
+    /**
+     * The cached value of the '{@link #getSizeComputationExpression() <em>Size Computation Expression</em>}' attribute.
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @see #getSizeComputationExpression()
+     * @generated
+     * @ordered
+     */
+    protected String sizeComputationExpression = SIZE_COMPUTATION_EXPRESSION_EDEFAULT;
 
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -450,6 +472,29 @@ public class NodeStyleImpl extends StyleImpl implements NodeStyle {
      * @generated
      */
     @Override
+    public String getSizeComputationExpression() {
+        return this.sizeComputationExpression;
+    }
+
+    /**
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     */
+    @Override
+    public void setSizeComputationExpression(String newSizeComputationExpression) {
+        String oldSizeComputationExpression = this.sizeComputationExpression;
+        this.sizeComputationExpression = newSizeComputationExpression;
+        if (this.eNotificationRequired())
+            this.eNotify(new ENotificationImpl(this, Notification.SET, ViewPackage.NODE_STYLE__SIZE_COMPUTATION_EXPRESSION, oldSizeComputationExpression, this.sizeComputationExpression));
+    }
+
+    /**
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     */
+    @Override
     public Object eGet(int featureID, boolean resolve, boolean coreType) {
         switch (featureID) {
         case ViewPackage.NODE_STYLE__LIST_MODE:
@@ -470,6 +515,8 @@ public class NodeStyleImpl extends StyleImpl implements NodeStyle {
             return this.isUnderline();
         case ViewPackage.NODE_STYLE__STRIKE_THROUGH:
             return this.isStrikeThrough();
+        case ViewPackage.NODE_STYLE__SIZE_COMPUTATION_EXPRESSION:
+            return this.getSizeComputationExpression();
         }
         return super.eGet(featureID, resolve, coreType);
     }
@@ -508,6 +555,9 @@ public class NodeStyleImpl extends StyleImpl implements NodeStyle {
             return;
         case ViewPackage.NODE_STYLE__STRIKE_THROUGH:
             this.setStrikeThrough((Boolean) newValue);
+            return;
+        case ViewPackage.NODE_STYLE__SIZE_COMPUTATION_EXPRESSION:
+            this.setSizeComputationExpression((String) newValue);
             return;
         }
         super.eSet(featureID, newValue);
@@ -548,6 +598,9 @@ public class NodeStyleImpl extends StyleImpl implements NodeStyle {
         case ViewPackage.NODE_STYLE__STRIKE_THROUGH:
             this.setStrikeThrough(STRIKE_THROUGH_EDEFAULT);
             return;
+        case ViewPackage.NODE_STYLE__SIZE_COMPUTATION_EXPRESSION:
+            this.setSizeComputationExpression(SIZE_COMPUTATION_EXPRESSION_EDEFAULT);
+            return;
         }
         super.eUnset(featureID);
     }
@@ -578,6 +631,8 @@ public class NodeStyleImpl extends StyleImpl implements NodeStyle {
             return this.underline != UNDERLINE_EDEFAULT;
         case ViewPackage.NODE_STYLE__STRIKE_THROUGH:
             return this.strikeThrough != STRIKE_THROUGH_EDEFAULT;
+        case ViewPackage.NODE_STYLE__SIZE_COMPUTATION_EXPRESSION:
+            return SIZE_COMPUTATION_EXPRESSION_EDEFAULT == null ? this.sizeComputationExpression != null : !SIZE_COMPUTATION_EXPRESSION_EDEFAULT.equals(this.sizeComputationExpression);
         }
         return super.eIsSet(featureID);
     }
@@ -611,6 +666,8 @@ public class NodeStyleImpl extends StyleImpl implements NodeStyle {
         result.append(this.underline);
         result.append(", strikeThrough: "); //$NON-NLS-1$
         result.append(this.strikeThrough);
+        result.append(", sizeComputationExpression: "); //$NON-NLS-1$
+        result.append(this.sizeComputationExpression);
         result.append(')');
         return result.toString();
     }

--- a/backend/sirius-web-view/src/main/java/org/eclipse/sirius/web/view/impl/ViewPackageImpl.java
+++ b/backend/sirius-web-view/src/main/java/org/eclipse/sirius/web/view/impl/ViewPackageImpl.java
@@ -744,6 +744,16 @@ public class ViewPackageImpl extends EPackageImpl implements ViewPackage {
      * @generated
      */
     @Override
+    public EAttribute getNodeStyle_SizeComputationExpression() {
+        return (EAttribute) this.nodeStyleEClass.getEStructuralFeatures().get(9);
+    }
+
+    /**
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     */
+    @Override
     public EClass getEdgeStyle() {
         return this.edgeStyleEClass;
     }
@@ -1149,6 +1159,7 @@ public class ViewPackageImpl extends EPackageImpl implements ViewPackage {
         this.createEAttribute(this.nodeStyleEClass, NODE_STYLE__BOLD);
         this.createEAttribute(this.nodeStyleEClass, NODE_STYLE__UNDERLINE);
         this.createEAttribute(this.nodeStyleEClass, NODE_STYLE__STRIKE_THROUGH);
+        this.createEAttribute(this.nodeStyleEClass, NODE_STYLE__SIZE_COMPUTATION_EXPRESSION);
 
         this.edgeStyleEClass = this.createEClass(EDGE_STYLE);
         this.createEAttribute(this.edgeStyleEClass, EDGE_STYLE__LINE_STYLE);
@@ -1338,6 +1349,8 @@ public class ViewPackageImpl extends EPackageImpl implements ViewPackage {
                 !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
         this.initEAttribute(this.getNodeStyle_StrikeThrough(), this.ecorePackage.getEBoolean(), "strikeThrough", "false", 1, 1, NodeStyle.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, //$NON-NLS-1$ //$NON-NLS-2$
                 !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+        this.initEAttribute(this.getNodeStyle_SizeComputationExpression(), this.ecorePackage.getEString(), "sizeComputationExpression", "1", 0, 1, NodeStyle.class, !IS_TRANSIENT, !IS_VOLATILE, //$NON-NLS-1$ //$NON-NLS-2$
+                IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
         this.initEClass(this.edgeStyleEClass, EdgeStyle.class, "EdgeStyle", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
         this.initEAttribute(this.getEdgeStyle_LineStyle(), this.getLineStyle(), "lineStyle", "Solid", 1, 1, EdgeStyle.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, //$NON-NLS-1$ //$NON-NLS-2$

--- a/backend/sirius-web-view/src/main/resources/model/view.ecore
+++ b/backend/sirius-web-view/src/main/resources/model/view.ecore
@@ -87,6 +87,8 @@
         eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean" defaultValueLiteral="false"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="strikeThrough" lowerBound="1"
         eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean" defaultValueLiteral="false"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="sizeComputationExpression"
+        eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString" defaultValueLiteral="1"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="EdgeStyle" eSuperTypes="#//Style">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="lineStyle" lowerBound="1"

--- a/backend/sirius-web-view/src/main/resources/model/view.genmodel
+++ b/backend/sirius-web-view/src/main/resources/model/view.genmodel
@@ -84,6 +84,7 @@
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute view.ecore#//NodeStyle/bold"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute view.ecore#//NodeStyle/underline"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute view.ecore#//NodeStyle/strikeThrough"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute view.ecore#//NodeStyle/sizeComputationExpression"/>
     </genClasses>
     <genClasses ecoreClass="view.ecore#//EdgeStyle">
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute view.ecore#//EdgeStyle/lineStyle"/>


### PR DESCRIPTION
- [726] Add NodeStyle.sizeComputationExpression the the MM
- [726] Add property section to configure the size expression
- [726] Compute the dynamic size when creating the node style
- [cleanup] Remove log message from Result

### Type of this PR 

- [ ] Bug fix
- [x] New feature or improvement
- [ ] Documentation
- [x] Cleanup
- [ ] Test
- [ ] Build/Releng

### Issue(s)

#726 

### What does this PR do?

Add a `sizeComputationExpression` to node styles in the View DSL, and use it to feed `NodeDescription.sizeProvider`.

### Screenshot/screencast of this PR

 https://user-images.githubusercontent.com/10608/144457549-fc6ac50a-f0db-4e61-96ce-dab3bfb7a195.mp4

### Potential side effects

...

### How to test this PR?

- [ ] Frontend Unit tests
- [ ] Backend Unit tests
- [ ] Cypress : please specify
- [ ] Manual Test : please specify

### Checklist

- [x] I have read CONTRIBUTING carefully.
- [x] I have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All my commits are signed-off (`-s`) with my mail address of my Eclipse Account.
- [ ] I have covered my changes by unit tests or integration tests or manual tests.
- [ ] All tests pass.
- [ ] I have updated the documentation accordingly
- [ ] New React components are availables in storybook
