### PR TITLE
[868] Compute the position of an edge label when it does not have any

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -46,6 +46,7 @@ Currently it is not possible to compute different values for width and height.
 - [form] Handle invalid format more gracefully when editing numeric properties
 - [view] Fix the canonical domain-based edge creation tool
 - https://github.com/eclipse-sirius/sirius-components/issues/377[#377] [workbench] Restore the real time feedback on representation renaming
+- https://github.com/eclipse-sirius/sirius-components/issues/868[#868] [diagram] Fix a layout issue with the label of the newly created edges
 
 
 == v2021.12.0

--- a/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/incremental/IncrementalLayoutEngine.java
+++ b/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/incremental/IncrementalLayoutEngine.java
@@ -83,10 +83,18 @@ public class IncrementalLayoutEngine {
 
         // finally we recompute the edges that needs to
         for (EdgeLayoutData edge : diagram.getEdges()) {
-            if (this.hasChanged(edge.getSource()) || this.hasChanged(edge.getTarget())) {
+            if (this.hasChanged(edge.getSource()) || this.hasChanged(edge.getTarget()) || !this.isLabelPositioned(edge)) {
                 this.layoutEdge(edge);
             }
         }
+    }
+
+    private boolean isLabelPositioned(EdgeLayoutData edge) {
+        if (edge.getCenterLabel() != null) {
+            Position position = edge.getCenterLabel().getPosition();
+            return position.getX() != -1 || position.getY() != -1;
+        }
+        return false;
     }
 
     private void layoutNode(Optional<IDiagramEvent> optionalDiagramElementEvent, NodeLayoutData node, ISiriusWebLayoutConfigurator layoutConfigurator) {


### PR DESCRIPTION
### Type of this PR 

- [x] Bug fix
- [ ] New feature or improvement
- [ ] Documentation
- [ ] Cleanup
- [ ] Test
- [ ] Build/Releng

### Issue(s)

https://github.com/eclipse-sirius/sirius-components/issues/868

### What does this PR do?

It computes the position of an edge label if its position is (-1, -1).

### Screenshot/screencast of this PR

![label-is-positionned-at-creation](https://user-images.githubusercontent.com/7371042/146409123-9e338242-0acc-4db8-ad7e-36dee0512eb0.gif)
