### PR TITLE
[fix] Fix potential NPE in logging code

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -21,6 +21,8 @@
 
 === Bug fixes
 
+- Fix a potential NPE in logging code of the `WidgetDescriptionConverter`
+
 
 == v2021.12.0
 

--- a/backend/sirius-web-compatibility/src/main/java/org/eclipse/sirius/web/compat/forms/WidgetDescriptionConverter.java
+++ b/backend/sirius-web-compatibility/src/main/java/org/eclipse/sirius/web/compat/forms/WidgetDescriptionConverter.java
@@ -85,7 +85,7 @@ public class WidgetDescriptionConverter {
             optionalWidgetDescription = Optional.of(this.convertRadio((org.eclipse.sirius.properties.RadioDescription) controlDescription));
         } else if (controlDescription instanceof org.eclipse.sirius.properties.SelectDescription) {
             optionalWidgetDescription = Optional.of(this.convertSelect((org.eclipse.sirius.properties.SelectDescription) controlDescription));
-        } else {
+        } else if (controlDescription != null) {
             this.logger.warn("The provided type {} is not yet handled", controlDescription.getClass().getName()); //$NON-NLS-1$
         }
         return optionalWidgetDescription;


### PR DESCRIPTION
This is not supposed to happen on well-formed odesign files, but in practice not all existing odesign files are well-formed/valid.