### PR TITLE
[845] Switch to Sirius Desktop 6.6.0

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -1,6 +1,6 @@
 = Changelog
 
-== v2022.02.0 (Unreleased)
+== v2022.01.0 (Unreleased)
 
 === Architectural decision records
 
@@ -16,6 +16,7 @@
 
 - [core] Switch to Spring Boot 2.6.1
 - [core] Switch to GraphQL Java 17.3
+- [compatibility] Switch to Sirius Desktop 6.6.0
 
 === New features
 
@@ -23,11 +24,13 @@
 
 - https://github.com/eclipse-sirius/sirius-components/issues/871[#871] [core] An `IEditingContextEventProcessorExecutorServiceProvider` can be given to the `EditingContextEventProcessor` in order to customize the `ExecutorService` which will be used to handle the processing of the `IInput` received. This will allow consumers to change the thread management policy of Sirius Components
 - https://github.com/eclipse-sirius/sirius-components/issues/134[#134] [workbench] The internal API of the workbench is now ready to accept features leveraging a multi-selection
+- [form] Add a tooltip to always make the full label available
 
 === Bug fixes
 
 - [compatibility] Fix a potential NPE in logging code of the `WidgetDescriptionConverter`
 - [form] Handle invalid format more gracefully when editing numeric properties
+- [view] Fix the canonical domain-based edge creation tool
 
 
 == v2021.12.0

--- a/backend/sirius-web-compatibility/pom.xml
+++ b/backend/sirius-web-compatibility/pom.xml
@@ -28,7 +28,7 @@
 
 	<properties>
 		<java.version>11</java.version>
-		<sirius.version>6.5.1-SNAPSHOT</sirius.version>
+		<sirius.version>6.6.0-SNAPSHOT</sirius.version>
 		<eef.version>2.1.5-SNAPSHOT</eef.version>
 	</properties>
 	


### PR DESCRIPTION
Switch to the recently released [Sirius Desktop 6.6.0](https://projects.eclipse.org/projects/modeling.sirius/releases/6.6.0).
It mostly contains bug fixes, and a single new feature. None of which should have any impact on us except making sure we follow the latest version of Sirius Desktop.