### PR TITLE
[enh] Add a tooltip to always make the full label available

### DIFF
--- a/frontend/src/properties/Properties.tsx
+++ b/frontend/src/properties/Properties.tsx
@@ -94,9 +94,11 @@ export const Properties = ({
   return (
     <div data-testid="properties" className={classes.properties}>
       <Toolbar variant="dense" disableGutters>
-        <Typography variant="h6" noWrap>
-          {label}
-        </Typography>
+        <Tooltip title={label}>
+          <Typography variant="h6" noWrap>
+            {label}
+          </Typography>
+        </Tooltip>
         <div className={classes.subscribers}>
           {subscribers.map((subscriber) => (
             <Tooltip title={subscriber.username} arrow key={subscriber.username}>


### PR DESCRIPTION
Add a tooltip to the title of the details view, so that in the (common) case where the label is truncated the user can still get the full name of the selected object.

Before:

![2021-12-14_09-35](https://user-images.githubusercontent.com/10608/145962950-7cd95b35-ec4a-48b3-87bb-0e682ce0f5aa.png)

After:

![Capture d’écran de 2021-12-14 09-36-02](https://user-images.githubusercontent.com/10608/145962985-efa8fb31-86c7-434a-b845-b2c8ac244e0d.png)

A better solution would be to have a more compact label, maybe by replacing the type name with the corresponding icon (the type name could still be available as a tooltip of the icon) and/or to wrap it instead of truncate. It would require more work however, so in the meantime this seems like a quasi-free improvement.
