### PR TITLE
[cleanup] Remove log message from Result

### DIFF
--- a/backend/sirius-web-interpreter/src/main/java/org/eclipse/sirius/web/interpreter/Result.java
+++ b/backend/sirius-web-interpreter/src/main/java/org/eclipse/sirius/web/interpreter/Result.java
@@ -21,17 +21,12 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
  * The evaluation result.
  *
  * @author sbegaudeau
  */
 public class Result {
-
-    private Logger logger = LoggerFactory.getLogger(Result.class);
 
     private final Optional<Object> rawValue;
 
@@ -106,7 +101,8 @@ public class Result {
                 try {
                     result = OptionalInt.of(Integer.parseInt(String.valueOf(object)));
                 } catch (NumberFormatException exception) {
-                    this.logger.warn(exception.getMessage(), exception);
+                    // We'll return an OptionalInt.empty() which clearly indicates
+                    // the result can not be interpreted as an int.
                 }
             }
         }


### PR DESCRIPTION
The API is already designed to indicate to the caller if the result
can be interpreted as an int or not. It's up to the client code to
decide what to do if not.

With the log at such a low level, there is no way to avoid "scary"
stack traces in the backend logs in case of a malformed user-supplied
expression for example, which should not be considered even a warning.

Signed-off-by: Pierre-Charles David <pierre-charles.david@obeo.fr>

### Type of this PR 

- [ ] Bug fix
- [ ] New feature or improvement
- [ ] Documentation
- [ ] Cleanup
- [ ] Test
- [ ] Build/Releng

### Issue(s)

...

### What does this PR do?

...

### Screenshot/screencast of this PR

...
 

### Potential side effects

...

### How to test this PR?

- [ ] Frontend Unit tests
- [ ] Backend Unit tests
- [ ] Cypress : please specify
- [ ] Manual Test : please specify

### Checklist

- [ ] I have read CONTRIBUTING carefully.
- [ ] I have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [ ] All my commits are signed-off (`-s`) with my mail address of my Eclipse Account.
- [ ] I have covered my changes by unit tests or integration tests or manual tests.
- [ ] All tests pass.
- [ ] I have updated the documentation accordingly
- [ ] New React components are availables in storybook
