### PR TITLE
[865] Fix workspace image path customization

### DIFF
--- a/backend/sirius-web-compatibility/src/main/java/org/eclipse/sirius/web/compat/diagrams/WorkspaceImageDescriptionConverter.java
+++ b/backend/sirius-web-compatibility/src/main/java/org/eclipse/sirius/web/compat/diagrams/WorkspaceImageDescriptionConverter.java
@@ -51,6 +51,7 @@ public class WorkspaceImageDescriptionConverter {
         // @formatter:off
         String workspacePath = this.eAttributeCustomizationProvider.getEAttributeCustomization(this.workspaceImageDescription, WORKSPACE_PATH)
                 .map(EAttributeCustomization::getValue)
+                .flatMap(expression -> this.interpreter.evaluateExpression(this.variableManager.getVariables(), expression).asString())
                 .orElse(this.workspaceImageDescription.getWorkspacePath());
         // @formatter:on
 


### PR DESCRIPTION
`EAttributeCustomization.value` is defined as an `InterpretedExpression` in the Sirius Desktop metamodel, and should be interpreted as such.
