### PR TITLE
[419] Restore the set default tool action

### DIFF
--- a/frontend/src/diagram/DiagramWebSocketContainerMachine.ts
+++ b/frontend/src/diagram/DiagramWebSocketContainerMachine.ts
@@ -434,6 +434,25 @@ export const diagramWebSocketContainerMachine = Machine<
         return { toolSections: toolSectionsWithDefaults };
       }),
 
+      setDefaultTool: assign((context, event) => {
+        const { defaultTool } = event as SetDefaultToolEvent;
+        let newToolSections;
+        if (context.toolSections) {
+          newToolSections = [];
+          context.toolSections.forEach((toolSection) => {
+            const newToolSection = Object.assign({}, toolSection);
+            newToolSection.tools.forEach((tool) => {
+              if (tool.id === defaultTool.id) {
+                newToolSection.defaultTool = defaultTool;
+                return;
+              }
+            });
+            newToolSections.push(newToolSection);
+          });
+        }
+        return { toolSections: newToolSections };
+      }),
+
       handleDiagramRefreshed: assign((_, event) => {
         const { diagram } = event as DiagramRefreshedEvent;
         return { diagram };


### PR DESCRIPTION
Signed-off-by: Raphaël Pagé <raphael.page@obeo.fr>

### Type of this PR 

- [x] Bug fix
- [ ] New feature or improvement
- [ ] Documentation
- [ ] Cleanup
- [ ] Test
- [ ] Build/Releng

### Issue(s)

[419](https://github.com/eclipse-sirius/sirius-components/issues/419)

### What does this PR do?

This PR restores the set default tools action, which allows to remember the last tool that was picked in the tool section. This tool is then displayed as the default tool of this section.

### Screenshot/screencast of this PR

...
 

### Potential side effects

...

### How to test this PR?

- [ ] Frontend Unit tests
- [ ] Backend Unit tests
- [ ] Cypress : please specify
- [x] Manual Test : please specify

- Create a new Topography diagram
- Create a new Composite Processor
- If you open the tool palette on the new element, the first tool of the left most section is the Composite Processor.
- On the tool palette, select the Data Source tool.
- If you open the tool palette, the first element is now the Data Source tool.

### Checklist

- [x] I have read CONTRIBUTING carefully.
- [x] I have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All my commits are signed-off (`-s`) with my mail address of my Eclipse Account.
- [ ] I have covered my changes by unit tests or integration tests or manual tests.
- [x] All tests pass.
- [ ] I have updated the documentation accordingly
- [ ] New React components are availables in storybook
