### PR TITLE
[377] Restore rename representation feedback

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -45,6 +45,7 @@ Currently it is not possible to compute different values for width and height.
 - [compatibility] Fix a potential NPE in logging code of the `WidgetDescriptionConverter`
 - [form] Handle invalid format more gracefully when editing numeric properties
 - [view] Fix the canonical domain-based edge creation tool
+- https://github.com/eclipse-sirius/sirius-components/issues/377[#377] [workbench] Restore the real time feedback on representation renaming
 
 
 == v2021.12.0

--- a/frontend/src/workbench/Workbench.types.ts
+++ b/frontend/src/workbench/Workbench.types.ts
@@ -22,6 +22,20 @@ export interface SelectionEntry {
   kind: string;
 }
 
+export interface GQLEditingContextEventPayload {
+  __typename: string;
+}
+
+export interface GQLRepresentationRenamedEventPayload extends GQLEditingContextEventPayload {
+  id: string;
+  representationId: string;
+  newLabel: string;
+}
+
+export type GQLEditingContextEventSubscription = {
+  editingContextEvent: GQLEditingContextEventPayload;
+};
+
 export type Representation = {
   id: string;
   label: string;


### PR DESCRIPTION
### Type of this PR 

- [x] Bug fix
- [ ] New feature or improvement
- [ ] Documentation
- [ ] Cleanup
- [ ] Test
- [ ] Build/Releng

### Issue(s)
[377](https://github.com/eclipse-sirius/sirius-components/issues/377)

### What does this PR do?
This PR fixes the issue 377, and restore the refresh of the tab when renaming a representation

### How to test this PR?

- [x] Cypress : I restored the OCP cypress tests concerning the renaming of diagrams

### Checklist

- [x] I have read CONTRIBUTING carefully.
- [x] I have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All my commits are signed-off (`-s`) with my mail address of my Eclipse Account.
- [x] I have covered my changes by unit tests or integration tests or manual tests.
- [x] All tests pass.
- [ ] I have updated the documentation accordingly
- [ ] New React components are availables in storybook
