### PR TITLE
[fix] Fix the canonical domain-based edge creation tool

### DIFF
--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/view/CanonicalBehaviors.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/view/CanonicalBehaviors.java
@@ -55,7 +55,7 @@ public class CanonicalBehaviors {
         EObject semanticTarget = variableManager.get(org.eclipse.sirius.web.diagrams.description.EdgeDescription.SEMANTIC_EDGE_TARGET, EObject.class).get();
         if (edgeDescription.isIsDomainBasedEdge()) {
             this.createSemanticInstance(semanticSource, edgeDescription.getDomainType()).ifPresent(instance -> {
-                this.addInParent(semanticSource, instance);
+                this.addInParent(semanticSource.eContainer(), instance);
                 this.addReferenceTo(instance, semanticSource);
                 this.addReferenceTo(instance, semanticTarget);
             });


### PR DESCRIPTION
In the most common case, the newly created semantic element should not
be inside the source element of the edge, but a sibling of that
element in the same parent.

For example when creation a Relation from Class A to Class B, the new
Relation instance would be in the enclosing Package, not inside A.

Signed-off-by: Pierre-Charles David <pierre-charles.david@obeo.fr>
