### PR TITLE
[enh] Add treeId to the context menu props

### DIFF
--- a/frontend/src/tree/TreeItem.tsx
+++ b/frontend/src/tree/TreeItem.tsx
@@ -189,6 +189,7 @@ export const TreeItem = ({
       <TreeItemContextMenu
         menuAnchor={menuAnchor}
         editingContextId={editingContextId}
+        treeId={treeId}
         item={item}
         readOnly={readOnly}
         depth={depth}

--- a/frontend/src/tree/TreeItemContextMenu.tsx
+++ b/frontend/src/tree/TreeItemContextMenu.tsx
@@ -25,6 +25,7 @@ export const TreeItemContextMenuContext = React.createContext([]);
 export const TreeItemContextMenu = ({
   menuAnchor,
   editingContextId,
+  treeId,
   item,
   readOnly,
   depth,
@@ -70,6 +71,7 @@ export const TreeItemContextMenu = ({
             setSelection,
             expandItem,
             key: index.toString(),
+            treeId: treeId,
           };
           const element = React.createElement(contribution.props.component, props);
           return element;

--- a/frontend/src/tree/TreeItemContextMenu.types.ts
+++ b/frontend/src/tree/TreeItemContextMenu.types.ts
@@ -17,6 +17,7 @@ export interface TreeItemContextMenuProps {
   menuAnchor: Element;
   item: TreeItemType;
   editingContextId: string;
+  treeId: string;
   readOnly: boolean;
   depth: number;
   onExpand: (id: string, depth: number) => void;

--- a/frontend/src/tree/TreeItemContextMenuContribution.types.ts
+++ b/frontend/src/tree/TreeItemContextMenuContribution.types.ts
@@ -20,6 +20,7 @@ export interface TreeItemContextMenuContributionProps {
 
 export interface TreeItemContextMenuComponentProps {
   editingContextId: string;
+  treeId: string;
   item: TreeItemType;
   readOnly: boolean;
   selection: Selection;


### PR DESCRIPTION
### Type of this PR 

- [ ] Bug fix
- [x] New feature or improvement
- [ ] Documentation
- [ ] Cleanup
- [ ] Test
- [ ] Build/Releng

### What does this PR do?

This PR makes the id of the tree accessible from the context menu of the items of the tree.

### How to test this PR?
I am not sure how to test this PR. If you have an idea, please suggest it in the comment

### Checklist

- [x] I have read CONTRIBUTING carefully.
- [x] I have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All my commits are signed-off (`-s`) with my mail address of my Eclipse Account.
- [ ] I have covered my changes by unit tests or integration tests or manual tests.
- [x] All tests pass.
- [ ] I have updated the documentation accordingly
- [ ] New React components are availables in storybook
