### PR TITLE
View DSL: Add support for defining border nodes

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -31,6 +31,7 @@
 If the expression is present and produces a positive integer, it will be used as both the width and height of the node, in pixels.
 Currently it is not possible to compute different values for width and height.
 - https://github.com/eclipse-sirius/sirius-components/issues/133[#133] [diagram] Add a connector tool to help create edges in diagrams
+- https://github.com/eclipse-sirius/sirius-components/issues/596[#596] [view] It is now possible to define border nodes in dynamic diagram definitions.
 
 === Improvements
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -4,6 +4,8 @@
 
 === Architectural decision records
 
+- [ADR-37] Add support for connector tool
+
 === Deprecation warning
 - https://github.com/eclipse-sirius/sirius-components/issues/858[#858] [core] Our dependency to Spring Security will be reduced or eliminated soon. Sirius Components will now longer have any opinion on matters of authentication, authorization, principal management, etc. All those concerns will be out of the scope of the project. It will also be way easier to integrate Sirius Components in a Spring based application since it won't come with this additional requirement
 
@@ -28,6 +30,7 @@
 - https://github.com/eclipse-sirius/sirius-components/issues/726[#726] [view] Nodes can now have a dynamically computed size (using `sizeComputationExpression`) which depends on the current state of the semantic model.
 If the expression is present and produces a positive integer, it will be used as both the width and height of the node, in pixels.
 Currently it is not possible to compute different values for width and height.
+- https://github.com/eclipse-sirius/sirius-components/issues/133[#133] [diagram] Add a connector tool to help create edges in diagrams
 
 === Improvements
 

--- a/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/view/ViewConverter.java
+++ b/backend/sirius-web-emf/src/main/java/org/eclipse/sirius/web/emf/view/ViewConverter.java
@@ -200,6 +200,9 @@ public class ViewConverter {
         var childNodeDescriptions = viewNodeDescription.getChildrenDescriptions().stream()
                                                        .map(childNodeDescription -> this.convert(childNodeDescription, interpreter))
                                                        .collect(Collectors.toList());
+        var borderNodeDescriptions = viewNodeDescription.getBorderNodesDescriptions().stream()
+                                                        .map(borderNodeDescription -> this.convert(borderNodeDescription, interpreter))
+                                                        .collect(Collectors.toList());
         // @formatter:on
         SynchronizationPolicy synchronizationPolicy = SynchronizationPolicy.SYNCHRONIZED;
 
@@ -257,7 +260,7 @@ public class ViewConverter {
                 .labelDescription(this.getLabelDescription(viewNodeDescription, interpreter))
                 .styleProvider(styleProvider)
                 .childNodeDescriptions(childNodeDescriptions)
-                .borderNodeDescriptions(List.of())
+                .borderNodeDescriptions(borderNodeDescriptions)
                 .sizeProvider(sizeProvider)
                 .labelEditHandler(this.createLabelEditHandler(viewNodeDescription, interpreter))
                 .deleteHandler(this.createDeleteHandler(viewNodeDescription, interpreter))

--- a/backend/sirius-web-view-edit/src/main/java/org/eclipse/sirius/web/view/provider/NodeDescriptionItemProvider.java
+++ b/backend/sirius-web-view-edit/src/main/java/org/eclipse/sirius/web/view/provider/NodeDescriptionItemProvider.java
@@ -68,6 +68,7 @@ public class NodeDescriptionItemProvider extends DiagramElementDescriptionItemPr
         if (this.childrenFeatures == null) {
             super.getChildrenFeatures(object);
             this.childrenFeatures.add(ViewPackage.Literals.NODE_DESCRIPTION__CHILDREN_DESCRIPTIONS);
+            this.childrenFeatures.add(ViewPackage.Literals.NODE_DESCRIPTION__BORDER_NODES_DESCRIPTIONS);
             this.childrenFeatures.add(ViewPackage.Literals.NODE_DESCRIPTION__STYLE);
             this.childrenFeatures.add(ViewPackage.Literals.NODE_DESCRIPTION__NODE_TOOLS);
             this.childrenFeatures.add(ViewPackage.Literals.NODE_DESCRIPTION__CONDITIONAL_STYLES);
@@ -133,6 +134,7 @@ public class NodeDescriptionItemProvider extends DiagramElementDescriptionItemPr
 
         switch (notification.getFeatureID(NodeDescription.class)) {
         case ViewPackage.NODE_DESCRIPTION__CHILDREN_DESCRIPTIONS:
+        case ViewPackage.NODE_DESCRIPTION__BORDER_NODES_DESCRIPTIONS:
         case ViewPackage.NODE_DESCRIPTION__STYLE:
         case ViewPackage.NODE_DESCRIPTION__NODE_TOOLS:
         case ViewPackage.NODE_DESCRIPTION__CONDITIONAL_STYLES:
@@ -157,13 +159,15 @@ public class NodeDescriptionItemProvider extends DiagramElementDescriptionItemPr
         nodeChild.setStyle(ViewFactory.eINSTANCE.createNodeStyle());
         newChildDescriptors.add(this.createChildParameter(ViewPackage.Literals.NODE_DESCRIPTION__CHILDREN_DESCRIPTIONS, nodeChild));
 
+        NodeDescription borderNodeChild = ViewFactory.eINSTANCE.createNodeDescription();
+        borderNodeChild.setName("Border node"); //$NON-NLS-1$
+        borderNodeChild.setStyle(ViewFactory.eINSTANCE.createNodeStyle());
+        newChildDescriptors.add(this.createChildParameter(ViewPackage.Literals.NODE_DESCRIPTION__BORDER_NODES_DESCRIPTIONS, borderNodeChild));
+
         NodeTool newNodeTool = ViewFactory.eINSTANCE.createNodeTool();
         newNodeTool.setName("Create Node"); //$NON-NLS-1$
         newNodeTool.getBody().add(ViewFactory.eINSTANCE.createChangeContext());
         newChildDescriptors.add(this.createChildParameter(ViewPackage.Literals.NODE_DESCRIPTION__NODE_TOOLS, newNodeTool));
-
-        newChildDescriptors.add(this.createChildParameter(ViewPackage.Literals.NODE_DESCRIPTION__STYLE, ViewFactory.eINSTANCE.createNodeStyle()));
-        newChildDescriptors.add(this.createChildParameter(ViewPackage.Literals.NODE_DESCRIPTION__CONDITIONAL_STYLES, ViewFactory.eINSTANCE.createConditionalNodeStyle()));
     }
 
     /**
@@ -177,7 +181,8 @@ public class NodeDescriptionItemProvider extends DiagramElementDescriptionItemPr
         Object childFeature = feature;
         Object childObject = child;
 
-        boolean qualify = childFeature == ViewPackage.Literals.NODE_DESCRIPTION__STYLE || childFeature == ViewPackage.Literals.NODE_DESCRIPTION__CONDITIONAL_STYLES;
+        boolean qualify = childFeature == ViewPackage.Literals.NODE_DESCRIPTION__CHILDREN_DESCRIPTIONS || childFeature == ViewPackage.Literals.NODE_DESCRIPTION__BORDER_NODES_DESCRIPTIONS
+                || childFeature == ViewPackage.Literals.NODE_DESCRIPTION__STYLE || childFeature == ViewPackage.Literals.NODE_DESCRIPTION__CONDITIONAL_STYLES;
 
         if (qualify) {
             return this.getString("_UI_CreateChild_text2", //$NON-NLS-1$

--- a/backend/sirius-web-view-edit/src/main/resources/plugin.properties
+++ b/backend/sirius-web-view-edit/src/main/resources/plugin.properties
@@ -62,6 +62,7 @@ _UI_DiagramElementDescription_labelExpression_feature = Label Expression
 _UI_DiagramElementDescription_deleteTool_feature = Delete Tool
 _UI_DiagramElementDescription_labelEditTool_feature = Label Edit Tool
 _UI_NodeDescription_childrenDescriptions_feature = Children Descriptions
+_UI_NodeDescription_borderNodesDescriptions_feature = Border Nodes Descriptions
 _UI_NodeDescription_style_feature = Style
 _UI_NodeDescription_nodeTools_feature = Node Tools
 _UI_NodeDescription_conditionalStyles_feature = Conditional Styles

--- a/backend/sirius-web-view/src/main/java/org/eclipse/sirius/web/view/NodeDescription.java
+++ b/backend/sirius-web-view/src/main/java/org/eclipse/sirius/web/view/NodeDescription.java
@@ -42,6 +42,18 @@ public interface NodeDescription extends DiagramElementDescription {
     EList<NodeDescription> getChildrenDescriptions();
 
     /**
+     * Returns the value of the '<em><b>Border Nodes Descriptions</b></em>' containment reference list. The list
+     * contents are of type {@link org.eclipse.sirius.web.view.NodeDescription}. <!-- begin-user-doc --> <!--
+     * end-user-doc -->
+     *
+     * @return the value of the '<em>Border Nodes Descriptions</em>' containment reference list.
+     * @see org.eclipse.sirius.web.view.ViewPackage#getNodeDescription_BorderNodesDescriptions()
+     * @model containment="true"
+     * @generated
+     */
+    EList<NodeDescription> getBorderNodesDescriptions();
+
+    /**
      * Returns the value of the '<em><b>Style</b></em>' containment reference. <!-- begin-user-doc --> <!-- end-user-doc
      * -->
      *

--- a/backend/sirius-web-view/src/main/java/org/eclipse/sirius/web/view/ViewPackage.java
+++ b/backend/sirius-web-view/src/main/java/org/eclipse/sirius/web/view/ViewPackage.java
@@ -381,13 +381,22 @@ public interface ViewPackage extends EPackage {
     int NODE_DESCRIPTION__CHILDREN_DESCRIPTIONS = DIAGRAM_ELEMENT_DESCRIPTION_FEATURE_COUNT + 0;
 
     /**
+     * The feature id for the '<em><b>Border Nodes Descriptions</b></em>' containment reference list. <!--
+     * begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     * @ordered
+     */
+    int NODE_DESCRIPTION__BORDER_NODES_DESCRIPTIONS = DIAGRAM_ELEMENT_DESCRIPTION_FEATURE_COUNT + 1;
+
+    /**
      * The feature id for the '<em><b>Style</b></em>' containment reference. <!-- begin-user-doc --> <!-- end-user-doc
      * -->
      *
      * @generated
      * @ordered
      */
-    int NODE_DESCRIPTION__STYLE = DIAGRAM_ELEMENT_DESCRIPTION_FEATURE_COUNT + 1;
+    int NODE_DESCRIPTION__STYLE = DIAGRAM_ELEMENT_DESCRIPTION_FEATURE_COUNT + 2;
 
     /**
      * The feature id for the '<em><b>Node Tools</b></em>' containment reference list. <!-- begin-user-doc --> <!--
@@ -396,7 +405,7 @@ public interface ViewPackage extends EPackage {
      * @generated
      * @ordered
      */
-    int NODE_DESCRIPTION__NODE_TOOLS = DIAGRAM_ELEMENT_DESCRIPTION_FEATURE_COUNT + 2;
+    int NODE_DESCRIPTION__NODE_TOOLS = DIAGRAM_ELEMENT_DESCRIPTION_FEATURE_COUNT + 3;
 
     /**
      * The feature id for the '<em><b>Conditional Styles</b></em>' containment reference list. <!-- begin-user-doc -->
@@ -405,7 +414,7 @@ public interface ViewPackage extends EPackage {
      * @generated
      * @ordered
      */
-    int NODE_DESCRIPTION__CONDITIONAL_STYLES = DIAGRAM_ELEMENT_DESCRIPTION_FEATURE_COUNT + 3;
+    int NODE_DESCRIPTION__CONDITIONAL_STYLES = DIAGRAM_ELEMENT_DESCRIPTION_FEATURE_COUNT + 4;
 
     /**
      * The number of structural features of the '<em>Node Description</em>' class. <!-- begin-user-doc --> <!--
@@ -414,7 +423,7 @@ public interface ViewPackage extends EPackage {
      * @generated
      * @ordered
      */
-    int NODE_DESCRIPTION_FEATURE_COUNT = DIAGRAM_ELEMENT_DESCRIPTION_FEATURE_COUNT + 4;
+    int NODE_DESCRIPTION_FEATURE_COUNT = DIAGRAM_ELEMENT_DESCRIPTION_FEATURE_COUNT + 5;
 
     /**
      * The number of operations of the '<em>Node Description</em>' class. <!-- begin-user-doc --> <!-- end-user-doc -->
@@ -1852,6 +1861,18 @@ public interface ViewPackage extends EPackage {
     EReference getNodeDescription_ChildrenDescriptions();
 
     /**
+     * Returns the meta object for the containment reference list
+     * '{@link org.eclipse.sirius.web.view.NodeDescription#getBorderNodesDescriptions <em>Border Nodes
+     * Descriptions</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @return the meta object for the containment reference list '<em>Border Nodes Descriptions</em>'.
+     * @see org.eclipse.sirius.web.view.NodeDescription#getBorderNodesDescriptions()
+     * @see #getNodeDescription()
+     * @generated
+     */
+    EReference getNodeDescription_BorderNodesDescriptions();
+
+    /**
      * Returns the meta object for the containment reference
      * '{@link org.eclipse.sirius.web.view.NodeDescription#getStyle <em>Style</em>}'. <!-- begin-user-doc --> <!--
      * end-user-doc -->
@@ -2686,6 +2707,14 @@ public interface ViewPackage extends EPackage {
          * @generated
          */
         EReference NODE_DESCRIPTION__CHILDREN_DESCRIPTIONS = eINSTANCE.getNodeDescription_ChildrenDescriptions();
+
+        /**
+         * The meta object literal for the '<em><b>Border Nodes Descriptions</b></em>' containment reference list
+         * feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+         *
+         * @generated
+         */
+        EReference NODE_DESCRIPTION__BORDER_NODES_DESCRIPTIONS = eINSTANCE.getNodeDescription_BorderNodesDescriptions();
 
         /**
          * The meta object literal for the '<em><b>Style</b></em>' containment reference feature. <!-- begin-user-doc

--- a/backend/sirius-web-view/src/main/java/org/eclipse/sirius/web/view/impl/NodeDescriptionImpl.java
+++ b/backend/sirius-web-view/src/main/java/org/eclipse/sirius/web/view/impl/NodeDescriptionImpl.java
@@ -53,6 +53,16 @@ public class NodeDescriptionImpl extends DiagramElementDescriptionImpl implement
     protected EList<NodeDescription> childrenDescriptions;
 
     /**
+     * The cached value of the '{@link #getBorderNodesDescriptions() <em>Border Nodes Descriptions</em>}' containment
+     * reference list. <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @see #getBorderNodesDescriptions()
+     * @generated
+     * @ordered
+     */
+    protected EList<NodeDescription> borderNodesDescriptions;
+
+    /**
      * The cached value of the '{@link #getStyle() <em>Style</em>}' containment reference. <!-- begin-user-doc --> <!--
      * end-user-doc -->
      *
@@ -112,6 +122,19 @@ public class NodeDescriptionImpl extends DiagramElementDescriptionImpl implement
             this.childrenDescriptions = new EObjectContainmentEList<>(NodeDescription.class, this, ViewPackage.NODE_DESCRIPTION__CHILDREN_DESCRIPTIONS);
         }
         return this.childrenDescriptions;
+    }
+
+    /**
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     */
+    @Override
+    public EList<NodeDescription> getBorderNodesDescriptions() {
+        if (this.borderNodesDescriptions == null) {
+            this.borderNodesDescriptions = new EObjectContainmentEList<>(NodeDescription.class, this, ViewPackage.NODE_DESCRIPTION__BORDER_NODES_DESCRIPTIONS);
+        }
+        return this.borderNodesDescriptions;
     }
 
     /**
@@ -198,6 +221,8 @@ public class NodeDescriptionImpl extends DiagramElementDescriptionImpl implement
         switch (featureID) {
         case ViewPackage.NODE_DESCRIPTION__CHILDREN_DESCRIPTIONS:
             return ((InternalEList<?>) this.getChildrenDescriptions()).basicRemove(otherEnd, msgs);
+        case ViewPackage.NODE_DESCRIPTION__BORDER_NODES_DESCRIPTIONS:
+            return ((InternalEList<?>) this.getBorderNodesDescriptions()).basicRemove(otherEnd, msgs);
         case ViewPackage.NODE_DESCRIPTION__STYLE:
             return this.basicSetStyle(null, msgs);
         case ViewPackage.NODE_DESCRIPTION__NODE_TOOLS:
@@ -218,6 +243,8 @@ public class NodeDescriptionImpl extends DiagramElementDescriptionImpl implement
         switch (featureID) {
         case ViewPackage.NODE_DESCRIPTION__CHILDREN_DESCRIPTIONS:
             return this.getChildrenDescriptions();
+        case ViewPackage.NODE_DESCRIPTION__BORDER_NODES_DESCRIPTIONS:
+            return this.getBorderNodesDescriptions();
         case ViewPackage.NODE_DESCRIPTION__STYLE:
             return this.getStyle();
         case ViewPackage.NODE_DESCRIPTION__NODE_TOOLS:
@@ -240,6 +267,10 @@ public class NodeDescriptionImpl extends DiagramElementDescriptionImpl implement
         case ViewPackage.NODE_DESCRIPTION__CHILDREN_DESCRIPTIONS:
             this.getChildrenDescriptions().clear();
             this.getChildrenDescriptions().addAll((Collection<? extends NodeDescription>) newValue);
+            return;
+        case ViewPackage.NODE_DESCRIPTION__BORDER_NODES_DESCRIPTIONS:
+            this.getBorderNodesDescriptions().clear();
+            this.getBorderNodesDescriptions().addAll((Collection<? extends NodeDescription>) newValue);
             return;
         case ViewPackage.NODE_DESCRIPTION__STYLE:
             this.setStyle((NodeStyle) newValue);
@@ -267,6 +298,9 @@ public class NodeDescriptionImpl extends DiagramElementDescriptionImpl implement
         case ViewPackage.NODE_DESCRIPTION__CHILDREN_DESCRIPTIONS:
             this.getChildrenDescriptions().clear();
             return;
+        case ViewPackage.NODE_DESCRIPTION__BORDER_NODES_DESCRIPTIONS:
+            this.getBorderNodesDescriptions().clear();
+            return;
         case ViewPackage.NODE_DESCRIPTION__STYLE:
             this.setStyle((NodeStyle) null);
             return;
@@ -290,6 +324,8 @@ public class NodeDescriptionImpl extends DiagramElementDescriptionImpl implement
         switch (featureID) {
         case ViewPackage.NODE_DESCRIPTION__CHILDREN_DESCRIPTIONS:
             return this.childrenDescriptions != null && !this.childrenDescriptions.isEmpty();
+        case ViewPackage.NODE_DESCRIPTION__BORDER_NODES_DESCRIPTIONS:
+            return this.borderNodesDescriptions != null && !this.borderNodesDescriptions.isEmpty();
         case ViewPackage.NODE_DESCRIPTION__STYLE:
             return this.style != null;
         case ViewPackage.NODE_DESCRIPTION__NODE_TOOLS:

--- a/backend/sirius-web-view/src/main/java/org/eclipse/sirius/web/view/impl/ViewPackageImpl.java
+++ b/backend/sirius-web-view/src/main/java/org/eclipse/sirius/web/view/impl/ViewPackageImpl.java
@@ -484,7 +484,7 @@ public class ViewPackageImpl extends EPackageImpl implements ViewPackage {
      * @generated
      */
     @Override
-    public EReference getNodeDescription_Style() {
+    public EReference getNodeDescription_BorderNodesDescriptions() {
         return (EReference) this.nodeDescriptionEClass.getEStructuralFeatures().get(1);
     }
 
@@ -494,7 +494,7 @@ public class ViewPackageImpl extends EPackageImpl implements ViewPackage {
      * @generated
      */
     @Override
-    public EReference getNodeDescription_NodeTools() {
+    public EReference getNodeDescription_Style() {
         return (EReference) this.nodeDescriptionEClass.getEStructuralFeatures().get(2);
     }
 
@@ -504,8 +504,18 @@ public class ViewPackageImpl extends EPackageImpl implements ViewPackage {
      * @generated
      */
     @Override
-    public EReference getNodeDescription_ConditionalStyles() {
+    public EReference getNodeDescription_NodeTools() {
         return (EReference) this.nodeDescriptionEClass.getEStructuralFeatures().get(3);
+    }
+
+    /**
+     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     *
+     * @generated
+     */
+    @Override
+    public EReference getNodeDescription_ConditionalStyles() {
+        return (EReference) this.nodeDescriptionEClass.getEStructuralFeatures().get(4);
     }
 
     /**
@@ -1130,6 +1140,7 @@ public class ViewPackageImpl extends EPackageImpl implements ViewPackage {
 
         this.nodeDescriptionEClass = this.createEClass(NODE_DESCRIPTION);
         this.createEReference(this.nodeDescriptionEClass, NODE_DESCRIPTION__CHILDREN_DESCRIPTIONS);
+        this.createEReference(this.nodeDescriptionEClass, NODE_DESCRIPTION__BORDER_NODES_DESCRIPTIONS);
         this.createEReference(this.nodeDescriptionEClass, NODE_DESCRIPTION__STYLE);
         this.createEReference(this.nodeDescriptionEClass, NODE_DESCRIPTION__NODE_TOOLS);
         this.createEReference(this.nodeDescriptionEClass, NODE_DESCRIPTION__CONDITIONAL_STYLES);
@@ -1297,6 +1308,8 @@ public class ViewPackageImpl extends EPackageImpl implements ViewPackage {
         this.initEClass(this.nodeDescriptionEClass, NodeDescription.class, "NodeDescription", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
         this.initEReference(this.getNodeDescription_ChildrenDescriptions(), this.getNodeDescription(), null, "childrenDescriptions", null, 0, -1, NodeDescription.class, !IS_TRANSIENT, !IS_VOLATILE, //$NON-NLS-1$
                 IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+        this.initEReference(this.getNodeDescription_BorderNodesDescriptions(), this.getNodeDescription(), null, "borderNodesDescriptions", null, 0, -1, NodeDescription.class, !IS_TRANSIENT, //$NON-NLS-1$
+                !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
         this.initEReference(this.getNodeDescription_Style(), this.getNodeStyle(), null, "style", null, 0, 1, NodeDescription.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, //$NON-NLS-1$
                 !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
         this.initEReference(this.getNodeDescription_NodeTools(), this.getNodeTool(), null, "nodeTools", null, 0, -1, NodeDescription.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, //$NON-NLS-1$

--- a/backend/sirius-web-view/src/main/resources/model/view.ecore
+++ b/backend/sirius-web-view/src/main/resources/model/view.ecore
@@ -37,6 +37,8 @@
   <eClassifiers xsi:type="ecore:EClass" name="NodeDescription" eSuperTypes="#//DiagramElementDescription">
     <eStructuralFeatures xsi:type="ecore:EReference" name="childrenDescriptions" upperBound="-1"
         eType="#//NodeDescription" containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="borderNodesDescriptions"
+        upperBound="-1" eType="#//NodeDescription" containment="true"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="style" eType="#//NodeStyle"
         containment="true"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="nodeTools" upperBound="-1"

--- a/backend/sirius-web-view/src/main/resources/model/view.genmodel
+++ b/backend/sirius-web-view/src/main/resources/model/view.genmodel
@@ -55,6 +55,7 @@
     </genClasses>
     <genClasses ecoreClass="view.ecore#//NodeDescription">
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference view.ecore#//NodeDescription/childrenDescriptions"/>
+      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference view.ecore#//NodeDescription/borderNodesDescriptions"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference view.ecore#//NodeDescription/style"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference view.ecore#//NodeDescription/nodeTools"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference view.ecore#//NodeDescription/conditionalStyles"/>


### PR DESCRIPTION
This is on top of https://github.com/eclipse-sirius/sirius-components/pull/857, the actual commits specific to this change are the last 3:

- [596] Add border nodes in the View DSL
- [596] Handle border nodes in viewconverter
- [596] Update the CHANGELOG
