### PR TITLE
Fix the position of self-loop edges

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -51,7 +51,7 @@ Currently it is not possible to compute different values for width and height.
 - https://github.com/eclipse-sirius/sirius-components/issues/377[#377] [workbench] Restore the real time feedback on representation renaming
 - https://github.com/eclipse-sirius/sirius-components/issues/868[#868] [diagram] Fix a layout issue with the label of the newly created edges
 - https://github.com/eclipse-sirius/sirius-components/issues/746[#746] [core] Keep representations in memory for 5 more seconds when they should be disposed in order to have the time to receive some input before their disposal
-
+- https://github.com/eclipse-sirius/sirius-components/issues/425[#425] [diagram] Fix a layout issue with self-loop edge
 
 == v2021.12.0
 

--- a/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/incremental/provider/EdgeLabelPositionProvider.java
+++ b/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/incremental/provider/EdgeLabelPositionProvider.java
@@ -41,16 +41,24 @@ public class EdgeLabelPositionProvider {
         if (spacingEdgeLabel == null) {
             spacingEdgeLabel = CoreOptions.SPACING_EDGE_LABEL.getDefault();
         }
-        Position position;
+        Position position = null;
         List<Position> routingPoints = edge.getRoutingPoints();
         if (routingPoints.size() < 2) {
             position = Position.UNDEFINED;
-        } else {
+        }
+
+        if (position == null && edge.getSource().equals(edge.getTarget())) {
+            double x = ((edge.getRoutingPoints().get(1).getX() + edge.getRoutingPoints().get(2).getX()) / 2) - (label.getTextBounds().getSize().getWidth() / 2);
+            double y = edge.getRoutingPoints().get(1).getY() - spacingEdgeLabel - label.getTextBounds().getSize().getHeight();
+            position = Position.at(x, y);
+        }
+
+        if (position == null) {
             Position sourceAnchor = routingPoints.get(0);
             Position targetAnchor = routingPoints.get(routingPoints.size() - 1);
             double x = ((sourceAnchor.getX() + targetAnchor.getX()) / 2) - (label.getTextBounds().getSize().getWidth() / 2);
             double y = (sourceAnchor.getY() + targetAnchor.getY()) / 2 + spacingEdgeLabel;
-            return Position.at(x, y);
+            position = Position.at(x, y);
         }
         return position;
     }

--- a/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/incremental/provider/EdgeRoutingPointsProvider.java
+++ b/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/incremental/provider/EdgeRoutingPointsProvider.java
@@ -29,6 +29,7 @@ import org.eclipse.sirius.web.diagrams.layout.incremental.utils.Geometry;
 public class EdgeRoutingPointsProvider {
 
     public List<Position> getRoutingPoints(EdgeLayoutData edge) {
+        List<Position> positions = List.of();
         Bounds sourceBounds = this.getAbsoluteBounds(edge.getSource());
         Bounds targetBounds = this.getAbsoluteBounds(edge.getTarget());
         Position sourceAbsolutePosition = this.getCenter(sourceBounds);
@@ -37,9 +38,19 @@ public class EdgeRoutingPointsProvider {
         Optional<Position> optionalSourceIntersection = geometry.getIntersection(targetAbsolutePosition, sourceAbsolutePosition, sourceBounds);
         Optional<Position> optionalTargetIntersection = geometry.getIntersection(sourceAbsolutePosition, targetAbsolutePosition, targetBounds);
         if (optionalSourceIntersection.isPresent() && optionalTargetIntersection.isPresent()) {
-            return List.of(optionalSourceIntersection.get(), optionalTargetIntersection.get());
+            positions = List.of(optionalSourceIntersection.get(), optionalTargetIntersection.get());
+        } else if (edge.getSource().equals(edge.getTarget())) {
+            positions = this.getRoutingPointsToMyself(edge.getSource().getPosition(), edge.getSource().getSize().getWidth());
         }
-        return List.of();
+        return positions;
+    }
+
+    private List<Position> getRoutingPointsToMyself(Position nodePosition, double size) {
+        Position p1 = Position.at(nodePosition.getX() + size / 3, nodePosition.getY());
+        Position p2 = Position.at(p1.getX(), p1.getY() - 10);
+        Position p3 = Position.at(p1.getX() + size / 3, p2.getY());
+        Position p4 = Position.at(p3.getX(), p1.getY());
+        return List.of(p1, p2, p3, p4);
     }
 
     private Bounds getAbsoluteBounds(NodeLayoutData nodeLayoutData) {

--- a/frontend/src/diagram/sprotty/siriusMove.ts
+++ b/frontend/src/diagram/sprotty/siriusMove.ts
@@ -42,10 +42,27 @@ export class SiriusMoveCommand extends MoveCommand {
     if (edge.routingPoints?.length === 2) {
       const label = edge.children.find((child) => this.isSLabel(child)) as SLabel;
       if (label) {
-        var source = edge.routingPoints[0];
-        var target = edge.routingPoints[1];
-        var labelX = source.x + (target.x - source.x) / 2;
-        var labelY = source.y + (target.y - source.y) / 2;
+        const source = edge.routingPoints[0];
+        const target = edge.routingPoints[1];
+        const labelX = source.x + (target.x - source.x) / 2;
+        const labelY = source.y + (target.y - source.y) / 2;
+        label.position = {
+          x: labelX,
+          y: labelY,
+        };
+      }
+    } else if (edge.routingPoints?.length === 5) {
+      /*
+       * We made this in a context where we cannot create routing point manually.
+       * So having 5 routing points here means we are handling the move of an element
+       * that contains a selfloop edge.
+       */
+      const label = edge.children.find((child) => this.isSLabel(child)) as SLabel;
+      if (label) {
+        const source = edge.routingPoints[2];
+        const target = edge.routingPoints[3];
+        const labelX = source.x + (target.x - source.x) / 2 - label.bounds.width / 2;
+        const labelY = source.y;
         label.position = {
           x: labelX,
           y: labelY,


### PR DESCRIPTION
### Type of this PR 

- [x] Bug fix
- [ ] New feature or improvement
- [ ] Documentation
- [ ] Cleanup
- [ ] Test
- [ ] Build/Releng

### Issue(s)

https://github.com/eclipse-sirius/sirius-components/issues/425

### What does this PR do?

This PR keeps self-loop edges in place during the move and puts all of them on top.

### Screenshot/screencast of this PR
 
![move-keep-edge-in-place](https://user-images.githubusercontent.com/7371042/146912427-f2036e25-07d1-47af-979a-5d6f56799e10.gif)

### Potential side effects

If there are many self-loop edges, all will be in the same position. (Will be fixed in https://github.com/eclipse-sirius/sirius-components/issues/565)
