### PR TITLE
[937] [938] [1019] Add diagram to SVG service

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -37,6 +37,7 @@
 - https://github.com/eclipse-sirius/sirius-components/issues/988[#988] [core] Add support for a post selection
 - https://github.com/eclipse-sirius/sirius-components/issues/1018[#1018] [compatibility] Add support for the `Navigation` model operation from Sirius RCP
 - https://github.com/eclipse-sirius/sirius-components/issues/1026[#1026] [compatibility] Add support for `OperationAction`. The action are converted to regular tools available in the palette of the frontend
+- https://github.com/eclipse-sirius/sirius-components/issues/937[#937] [diagram] Add the ability to export diagram as SVG images
 
 
 == v2022.01.0

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -20,6 +20,7 @@
 - https://github.com/eclipse-sirius/sirius-components/issues/975[#975] [core] Remove useless parts of the GraphQL API which were both unused by the Sirius Components frontend and not handled by the Sirius Components backend
 - https://github.com/eclipse-sirius/sirius-components/issues/959[#959] [diagram] Remove the concept of `DeleteTool`. This concept was not useful since any tool can perform a deletion
 - https://github.com/eclipse-sirius/sirius-components/issues/1018[#1018] [core] Remove the default implementation of `IRepresentationMetadataSearchService` since products integrating Sirius Components needs the ability to customize its behavior
+- https://github.com/eclipse-sirius/sirius-components/issues/1019[#1019] [core] Services now have access to the context of the request triggering their execution. Consumer of Sirius Components will have to provide the `RequestAttributes`` in the `RequestContextHolder`` to make the `EditingContextEventProcessor`` work. It should be very easy for those in a Spring environment, but it is not automatic for those outside of a Spring environment
 
 === Bug fixes
 

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -15,7 +15,7 @@
 
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components</artifactId>
-	<version>2022.01.6</version>
+	<version>2022.01.7</version>
 
 	<name>sirius-components</name>
 	<description>Sirius Components</description>

--- a/backend/sirius-components-annotations-spring/pom.xml
+++ b/backend/sirius-components-annotations-spring/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-annotations-spring</artifactId>
-	<version>2022.01.6</version>
+	<version>2022.01.7</version>
 	<name>sirius-components-annotations-spring</name>
 	<description>Sirius Components Annotations Spring</description>
 

--- a/backend/sirius-components-annotations/pom.xml
+++ b/backend/sirius-components-annotations/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-annotations</artifactId>
-	<version>2022.01.6</version>
+	<version>2022.01.7</version>
 	<name>sirius-components-annotations</name>
 	<description>Sirius Components Annotations</description>
 

--- a/backend/sirius-components-collaborative-diagrams/pom.xml
+++ b/backend/sirius-components-collaborative-diagrams/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-collaborative-diagrams</artifactId>
-	<version>2022.01.6</version>
+	<version>2022.01.7</version>
 	<name>sirius-components-collaborative-diagrams</name>
 	<description>Sirius Components Collaborative Diagrams</description>
 
@@ -50,34 +50,34 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-layout</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-tests</artifactId>
-    		<version>2022.01.6</version>
+    		<version>2022.01.7</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-spring-tests</artifactId>
-    		<version>2022.01.6</version>
+    		<version>2022.01.7</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-tests</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/backend/sirius-components-collaborative-diagrams/src/main/java/org/eclipse/sirius/components/collaborative/diagrams/dto/ExportRepresentationInput.java
+++ b/backend/sirius-components-collaborative-diagrams/src/main/java/org/eclipse/sirius/components/collaborative/diagrams/dto/ExportRepresentationInput.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.collaborative.diagrams.dto;
+
+import java.util.Objects;
+import java.util.UUID;
+
+import org.eclipse.sirius.components.collaborative.diagrams.api.IDiagramInput;
+
+/**
+ * The input object for the export representation service.
+ *
+ * @author rpage
+ */
+public final class ExportRepresentationInput implements IDiagramInput {
+    private final UUID id;
+
+    private final String representationId;
+
+    public ExportRepresentationInput(UUID id, String representationId) {
+        this.id = Objects.requireNonNull(id);
+        this.representationId = Objects.requireNonNull(representationId);
+    }
+
+    @Override
+    public String getRepresentationId() {
+        return this.representationId;
+    }
+
+    @Override
+    public UUID getId() {
+        return this.id;
+    }
+}

--- a/backend/sirius-components-collaborative-diagrams/src/main/java/org/eclipse/sirius/components/collaborative/diagrams/dto/ExportRepresentationPayload.java
+++ b/backend/sirius-components-collaborative-diagrams/src/main/java/org/eclipse/sirius/components/collaborative/diagrams/dto/ExportRepresentationPayload.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.collaborative.diagrams.dto;
+
+import java.text.MessageFormat;
+import java.util.Objects;
+import java.util.UUID;
+
+import org.eclipse.sirius.components.core.api.IPayload;
+
+/**
+ * The payload of the export representation handler.
+ *
+ * @author rpage
+ */
+public final class ExportRepresentationPayload implements IPayload {
+    private final UUID id;
+
+    private final String name;
+
+    private final String content;
+
+    public ExportRepresentationPayload(UUID id, String name, String svgExport) {
+        this.id = Objects.requireNonNull(id);
+        this.name = Objects.requireNonNull(name);
+        this.content = Objects.requireNonNull(svgExport);
+    }
+
+    @Override
+    public UUID getId() {
+        return this.id;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public String getContent() {
+        return this.content;
+    }
+
+    @Override
+    public String toString() {
+        String pattern = "{0} '{'id: {1}, name: {2}, content: {3} '}'"; //$NON-NLS-1$
+        return MessageFormat.format(pattern, this.getClass().getSimpleName(), this.id, this.name, this.content);
+    }
+}

--- a/backend/sirius-components-collaborative-diagrams/src/main/java/org/eclipse/sirius/components/collaborative/diagrams/dto/InvokeEdgeToolOnDiagramSuccessPayload.java
+++ b/backend/sirius-components-collaborative-diagrams/src/main/java/org/eclipse/sirius/components/collaborative/diagrams/dto/InvokeEdgeToolOnDiagramSuccessPayload.java
@@ -32,7 +32,7 @@ public final class InvokeEdgeToolOnDiagramSuccessPayload implements IPayload {
 
     public InvokeEdgeToolOnDiagramSuccessPayload(UUID id, WorkbenchSelection newSelection) {
         this.id = Objects.requireNonNull(id);
-        this.newSelection = Objects.requireNonNull(newSelection);
+        this.newSelection = newSelection;
     }
 
     @Override

--- a/backend/sirius-components-collaborative-diagrams/src/main/java/org/eclipse/sirius/components/collaborative/diagrams/export/api/ISVGDiagramExportService.java
+++ b/backend/sirius-components-collaborative-diagrams/src/main/java/org/eclipse/sirius/components/collaborative/diagrams/export/api/ISVGDiagramExportService.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.collaborative.diagrams.export.api;
+
+import org.eclipse.sirius.components.diagrams.Diagram;
+
+/**
+ * Interface of the service used to export a diagram to SVG.
+ *
+ * @author rpage
+ */
+public interface ISVGDiagramExportService {
+    String export(Diagram diagram);
+}

--- a/backend/sirius-components-collaborative-diagrams/src/main/java/org/eclipse/sirius/components/collaborative/diagrams/export/svg/DiagramElementExportService.java
+++ b/backend/sirius-components-collaborative-diagrams/src/main/java/org/eclipse/sirius/components/collaborative/diagrams/export/svg/DiagramElementExportService.java
@@ -12,7 +12,9 @@
  *******************************************************************************/
 package org.eclipse.sirius.components.collaborative.diagrams.export.svg;
 
+import java.util.Objects;
 import java.util.Optional;
+import java.util.UUID;
 
 import org.eclipse.sirius.components.diagrams.Label;
 import org.eclipse.sirius.components.diagrams.LabelStyle;
@@ -30,6 +32,12 @@ import org.springframework.stereotype.Service;
 @Service
 @SuppressWarnings("checkstyle:MultipleStringLiterals")
 public class DiagramElementExportService {
+    private final ImageRegistry imageRegistry;
+
+    public DiagramElementExportService(ImageRegistry imageRegistry) {
+        this.imageRegistry = Objects.requireNonNull(imageRegistry);
+    }
+
     public StringBuilder exportLabel(Label label) {
         StringBuilder labelExport = new StringBuilder();
         Position position = label.getPosition();
@@ -53,14 +61,16 @@ public class DiagramElementExportService {
 
     public StringBuilder exportImageElement(String imageURL, int x, int y, Optional<Size> size) {
         StringBuilder imageExport = new StringBuilder();
-
-        imageExport.append("<image "); //$NON-NLS-1$
-        imageExport.append("href=\"" + imageURL + "\" "); //$NON-NLS-1$ //$NON-NLS-2$
-        imageExport.append("x=\"0\" "); //$NON-NLS-1$
-        imageExport.append("y=\"0\" "); //$NON-NLS-1$
-        size.ifPresent(it -> imageExport.append(this.addSizeParam(it)));
-
-        return imageExport.append("/>"); //$NON-NLS-1$
+        UUID symbolId = this.imageRegistry.registerImage(imageURL);
+        if (symbolId != null) {
+            imageExport.append("<use "); //$NON-NLS-1$
+            imageExport.append("xlink:href=\"#" + symbolId + "\" "); //$NON-NLS-1$ //$NON-NLS-2$
+            imageExport.append("x=\"0\" "); //$NON-NLS-1$
+            imageExport.append("y=\"0\" "); //$NON-NLS-1$
+            size.ifPresent(it -> imageExport.append(this.addSizeParam(it)));
+            imageExport.append("/>"); //$NON-NLS-1$
+        }
+        return imageExport;
     }
 
     /**

--- a/backend/sirius-components-collaborative-diagrams/src/main/java/org/eclipse/sirius/components/collaborative/diagrams/export/svg/DiagramElementExportService.java
+++ b/backend/sirius-components-collaborative-diagrams/src/main/java/org/eclipse/sirius/components/collaborative/diagrams/export/svg/DiagramElementExportService.java
@@ -1,0 +1,181 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.collaborative.diagrams.export.svg;
+
+import java.util.Optional;
+
+import org.eclipse.sirius.components.diagrams.Label;
+import org.eclipse.sirius.components.diagrams.LabelStyle;
+import org.eclipse.sirius.components.diagrams.LineStyle;
+import org.eclipse.sirius.components.diagrams.Node;
+import org.eclipse.sirius.components.diagrams.Position;
+import org.eclipse.sirius.components.diagrams.Size;
+import org.springframework.stereotype.Service;
+
+/**
+ * Contains methods used when exporting diagram elements.
+ *
+ * @author rpage
+ */
+@Service
+@SuppressWarnings("checkstyle:MultipleStringLiterals")
+public class DiagramElementExportService {
+    public StringBuilder exportLabel(Label label) {
+        StringBuilder labelExport = new StringBuilder();
+        Position position = label.getPosition();
+        Position alignment = label.getAlignment();
+        LabelStyle style = label.getStyle();
+
+        labelExport.append("<g "); //$NON-NLS-1$
+        labelExport.append("transform=\""); //$NON-NLS-1$
+        labelExport.append("translate(" + position.getX() + ", " + position.getY() + ") "); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        labelExport.append("translate(" + alignment.getX() + ", " + alignment.getY() + ")\""); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        labelExport.append(">"); //$NON-NLS-1$
+
+        if (!(style.getIconURL().isEmpty())) {
+            labelExport.append(this.exportImageElement(style.getIconURL(), -20, -12, Optional.empty()));
+        }
+
+        labelExport.append(this.exportTextElement(label.getText(), style));
+
+        return labelExport.append("</g>"); //$NON-NLS-1$
+    }
+
+    public StringBuilder exportImageElement(String imageURL, int x, int y, Optional<Size> size) {
+        StringBuilder imageExport = new StringBuilder();
+
+        imageExport.append("<image "); //$NON-NLS-1$
+        imageExport.append("href=\"" + imageURL + "\" "); //$NON-NLS-1$ //$NON-NLS-2$
+        imageExport.append("x=\"0\" "); //$NON-NLS-1$
+        imageExport.append("y=\"0\" "); //$NON-NLS-1$
+        size.ifPresent(it -> imageExport.append(this.addSizeParam(it)));
+
+        return imageExport.append("/>"); //$NON-NLS-1$
+    }
+
+    /**
+     * Export the g element containing the position of a diagram element.
+     *
+     * @param node
+     *            The diagram element
+     * @return The g element containing its position
+     */
+    public StringBuilder exportGNodeElement(Node node) {
+        StringBuilder gExport = new StringBuilder();
+
+        gExport.append("<g "); //$NON-NLS-1$
+        gExport.append("transform=\"translate(" + node.getPosition().getX() + ", " + node.getPosition().getY() + ")\" "); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+
+        return gExport.append(">"); //$NON-NLS-1$
+    }
+
+    public StringBuilder exportRectangleElement(Size size, Optional<Integer> borderRadius, Optional<String> color, Optional<String> borderColor, Optional<Integer> borderSize,
+            Optional<LineStyle> borderStyle) {
+        StringBuilder rectangle = new StringBuilder();
+
+        rectangle.append("<rect "); //$NON-NLS-1$
+        rectangle.append("x=\"0\" "); //$NON-NLS-1$
+        rectangle.append("y=\"0\" "); //$NON-NLS-1$
+        borderRadius.ifPresent(radius -> rectangle.append("rx=\"" + radius + "\" ")); //$NON-NLS-1$ //$NON-NLS-2$
+        rectangle.append(this.addSizeParam(size));
+        rectangle.append(this.exportRectangleStyleParam(color, borderColor, borderSize, borderStyle));
+
+        return rectangle.append("/> "); //$NON-NLS-1$
+    }
+
+    private StringBuilder addSizeParam(Size size) {
+        StringBuilder sizeParam = new StringBuilder();
+        sizeParam.append("width=\"" + size.getWidth() + "\" "); //$NON-NLS-1$ //$NON-NLS-2$
+        return sizeParam.append("height=\"" + size.getHeight() + "\" "); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    private StringBuilder exportTextElement(String text, LabelStyle labelStyle) {
+        StringBuilder textExport = new StringBuilder();
+
+        textExport.append("<text "); //$NON-NLS-1$
+        textExport.append("style=\""); //$NON-NLS-1$
+        textExport.append("fill: " + labelStyle.getColor() + "; "); //$NON-NLS-1$ //$NON-NLS-2$
+        textExport.append(this.exportFont(labelStyle));
+        textExport.append("\">"); //$NON-NLS-1$
+
+        textExport.append(text);
+
+        return textExport.append("</text>"); //$NON-NLS-1$
+    }
+
+    private StringBuilder exportFont(LabelStyle labelStyle) {
+        StringBuilder textExport = new StringBuilder();
+
+        textExport.append("font-size: " + labelStyle.getFontSize() + "px; "); //$NON-NLS-1$ //$NON-NLS-2$
+        textExport.append("font-family: Arial, Helvetica, sans-serif; "); //$NON-NLS-1$
+
+        textExport.append("font-weight: "); //$NON-NLS-1$
+        if (labelStyle.isBold()) {
+            textExport.append("bold"); //$NON-NLS-1$
+        } else {
+            textExport.append("normal"); //$NON-NLS-1$
+        }
+        textExport.append("; "); //$NON-NLS-1$
+
+        textExport.append("font-style: "); //$NON-NLS-1$
+        if (labelStyle.isItalic()) {
+            textExport.append("italic"); //$NON-NLS-1$
+        } else {
+            textExport.append("normal"); //$NON-NLS-1$
+        }
+        textExport.append("; "); //$NON-NLS-1$
+
+        textExport.append("text-decoration: "); //$NON-NLS-1$
+        if (labelStyle.isUnderline() || labelStyle.isStrikeThrough()) {
+            if (labelStyle.isUnderline()) {
+                textExport.append("underline "); //$NON-NLS-1$
+            }
+            if (labelStyle.isStrikeThrough()) {
+                textExport.append("line-through"); //$NON-NLS-1$
+            }
+        } else {
+            textExport.append("none"); //$NON-NLS-1$
+        }
+        return textExport.append(";"); //$NON-NLS-1$
+    }
+
+    private StringBuilder exportRectangleStyleParam(Optional<String> color, Optional<String> borderColor, Optional<Integer> borderSize, Optional<LineStyle> borderStyle) {
+        StringBuilder styleExport = new StringBuilder();
+
+        styleExport.append("style=\""); //$NON-NLS-1$
+        color.ifPresent(it -> styleExport.append("fill: " + it + "; ")); //$NON-NLS-1$ //$NON-NLS-2$
+        borderColor.ifPresent(it -> styleExport.append("stroke: " + it + "; ")); //$NON-NLS-1$ //$NON-NLS-2$
+        borderSize.ifPresent(it -> styleExport.append("stroke-width: " + it + "px; ")); //$NON-NLS-1$ //$NON-NLS-2$
+        borderStyle.ifPresent(style -> styleExport.append(this.exportBorderStyle(style)));
+
+        return styleExport.append("\""); //$NON-NLS-1$
+    }
+
+    private StringBuilder exportBorderStyle(LineStyle borderStyle) {
+        StringBuilder style = new StringBuilder();
+        switch (borderStyle.toString()) {
+        case "Dash": //$NON-NLS-1$
+            style.append(" stroke-dasharray: 4, 4;"); //$NON-NLS-1$
+            break;
+        case "Dot": //$NON-NLS-1$
+            style.append(" stroke-dasharray: 2, 2;"); //$NON-NLS-1$
+            break;
+        case "Dash_Dot": //$NON-NLS-1$
+            style.append(" stroke-dasharray: 2, 4, 2;"); //$NON-NLS-1$
+            break;
+        default:
+            break;
+        }
+        return style;
+    }
+}

--- a/backend/sirius-components-collaborative-diagrams/src/main/java/org/eclipse/sirius/components/collaborative/diagrams/export/svg/DiagramExportService.java
+++ b/backend/sirius-components-collaborative-diagrams/src/main/java/org/eclipse/sirius/components/collaborative/diagrams/export/svg/DiagramExportService.java
@@ -1,0 +1,182 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.collaborative.diagrams.export.svg;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import org.eclipse.sirius.components.collaborative.diagrams.export.api.ISVGDiagramExportService;
+import org.eclipse.sirius.components.diagrams.Diagram;
+import org.eclipse.sirius.components.diagrams.Label;
+import org.eclipse.sirius.components.diagrams.Position;
+import org.eclipse.sirius.components.diagrams.Size;
+import org.springframework.stereotype.Service;
+
+/**
+ * Used to export a {@link Diagram} to an SVG format.
+ *
+ * @author rpage
+ */
+@Service
+@SuppressWarnings("checkstyle:MultipleStringLiterals")
+public class DiagramExportService implements ISVGDiagramExportService {
+    private static final String SVG_NAMESPACE = "xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" "; //$NON-NLS-1$
+
+    private final NodeExportService nodeExport;
+
+    private final EdgeExportService edgeExport;
+
+    private final List<Double> xBeginPositions = new ArrayList<>();
+
+    private final List<Double> yBeginPositions = new ArrayList<>();
+
+    private final List<Double> xEndPositions = new ArrayList<>();
+
+    private final List<Double> yEndPositions = new ArrayList<>();
+
+    public DiagramExportService(NodeExportService nodeExport, EdgeExportService edgeExport) {
+        this.nodeExport = Objects.requireNonNull(nodeExport);
+        this.edgeExport = Objects.requireNonNull(edgeExport);
+    }
+
+    @Override
+    public String export(Diagram diagram) {
+        StringBuilder svg = new StringBuilder();
+        svg.append(this.addSvgRoot(diagram));
+
+        svg.append("<g transform=\"scale(1) translate(0,0)\">"); //$NON-NLS-1$ )
+
+        diagram.getNodes().forEach(node -> svg.append(this.nodeExport.export(node)));
+        diagram.getEdges().forEach(edge -> svg.append(this.edgeExport.export(edge)));
+
+        svg.append("</g>"); //$NON-NLS-1$
+
+        return svg.append("</svg>").toString(); //$NON-NLS-1$
+    }
+
+    private StringBuilder addSvgRoot(Diagram diagram) {
+        StringBuilder rootSvg = new StringBuilder();
+
+        rootSvg.append("<svg "); //$NON-NLS-1$
+        rootSvg.append(SVG_NAMESPACE);
+        rootSvg.append(this.computeViewBox(diagram));
+        rootSvg.append("tabindex=\"0\" "); //$NON-NLS-1$
+        rootSvg.append("style=\"cursor: pointer; outline: transparent solid 1px;\""); //$NON-NLS-1$
+        return rootSvg.append(">"); //$NON-NLS-1$
+    }
+
+    /**
+     * Determines the viewBox argument of the svg element.
+     *
+     * <p>
+     * Since the coordinates of the elements are saved depending on the viewPort of the frontend, we need to compute the
+     * viewPort of the SVG. This viewPort can be declared using the viewBox argument.
+     *
+     * viewBox = (min-x, min-y, width, height)
+     *
+     * With :
+     *
+     * diagram.children = nodes, borderNodes, edges and their labels </br>
+     * min x = { min(e.x) | e in diagram.children } </br>
+     * min y = { min(e.y) | e in diagram.children } </br>
+     * max x = {max(e.x + e.width) | e in diagram.children } </br>
+     * max y = { max(e.y + e.height) | e in diagram.children } </br>
+     * width = abs( min x - max x ) + diag.x </br>
+     * height = abs( min y - max y ) + diag.y </br>
+     * </p>
+     *
+     *
+     * @param diagram
+     *            The diagram being exported
+     * @return The StringBuilder containing the viewBox attribute of the SVG
+     */
+    private StringBuilder computeViewBox(Diagram diagram) {
+        StringBuilder viewBoxExport = new StringBuilder();
+
+        viewBoxExport.append("viewBox=\""); //$NON-NLS-1$
+
+        this.computeElementsCoordinates(diagram);
+
+        double minX = this.xBeginPositions.stream().min(Double::compare).get();
+        double minY = this.yBeginPositions.stream().min(Double::compare).get();
+        double maxX = this.xEndPositions.stream().max(Double::compare).get();
+        double maxY = this.yEndPositions.stream().max(Double::compare).get();
+
+        int padding = 20;
+        double width = Math.abs(minX - maxX) + diagram.getPosition().getX();
+        double height = Math.abs(minY - maxY) + diagram.getPosition().getY();
+
+        double finalMinX = minX - padding / 2;
+        double finalMinY = minY - padding / 2;
+        double finalWidth = width + padding;
+        double finalHeight = height + padding;
+
+        viewBoxExport.append(finalMinX + " " + finalMinY + " " + finalWidth + " " + finalHeight); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        return viewBoxExport.append("\" "); //$NON-NLS-1$
+    }
+
+    private void computeElementsCoordinates(Diagram diagram) {
+        diagram.getNodes().forEach(node -> {
+            this.addElementPositions(node.getPosition(), node.getSize(), node.getLabel(), Position.at(0, 0));
+
+            node.getBorderNodes().forEach(border -> {
+                this.addElementPositions(border.getPosition(), border.getSize(), border.getLabel(), node.getPosition());
+            });
+        });
+
+        diagram.getEdges().forEach(edge -> {
+            if (edge.getBeginLabel() != null) {
+                this.addAbsoluteLabelPosition(edge.getBeginLabel(), Position.at(0, 0));
+            }
+            if (edge.getCenterLabel() != null) {
+                this.addAbsoluteLabelPosition(edge.getCenterLabel(), Position.at(0, 0));
+
+            }
+            if (edge.getEndLabel() != null) {
+                this.addAbsoluteLabelPosition(edge.getEndLabel(), Position.at(0, 0));
+            }
+            edge.getRoutingPoints().forEach(point -> {
+                this.xBeginPositions.add(point.getX());
+                this.xEndPositions.add(point.getX());
+                this.yBeginPositions.add(point.getY());
+                this.yEndPositions.add(point.getY());
+            });
+        });
+    }
+
+    private void addElementPositions(Position elementPosition, Size elementSize, Label elementLabel, Position parentPosition) {
+        double nodeX = parentPosition.getX() + elementPosition.getX();
+        double nodeY = parentPosition.getY() + elementPosition.getY();
+        this.xBeginPositions.add(nodeX);
+        this.yBeginPositions.add(nodeY);
+        this.xEndPositions.add(nodeX + elementSize.getWidth());
+        this.yEndPositions.add(nodeY + elementSize.getHeight());
+        this.addAbsoluteLabelPosition(elementLabel, elementPosition);
+    }
+
+    private void addAbsoluteLabelPosition(Label label, Position parentPosition) {
+        double xOffest = parentPosition.getX();
+        double yOffest = parentPosition.getY();
+        Position labelPosition = label.getPosition();
+        Position labelAlignment = label.getAlignment();
+        Size labelSize = label.getSize();
+
+        double xLabel = xOffest + labelPosition.getX() + labelAlignment.getX();
+        double yLabel = yOffest + labelPosition.getY() + labelAlignment.getY();
+        this.xBeginPositions.add(xLabel);
+        this.yBeginPositions.add(yLabel);
+        this.xEndPositions.add(xLabel + labelSize.getWidth());
+        this.yEndPositions.add(yLabel + labelSize.getHeight());
+    }
+}

--- a/backend/sirius-components-collaborative-diagrams/src/main/java/org/eclipse/sirius/components/collaborative/diagrams/export/svg/DiagramExportService.java
+++ b/backend/sirius-components-collaborative-diagrams/src/main/java/org/eclipse/sirius/components/collaborative/diagrams/export/svg/DiagramExportService.java
@@ -37,6 +37,8 @@ public class DiagramExportService implements ISVGDiagramExportService {
 
     private final EdgeExportService edgeExport;
 
+    private final ImageRegistry imageRegistry;
+
     private final List<Double> xBeginPositions = new ArrayList<>();
 
     private final List<Double> yBeginPositions = new ArrayList<>();
@@ -45,9 +47,10 @@ public class DiagramExportService implements ISVGDiagramExportService {
 
     private final List<Double> yEndPositions = new ArrayList<>();
 
-    public DiagramExportService(NodeExportService nodeExport, EdgeExportService edgeExport) {
+    public DiagramExportService(NodeExportService nodeExport, EdgeExportService edgeExport, ImageRegistry imageRegistry) {
         this.nodeExport = Objects.requireNonNull(nodeExport);
         this.edgeExport = Objects.requireNonNull(edgeExport);
+        this.imageRegistry = Objects.requireNonNull(imageRegistry);
     }
 
     @Override
@@ -61,6 +64,8 @@ public class DiagramExportService implements ISVGDiagramExportService {
         diagram.getEdges().forEach(edge -> svg.append(this.edgeExport.export(edge)));
 
         svg.append("</g>"); //$NON-NLS-1$
+
+        svg.append(this.imageRegistry.getReferencedImageSymbols());
 
         return svg.append("</svg>").toString(); //$NON-NLS-1$
     }

--- a/backend/sirius-components-collaborative-diagrams/src/main/java/org/eclipse/sirius/components/collaborative/diagrams/export/svg/EdgeExportService.java
+++ b/backend/sirius-components-collaborative-diagrams/src/main/java/org/eclipse/sirius/components/collaborative/diagrams/export/svg/EdgeExportService.java
@@ -1,0 +1,404 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.collaborative.diagrams.export.svg;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.eclipse.sirius.components.diagrams.Edge;
+import org.eclipse.sirius.components.diagrams.EdgeStyle;
+import org.eclipse.sirius.components.diagrams.Position;
+import org.springframework.stereotype.Service;
+
+/**
+ * Export an {@link Edge} to an SVG format.
+ *
+ * @author rpage
+ */
+@Service
+@SuppressWarnings("checkstyle:MultipleStringLiterals")
+public class EdgeExportService {
+    private final DiagramElementExportService elementExport;
+
+    public EdgeExportService(DiagramElementExportService elementExport) {
+        this.elementExport = Objects.requireNonNull(elementExport);
+    }
+
+    public StringBuilder export(Edge edge) {
+        StringBuilder edgeExport = new StringBuilder();
+        EdgeStyle style = edge.getStyle();
+        List<Position> lineRootingPoints = edge.getRoutingPoints();
+
+        edgeExport.append("<g>"); //$NON-NLS-1$
+        edgeExport.append(this.exportLine(style, lineRootingPoints));
+        edgeExport.append(this.exportAdditionals(style, lineRootingPoints));
+        edgeExport.append(this.exportEdgeLabels(edge));
+
+        return edgeExport.append("</g>"); //$NON-NLS-1$
+    }
+
+    private StringBuilder exportEdgeLabels(Edge edge) {
+        StringBuilder labelsExport = new StringBuilder();
+        if (edge.getBeginLabel() != null) {
+            labelsExport.append(this.elementExport.exportLabel(edge.getBeginLabel()));
+        }
+        if (edge.getCenterLabel() != null) {
+            labelsExport.append(this.elementExport.exportLabel(edge.getCenterLabel()));
+        }
+        if (edge.getEndLabel() != null) {
+            labelsExport.append(this.elementExport.exportLabel(edge.getEndLabel()));
+        }
+        return labelsExport;
+    }
+
+    private StringBuilder exportLine(EdgeStyle style, List<Position> rootingPoints) {
+        StringBuilder lineExport = new StringBuilder();
+        lineExport.append("<g>"); //$NON-NLS-1$
+
+        lineExport.append("<path "); //$NON-NLS-1$
+        lineExport.append("d=\"" + this.exportLinePath(rootingPoints) + "\" "); //$NON-NLS-1$ //$NON-NLS-2$
+        lineExport.append("style=\"" + this.exportLineStyle(style) + "\"/>"); //$NON-NLS-1$ //$NON-NLS-2$
+
+        return lineExport.append("</g>"); //$NON-NLS-1$
+    }
+
+    private StringBuilder exportStrokeDasharray(EdgeStyle style) {
+        StringBuilder dashArrayExport = new StringBuilder();
+        String lineStyleName = style.getLineStyle().toString();
+
+        if (lineStyleName.equals("Dash")) { //$NON-NLS-1$
+            dashArrayExport.append("stroke-dasharray: 5,5;"); //$NON-NLS-1$
+        } else if (lineStyleName.equals("Dot")) { //$NON-NLS-1$
+            dashArrayExport.append("stroke-dasharray: 2,2;"); //$NON-NLS-1$
+        } else if (lineStyleName.equals("Dash_Dot")) { //$NON-NLS-1$
+            dashArrayExport.append("stroke-dasharray: 10,5,2,2,2,5;"); //$NON-NLS-1$
+        }
+
+        return dashArrayExport;
+    }
+
+    private StringBuilder exportLineStyle(EdgeStyle style) {
+        StringBuilder styleExport = new StringBuilder();
+
+        styleExport.append("stroke: " + style.getColor() + "; "); //$NON-NLS-1$ //$NON-NLS-2$
+        styleExport.append("stroke-width: " + style.getSize() + "px; "); //$NON-NLS-1$ //$NON-NLS-2$
+        styleExport.append("pointer-events: stroke; "); //$NON-NLS-1$
+        styleExport.append("fill: none; "); //$NON-NLS-1$
+
+        return styleExport.append(this.exportStrokeDasharray(style));
+    }
+
+    private StringBuilder exportLinePath(List<Position> rootingPoints) {
+        StringBuilder pathExport = new StringBuilder();
+
+        Position[] positions = rootingPoints.toArray(Position[]::new);
+        Position firstPoint = positions[0];
+        pathExport.append("M "); //$NON-NLS-1$
+        pathExport.append(firstPoint.getX());
+        pathExport.append(","); //$NON-NLS-1$
+        pathExport.append(firstPoint.getY());
+        for (int i = 1; i < positions.length; i++) {
+            Position point = positions[i];
+            pathExport.append(" L "); //$NON-NLS-1$
+            pathExport.append(point.getX());
+            pathExport.append(","); //$NON-NLS-1$
+            pathExport.append(point.getY());
+        }
+        return pathExport;
+    }
+
+    private StringBuilder exportAdditionals(EdgeStyle style, List<Position> rootingPoints) {
+        StringBuilder additionalsExport = new StringBuilder();
+
+        additionalsExport.append(this.exportArrow(rootingPoints.get(0), rootingPoints.get(1), style.getSourceArrow().toString(), style));
+        return additionalsExport.append(this.exportArrow(rootingPoints.get(rootingPoints.size() - 2), rootingPoints.get(rootingPoints.size() - 1), style.getTargetArrow().toString(), style));
+    }
+
+    private StringBuilder exportArrow(Position p1, Position p2, String arrowStyle, EdgeStyle style) {
+        StringBuilder arrowExport;
+
+        String styleName = arrowStyle.toString();
+
+        if (styleName.equals("OutputArrow")) { //$NON-NLS-1$
+            arrowExport = this.exportOutputArrow(p1, p2, style);
+        } else if (styleName.equals("InputArrow")) { //$NON-NLS-1$
+            arrowExport = this.exportInputArrow(p1, p2, style);
+        } else if (styleName.equals("OutputClosedArrow")) { //$NON-NLS-1$
+            arrowExport = this.exportOutputClosedArrow(p1, p2, style, false);
+        } else if (styleName.equals("InputClosedArrow")) { //$NON-NLS-1$
+            arrowExport = this.exportInputClosedArrow(p1, p2, style, false);
+        } else if (styleName.equals("OutputFillClosedArrow")) { //$NON-NLS-1$
+            arrowExport = this.exportOutputClosedArrow(p1, p2, style, true);
+        } else if (styleName.equals("InputFillClosedArrow")) { //$NON-NLS-1$
+            arrowExport = this.exportInputClosedArrow(p1, p2, style, true);
+        } else if (styleName.equals("Diamond")) { //$NON-NLS-1$
+            arrowExport = this.exportDiamondArrow(p1, p2, style, false);
+        } else if (styleName.equals("FillDiamond")) { //$NON-NLS-1$
+            arrowExport = this.exportDiamondArrow(p1, p2, style, true);
+        } else if (styleName.equals("InputArrowWithDiamond")) { //$NON-NLS-1$
+            arrowExport = this.exportInputArrowWithDiamond(p1, p2, style, false);
+        } else if (styleName.equals("InputArrowWithFillDiamond")) { //$NON-NLS-1$
+            arrowExport = this.exportInputArrowWithDiamond(p1, p2, style, true);
+        } else if (styleName.equals("Circle")) { //$NON-NLS-1$
+            arrowExport = this.exportCircleArrow(p1, p2, style, false);
+        } else if (styleName.equals("FillCircle")) { //$NON-NLS-1$
+            arrowExport = this.exportCircleArrow(p1, p2, style, true);
+        } else {
+            arrowExport = new StringBuilder();
+        }
+
+        return arrowExport;
+    }
+
+    private StringBuilder exportOutputArrow(Position p1, Position p2, EdgeStyle style) {
+        StringBuilder arrowExport = new StringBuilder();
+        double offsetX = p2.getX() + style.getSize();
+        double offsetY = p2.getY();
+        double rotationAngle = Math.toDegrees(this.angle(p2, p1));
+        double rotationX = p2.getX();
+        double rotationY = p2.getY();
+        StringBuilder path = this.exportBasicArrowPath(style.getSize());
+        StringBuilder transformation = this.exportArrowTransformation(rotationAngle, rotationX, rotationY, offsetX, offsetY);
+        StringBuilder arrowStyle = this.exportArrowStyle(style, style.getColor());
+        return arrowExport.append(this.buildArrowPath(path, transformation, arrowStyle));
+    }
+
+    private StringBuilder exportInputArrow(Position p1, Position p2, EdgeStyle style) {
+        StringBuilder arrowExport = new StringBuilder();
+        double offsetX = p2.getX();
+        double offsetY = p2.getY();
+        double rotationAngle = Math.toDegrees(this.angle(p1, p2));
+        double rotationX = p2.getX();
+        double rotationY = p2.getY();
+        StringBuilder path = this.exportBasicArrowPath(style.getSize());
+        StringBuilder transformation = this.exportArrowTransformation(rotationAngle, rotationX, rotationY, offsetX, offsetY);
+        StringBuilder arrowStyle = this.exportArrowStyle(style, "none"); //$NON-NLS-1$
+        return arrowExport.append(this.buildArrowPath(path, transformation, arrowStyle));
+    }
+
+    private StringBuilder exportOutputClosedArrow(Position p1, Position p2, EdgeStyle style, boolean fill) {
+        StringBuilder arrowExport = new StringBuilder();
+        String fillColor;
+        if (!fill) {
+            fillColor = "#ffffff"; //$NON-NLS-1$
+        } else {
+            fillColor = style.getColor();
+        }
+        double offsetX = p2.getX() + 5.5 + style.getSize();
+        double offsetY = p2.getY();
+        double rotationAngle = Math.toDegrees(this.angle(p2, p1));
+        double rotationX = p2.getX();
+        double rotationY = p2.getY();
+        StringBuilder path = this.exportBasicClosedArrowPath(style.getSize());
+        StringBuilder transformation = this.exportArrowTransformation(rotationAngle, rotationX, rotationY, offsetX, offsetY);
+        StringBuilder arrowStyle = this.exportArrowStyle(style, fillColor);
+        return arrowExport.append(this.buildArrowPath(path, transformation, arrowStyle));
+    }
+
+    private StringBuilder exportInputClosedArrow(Position p1, Position p2, EdgeStyle style, boolean fill) {
+        StringBuilder arrowExport = new StringBuilder();
+        String fillColor;
+        if (!fill) {
+            fillColor = "#ffffff"; //$NON-NLS-1$
+        } else {
+            fillColor = style.getColor();
+        }
+        double offsetX = p2.getX();
+        double offsetY = p2.getY();
+        double rotationAngle = Math.toDegrees(this.angle(p1, p2));
+        double rotationX = p2.getX();
+        double rotationY = p2.getY();
+        StringBuilder path = this.exportBasicClosedArrowPath(style.getSize());
+        StringBuilder transformation = this.exportArrowTransformation(rotationAngle, rotationX, rotationY, offsetX, offsetY);
+        StringBuilder arrowStyle = this.exportArrowStyle(style, fillColor);
+        arrowExport.append(this.buildArrowPath(path, transformation, arrowStyle));
+        return arrowExport;
+    }
+
+    private StringBuilder exportDiamondArrow(Position p1, Position p2, EdgeStyle style, boolean fill) {
+        StringBuilder arrowExport = new StringBuilder();
+        String fillColor;
+        if (!fill) {
+            fillColor = "#ffffff"; //$NON-NLS-1$
+        } else {
+            fillColor = style.getColor();
+        }
+        double offsetX = p2.getX();
+        double offsetY = p2.getY();
+        double rotationAngle = Math.toDegrees(this.angle(p2, p1));
+        double rotationX = p2.getX();
+        double rotationY = p2.getY();
+        StringBuilder path = this.exportBasicDiamondPath(style.getSize());
+        StringBuilder transformation = this.exportArrowTransformation(rotationAngle, rotationX, rotationY, offsetX, offsetY);
+        StringBuilder arrowStyle = this.exportArrowStyle(style, fillColor);
+        arrowExport.append(this.buildArrowPath(path, transformation, arrowStyle));
+        return arrowExport;
+    }
+
+    private StringBuilder exportInputArrowWithDiamond(Position p1, Position p2, EdgeStyle style, boolean fill) {
+        StringBuilder arrowExport = new StringBuilder();
+        String fillColor;
+        if (!fill) {
+            fillColor = "#ffffff"; //$NON-NLS-1$
+        } else {
+            fillColor = style.getColor();
+        }
+        double offsetX = p2.getX() + style.getSize();
+        double offsetY = p2.getY();
+        double rotationAngle = Math.toDegrees(this.angle(p2, p1));
+        double rotationX = p2.getX();
+        double rotationY = p2.getY();
+        StringBuilder path = this.exportInputArrowWithDiamondPath(style.getSize());
+        StringBuilder transformation = this.exportArrowTransformation(rotationAngle, rotationX, rotationY, offsetX, offsetY);
+        StringBuilder arrowStyle = this.exportArrowStyle(style, fillColor);
+        return arrowExport.append(this.buildArrowPath(path, transformation, arrowStyle));
+    }
+
+    private StringBuilder exportCircleArrow(Position p1, Position p2, EdgeStyle styleObject, boolean fill) {
+        StringBuilder arrowExport = new StringBuilder();
+        String fillColor;
+        if (!fill) {
+            fillColor = "#ffffff"; //$NON-NLS-1$
+        } else {
+            fillColor = styleObject.getColor();
+        }
+        double rotationAngle = Math.toDegrees(this.angle(p2, p1));
+        double rotationX = p2.getX();
+        double rotationY = p2.getY();
+        double translateX = p2.getX() + 5;
+        double translateY = p2.getY();
+
+        StringBuilder arrowTransformation = this.exportArrowTransformation(rotationAngle, rotationX, rotationY, translateX, translateY);
+        arrowExport.append("<circle "); //$NON-NLS-1$
+
+        arrowExport.append("transform=\""); //$NON-NLS-1$
+        arrowExport.append(arrowTransformation);
+        arrowExport.append("\" "); //$NON-NLS-1$
+
+        arrowExport.append("r=\""); //$NON-NLS-1$
+        arrowExport.append(4 + styleObject.getSize());
+        arrowExport.append("\" "); //$NON-NLS-1$
+
+        arrowExport.append("style=\""); //$NON-NLS-1$
+        arrowExport.append(this.exportArrowStyle(styleObject, fillColor));
+        arrowExport.append("\" "); //$NON-NLS-1$
+
+        return arrowExport.append("/>"); //$NON-NLS-1$
+    }
+
+    private StringBuilder exportBasicClosedArrowPath(int strokeWidth) {
+        return this.exportBasicArrowPath(strokeWidth).append("z"); //$NON-NLS-1$
+    }
+
+    private StringBuilder exportInputArrowWithDiamondPath(int strokeWidth) {
+        return this.exportBasicDiamondPath(strokeWidth).append(this.exportOffsetArrowPath(strokeWidth));
+    }
+
+    private StringBuilder exportBasicArrowPath(int strokeWidth) {
+        // Path definitions scaled with the stroke-width style attribute
+        StringBuilder basicArrowPathExport = new StringBuilder();
+        basicArrowPathExport.append("m "); //$NON-NLS-1$
+        basicArrowPathExport.append(-5 - strokeWidth);
+        basicArrowPathExport.append(" "); //$NON-NLS-1$
+        basicArrowPathExport.append(-3.5 - strokeWidth);
+        basicArrowPathExport.append(" L 0 0 L "); //$NON-NLS-1$
+        basicArrowPathExport.append(-5 - strokeWidth);
+        basicArrowPathExport.append(" "); //$NON-NLS-1$
+        return basicArrowPathExport.append(3.5 + strokeWidth);
+    }
+
+    private StringBuilder exportBasicDiamondPath(int strokeWidth) {
+        // Path definitions scaled with the stroke-width style attribute
+        StringBuilder basicDiamondPathExport = new StringBuilder();
+
+        basicDiamondPathExport.append("m 0 0 L "); //$NON-NLS-1$
+        basicDiamondPathExport.append(5 + strokeWidth);
+        basicDiamondPathExport.append(" "); //$NON-NLS-1$
+        basicDiamondPathExport.append(-3.5 - strokeWidth);
+        basicDiamondPathExport.append(" L "); //$NON-NLS-1$
+        basicDiamondPathExport.append(10 + strokeWidth * 2);
+        basicDiamondPathExport.append(" 0 L "); //$NON-NLS-1$
+        return basicDiamondPathExport.append(5 + strokeWidth);
+    }
+
+    private StringBuilder exportOffsetArrowPath(int strokeWidth) {
+        // Path definitions scaled with the stroke-width style attribute
+        StringBuilder offsetArrowPathExport = new StringBuilder();
+
+        offsetArrowPathExport.append("m "); //$NON-NLS-1$
+        offsetArrowPathExport.append((5 + strokeWidth) * 2);
+        offsetArrowPathExport.append(" 0 L "); //$NON-NLS-1$
+        offsetArrowPathExport.append((5 + strokeWidth) * 2 + (5 + strokeWidth));
+        offsetArrowPathExport.append(" "); //$NON-NLS-1$
+        offsetArrowPathExport.append(-3.5 - strokeWidth);
+        offsetArrowPathExport.append(" M "); //$NON-NLS-1$
+        offsetArrowPathExport.append((5 + strokeWidth) * 2);
+        offsetArrowPathExport.append(" 0 L "); //$NON-NLS-1$
+        offsetArrowPathExport.append((5 + strokeWidth) * 2 + (5 + strokeWidth));
+        offsetArrowPathExport.append(" "); //$NON-NLS-1$
+        return offsetArrowPathExport.append(3.5 + strokeWidth);
+    }
+
+    private StringBuilder buildArrowPath(StringBuilder path, StringBuilder transformation, StringBuilder style) {
+        StringBuilder arrowPath = new StringBuilder();
+        arrowPath.append("<path "); //$NON-NLS-1$
+        arrowPath.append("d=\""); //$NON-NLS-1$
+        arrowPath.append(path);
+        arrowPath.append("\" "); //$NON-NLS-1$
+
+        arrowPath.append("transform=\""); //$NON-NLS-1$
+        arrowPath.append(transformation);
+        arrowPath.append("\" "); //$NON-NLS-1$
+
+        arrowPath.append("style=\""); //$NON-NLS-1$
+        arrowPath.append(style);
+        return arrowPath.append("\"/>"); //$NON-NLS-1$
+    }
+
+    private StringBuilder exportArrowStyle(EdgeStyle style, String fillColor) {
+        StringBuilder arrowStyleExport = new StringBuilder();
+
+        arrowStyleExport.append("stroke:"); //$NON-NLS-1$
+        arrowStyleExport.append(style.getColor());
+        arrowStyleExport.append("; "); //$NON-NLS-1$
+
+        arrowStyleExport.append("stroke-width:"); //$NON-NLS-1$
+        arrowStyleExport.append(style.getSize());
+        arrowStyleExport.append("; "); //$NON-NLS-1$
+
+        arrowStyleExport.append("fill:"); //$NON-NLS-1$
+        arrowStyleExport.append(fillColor);
+        return arrowStyleExport.append(";"); //$NON-NLS-1$
+    }
+
+    private StringBuilder exportArrowTransformation(double rotationAngle, double rotationX, double rotationY, double translateX, double translateY) {
+        StringBuilder transformation = new StringBuilder();
+        transformation.append("rotate("); //$NON-NLS-1$
+        transformation.append(rotationAngle);
+        transformation.append(" "); //$NON-NLS-1$
+        transformation.append(rotationX);
+        transformation.append(" "); //$NON-NLS-1$
+        transformation.append(rotationY);
+        transformation.append(")"); //$NON-NLS-1$
+
+        transformation.append(" translate("); //$NON-NLS-1$
+        transformation.append(translateX);
+        transformation.append(" "); //$NON-NLS-1$
+        transformation.append(translateY);
+        return transformation.append(")"); //$NON-NLS-1$
+    }
+
+    private double angle(Position a, Position b) {
+        return Math.atan2(b.getY() - a.getY(), b.getX() - a.getX());
+    }
+}

--- a/backend/sirius-components-collaborative-diagrams/src/main/java/org/eclipse/sirius/components/collaborative/diagrams/export/svg/ImageRegistry.java
+++ b/backend/sirius-components-collaborative-diagrams/src/main/java/org/eclipse/sirius/components/collaborative/diagrams/export/svg/ImageRegistry.java
@@ -1,0 +1,147 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.collaborative.diagrams.export.svg;
+
+import java.io.IOException;
+import java.net.CookieHandler;
+import java.net.CookieManager;
+import java.net.CookieStore;
+import java.net.HttpCookie;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+
+import org.eclipse.sirius.components.diagrams.Diagram;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.web.context.annotation.RequestScope;
+
+/**
+ * Registers the images referenced in a {@link Diagram} for later retrieval as \<symbol\>.
+ *
+ * @author rpage
+ */
+@Service
+@RequestScope
+public class ImageRegistry {
+    private final Map<URI, UUID> imageRegistry = new HashMap<>();
+
+    private final HttpClient imageFetcher;
+
+    private final URI imageBasePath;
+
+    private final Logger logger = LoggerFactory.getLogger(ImageRegistry.class);
+
+    public ImageRegistry(HttpServletRequest request) throws URISyntaxException {
+        Objects.requireNonNull(request);
+        URI uri = URI.create(request.getRequestURL().toString());
+        this.imageBasePath = new URI(uri.getScheme() + "://" + uri.getHost() + ":" + uri.getPort() + "/api/images"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        this.imageFetcher = this.buildImageClient(request);
+    }
+
+    public UUID registerImage(String imageURL) {
+        try {
+            URI imageFullPath = new URI(this.imageBasePath.toString() + imageURL);
+            UUID symbolId = this.imageRegistry.get(imageFullPath);
+            if (symbolId == null) {
+                symbolId = UUID.randomUUID();
+                this.imageRegistry.put(imageFullPath, symbolId);
+            }
+            return symbolId;
+        } catch (URISyntaxException e) {
+            this.logger.warn(e.getMessage(), e);
+            return null;
+        }
+    }
+
+    public StringBuilder getReferencedImageSymbols() {
+        StringBuilder symbols = new StringBuilder();
+        this.imageRegistry.entrySet().forEach(entry -> symbols.append(this.getReferencedImage(entry.getKey(), entry.getValue())));
+        return symbols;
+    }
+
+    private StringBuilder getReferencedImage(URI imageURI, UUID symbolId) {
+        HttpRequest request = HttpRequest.newBuilder().uri(imageURI).GET().build();
+        Optional<String> imageType = this.getImageType(imageURI);
+        if (!imageType.isPresent()) {
+            this.logger.warn("The type of the image at URI " + imageURI + " is not valid."); //$NON-NLS-1$ //$NON-NLS-2$
+        } else {
+            try {
+                byte[] content = this.imageFetcher.send(request, BodyHandlers.ofByteArray()).body();
+                return this.addSymbolElement(symbolId, imageType.get(), content);
+            } catch (IOException | InterruptedException e) {
+                this.logger.warn(e.getMessage(), e);
+            }
+        }
+        return new StringBuilder();
+    }
+
+    private StringBuilder addSymbolElement(UUID symbolId, String imageType, byte[] content) {
+        StringBuilder symbol = new StringBuilder();
+        symbol.append("<symbol id=\"" + symbolId + "\">"); //$NON-NLS-1$ //$NON-NLS-2$
+        if ("svg".equals(imageType)) { //$NON-NLS-1$
+            symbol.append(new String(content));
+        } else {
+            symbol.append("<image xlink:href=\"data:image/" + imageType + ";charset=utf-8;base64,"); //$NON-NLS-1$ //$NON-NLS-2$
+            String encodedString = Base64.getEncoder().encodeToString(content);
+            symbol.append(encodedString);
+            symbol.append("\"/>"); //$NON-NLS-1$
+        }
+        return symbol.append("</symbol>"); //$NON-NLS-1$
+    }
+
+    private Optional<String> getImageType(URI imageURI) {
+        String imagePath = imageURI.getPath();
+        String fileName = imagePath.substring(imagePath.lastIndexOf("/") + 1); //$NON-NLS-1$
+        // @formatter:off
+        return Optional.ofNullable(fileName)
+                .filter(name -> name.contains("."))  //$NON-NLS-1$
+                .map(name -> name.substring(fileName.lastIndexOf(".") + 1)); //$NON-NLS-1$
+        // @formatter:on
+    }
+
+    private HttpClient buildImageClient(HttpServletRequest request) {
+        this.addRequestCookies(request);
+        return HttpClient.newBuilder().cookieHandler(CookieHandler.getDefault()).build();
+    }
+
+    private void addRequestCookies(HttpServletRequest request) {
+        CookieHandler.setDefault(new CookieManager());
+        Cookie[] cookies = request.getCookies();
+        CookieStore store = ((CookieManager) CookieHandler.getDefault()).getCookieStore();
+        if (cookies != null) {
+            // @formatter:off
+             Arrays.stream(cookies)
+                 .forEach(cookie -> {
+                     HttpCookie newCookie = new HttpCookie(cookie.getName(), cookie.getValue());
+                     newCookie.setPath("/"); //$NON-NLS-1$
+                     newCookie.setVersion(0);
+                     store.add(this.imageBasePath, newCookie);
+                 });
+             // @formatter:on
+        }
+    }
+}

--- a/backend/sirius-components-collaborative-diagrams/src/main/java/org/eclipse/sirius/components/collaborative/diagrams/export/svg/NodeExportService.java
+++ b/backend/sirius-components-collaborative-diagrams/src/main/java/org/eclipse/sirius/components/collaborative/diagrams/export/svg/NodeExportService.java
@@ -1,0 +1,138 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.collaborative.diagrams.export.svg;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.eclipse.sirius.components.diagrams.INodeStyle;
+import org.eclipse.sirius.components.diagrams.ImageNodeStyle;
+import org.eclipse.sirius.components.diagrams.Label;
+import org.eclipse.sirius.components.diagrams.ListItemNodeStyle;
+import org.eclipse.sirius.components.diagrams.ListNodeStyle;
+import org.eclipse.sirius.components.diagrams.Node;
+import org.eclipse.sirius.components.diagrams.RectangularNodeStyle;
+import org.eclipse.sirius.components.diagrams.Size;
+import org.springframework.stereotype.Service;
+
+/**
+ * Used to export a {@link Node} to SVG.
+ *
+ * @author rpage
+ */
+@Service
+@SuppressWarnings("checkstyle:MultipleStringLiterals")
+public class NodeExportService {
+    private final DiagramElementExportService elementExport;
+
+    public NodeExportService(DiagramElementExportService elementExport) {
+        this.elementExport = Objects.requireNonNull(elementExport);
+    }
+
+    public StringBuilder export(Node node) {
+        StringBuilder nodeExport = new StringBuilder();
+        INodeStyle style = node.getStyle();
+
+        if (style instanceof ImageNodeStyle) {
+            nodeExport.append(this.exportImage(node, (ImageNodeStyle) style));
+        } else if (style instanceof ListNodeStyle) {
+            nodeExport.append(this.exportList(node, (ListNodeStyle) style));
+        } else if (style instanceof ListItemNodeStyle) {
+            nodeExport.append(this.exportListItem(node, (ListItemNodeStyle) style));
+        } else if (style instanceof RectangularNodeStyle) {
+            nodeExport.append(this.exportRectangle(node, (RectangularNodeStyle) style));
+        }
+
+        return nodeExport;
+    }
+
+    private StringBuilder exportChildren(Node node) {
+        StringBuilder childrenExport = new StringBuilder();
+        // @formatter:off
+        Stream.concat(node.getBorderNodes().stream(),
+                      node.getChildNodes().stream())
+            .forEach(elt -> childrenExport.append(this.export(elt)));
+        // @formatter:on
+        return childrenExport;
+    }
+
+    private StringBuilder exportImage(Node node, ImageNodeStyle style) {
+        StringBuilder imageExport = new StringBuilder();
+        Size size = node.getSize();
+        Label label = node.getLabel();
+
+        imageExport.append(this.elementExport.exportGNodeElement(node));
+        imageExport.append(this.elementExport.exportImageElement(style.getImageURL(), 0, 0, Optional.of(size)));
+        imageExport.append(this.elementExport.exportLabel(label));
+        imageExport.append(this.exportChildren(node));
+
+        return imageExport.append("</g>"); //$NON-NLS-1$
+    }
+
+    private StringBuilder exportList(Node node, ListNodeStyle style) {
+        StringBuilder listExport = new StringBuilder();
+
+        listExport.append(this.elementExport.exportGNodeElement(node));
+        listExport.append(this.elementExport.exportRectangleElement(node.getSize(), Optional.of(style.getBorderRadius()), Optional.of(style.getColor()), Optional.of(style.getBorderColor()),
+                Optional.of(style.getBorderSize()), Optional.of(style.getBorderStyle())));
+        listExport.append(this.elementExport.exportLabel(node.getLabel()));
+        listExport.append(this.exportHeaderSeparator(node, node.getLabel(), style));
+        listExport.append(this.exportChildren(node));
+
+        return listExport.append("</g>"); //$NON-NLS-1$
+    }
+
+    private StringBuilder exportHeaderSeparator(Node node, Label label, ListNodeStyle nodeStyle) {
+        StringBuilder headerExport = new StringBuilder();
+        // The label y position indicates the padding top, we suppose the same padding is applied to the bottom.
+        double headerLabelPadding = label.getPosition().getY();
+        double y = label.getSize().getHeight() + 2 * headerLabelPadding;
+
+        headerExport.append("<line "); //$NON-NLS-1$
+        headerExport.append("x1=\"0\" "); //$NON-NLS-1$
+        headerExport.append("y1=\"" + y + "\" "); //$NON-NLS-1$ //$NON-NLS-2$
+        headerExport.append("x2=\"" + node.getSize().getWidth() + "\" "); //$NON-NLS-1$ //$NON-NLS-2$
+        headerExport.append("y2=\"" + y + "\" "); //$NON-NLS-1$ //$NON-NLS-2$
+        headerExport.append("style=\""); //$NON-NLS-1$
+        headerExport.append("stroke: " + nodeStyle.getBorderColor() + "; "); //$NON-NLS-1$ //$NON-NLS-2$
+        headerExport.append("stroke-width: " + nodeStyle.getBorderSize() + "; "); //$NON-NLS-1$ //$NON-NLS-2$
+        headerExport.append("\" "); //$NON-NLS-1$
+
+        return headerExport.append("/>"); //$NON-NLS-1$
+    }
+
+    private StringBuilder exportListItem(Node node, ListItemNodeStyle style) {
+        StringBuilder rectangleExport = new StringBuilder();
+
+        rectangleExport.append(this.elementExport.exportGNodeElement(node));
+        rectangleExport
+                .append(this.elementExport.exportRectangleElement(node.getSize(), Optional.empty(), Optional.of(style.getBackgroundColor()), Optional.empty(), Optional.empty(), Optional.empty()));
+        rectangleExport.append(this.elementExport.exportLabel(node.getLabel()));
+        rectangleExport.append(this.exportChildren(node));
+
+        return rectangleExport.append("</g>"); //$NON-NLS-1$
+    }
+
+    private StringBuilder exportRectangle(Node node, RectangularNodeStyle style) {
+        StringBuilder rectangleExport = new StringBuilder();
+
+        rectangleExport.append(this.elementExport.exportGNodeElement(node));
+        rectangleExport.append(this.elementExport.exportRectangleElement(node.getSize(), Optional.of(style.getBorderRadius()), Optional.of(style.getColor()), Optional.of(style.getBorderColor()),
+                Optional.of(style.getBorderSize()), Optional.of(style.getBorderStyle())));
+        rectangleExport.append(this.elementExport.exportLabel(node.getLabel()));
+        rectangleExport.append(this.exportChildren(node));
+
+        return rectangleExport.append("</g>"); //$NON-NLS-1$
+    }
+}

--- a/backend/sirius-components-collaborative-diagrams/src/main/java/org/eclipse/sirius/components/collaborative/diagrams/handlers/ExportDiagramEventHandler.java
+++ b/backend/sirius-components-collaborative-diagrams/src/main/java/org/eclipse/sirius/components/collaborative/diagrams/handlers/ExportDiagramEventHandler.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.collaborative.diagrams.handlers;
+
+import java.util.Objects;
+
+import org.eclipse.sirius.components.collaborative.api.ChangeDescription;
+import org.eclipse.sirius.components.collaborative.diagrams.api.IDiagramContext;
+import org.eclipse.sirius.components.collaborative.diagrams.api.IDiagramEventHandler;
+import org.eclipse.sirius.components.collaborative.diagrams.api.IDiagramInput;
+import org.eclipse.sirius.components.collaborative.diagrams.dto.ExportRepresentationInput;
+import org.eclipse.sirius.components.collaborative.diagrams.dto.ExportRepresentationPayload;
+import org.eclipse.sirius.components.collaborative.diagrams.export.api.ISVGDiagramExportService;
+import org.eclipse.sirius.components.core.api.IEditingContext;
+import org.eclipse.sirius.components.core.api.IPayload;
+import org.springframework.stereotype.Service;
+
+import reactor.core.publisher.Sinks.Many;
+import reactor.core.publisher.Sinks.One;
+
+/**
+ * Handler used to export a representation.
+ *
+ * @author rpage
+ */
+@Service
+public class ExportDiagramEventHandler implements IDiagramEventHandler {
+    private final ISVGDiagramExportService exportService;
+
+    public ExportDiagramEventHandler(ISVGDiagramExportService exportService) {
+        this.exportService = Objects.requireNonNull(exportService);
+    }
+
+    @Override
+    public boolean canHandle(IDiagramInput diagramInput) {
+        return diagramInput instanceof ExportRepresentationInput;
+    }
+
+    @Override
+    public void handle(One<IPayload> payloadSink, Many<ChangeDescription> changeDescriptionSink, IEditingContext editingContext, IDiagramContext diagramContext, IDiagramInput diagramInput) {
+        String svgExport = this.exportService.export(diagramContext.getDiagram());
+        IPayload payload = new ExportRepresentationPayload(diagramInput.getId(), diagramContext.getDiagram().getLabel() + ".svg", svgExport); //$NON-NLS-1$
+        payloadSink.tryEmitValue(payload);
+    }
+}

--- a/backend/sirius-components-collaborative-forms/pom.xml
+++ b/backend/sirius-components-collaborative-forms/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-collaborative-forms</artifactId>
-	<version>2022.01.6</version>
+	<version>2022.01.7</version>
 	<name>sirius-components-collaborative-forms</name>
 	<description>Sirius Components Collaborative Forms</description>
 
@@ -50,23 +50,23 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-forms</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-tests</artifactId>
-    		<version>2022.01.6</version>
+    		<version>2022.01.7</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-spring-tests</artifactId>
-    		<version>2022.01.6</version>
+    		<version>2022.01.7</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>

--- a/backend/sirius-components-collaborative-selection/pom.xml
+++ b/backend/sirius-components-collaborative-selection/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-collaborative-selection</artifactId>
-	<version>2022.01.6</version>
+	<version>2022.01.7</version>
 	<name>sirius-components-collaborative-selection</name>
 	<description>Sirius Components Collaborative Selection</description>
 
@@ -43,7 +43,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-selection</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>
@@ -56,18 +56,18 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/backend/sirius-components-collaborative-trees/pom.xml
+++ b/backend/sirius-components-collaborative-trees/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-collaborative-trees</artifactId>
-	<version>2022.01.6</version>
+	<version>2022.01.7</version>
 	<name>sirius-components-collaborative-trees</name>
 	<description>Sirius Components Collaborative Trees</description>
 
@@ -42,12 +42,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-trees</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>
@@ -64,13 +64,13 @@
 		<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-tests</artifactId>
-    		<version>2022.01.6</version>
+    		<version>2022.01.7</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-spring-tests</artifactId>
-    		<version>2022.01.6</version>
+    		<version>2022.01.7</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>

--- a/backend/sirius-components-collaborative-validation/pom.xml
+++ b/backend/sirius-components-collaborative-validation/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-collaborative-validation</artifactId>
-	<version>2022.01.6</version>
+	<version>2022.01.7</version>
 	<name>sirius-components-collaborative-validation</name>
 	<description>Sirius Components Collaborative Validation</description>
 	
@@ -46,12 +46,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-validation</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -61,13 +61,13 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 			<scope>test</scope>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-spring-tests</artifactId>
-    		<version>2022.01.6</version>
+    		<version>2022.01.7</version>
     		<scope>test</scope>
     	</dependency>
 	</dependencies>

--- a/backend/sirius-components-collaborative/pom.xml
+++ b/backend/sirius-components-collaborative/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-collaborative</artifactId>
-	<version>2022.01.6</version>
+	<version>2022.01.7</version>
 	<name>sirius-components-collaborative</name>
 	<description>Sirius Components Collaborative</description>
 
@@ -66,12 +66,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-core</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -80,13 +80,13 @@
 		<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-tests</artifactId>
-    		<version>2022.01.6</version>
+    		<version>2022.01.7</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-spring-tests</artifactId>
-    		<version>2022.01.6</version>
+    		<version>2022.01.7</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>

--- a/backend/sirius-components-collaborative/pom.xml
+++ b/backend/sirius-components-collaborative/pom.xml
@@ -74,6 +74,10 @@
 			<version>2022.01.6</version>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+		<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-tests</artifactId>
     		<version>2022.01.6</version>

--- a/backend/sirius-components-collaborative/src/main/java/org/eclipse/sirius/components/collaborative/editingcontext/EditingContextEventProcessor.java
+++ b/backend/sirius-components-collaborative/src/main/java/org/eclipse/sirius/components/collaborative/editingcontext/EditingContextEventProcessor.java
@@ -40,6 +40,7 @@ import org.eclipse.sirius.components.collaborative.dto.RenameRepresentationInput
 import org.eclipse.sirius.components.collaborative.dto.RepresentationRefreshedEvent;
 import org.eclipse.sirius.components.collaborative.dto.RepresentationRenamedEventPayload;
 import org.eclipse.sirius.components.collaborative.messages.ICollaborativeMessageService;
+import org.eclipse.sirius.components.collaborative.requestcontext.DelegatingRequestContextExecutorService;
 import org.eclipse.sirius.components.core.api.ErrorPayload;
 import org.eclipse.sirius.components.core.api.IEditingContext;
 import org.eclipse.sirius.components.core.api.IEditingContextPersistenceService;
@@ -109,7 +110,7 @@ public class EditingContextEventProcessor implements IEditingContextEventProcess
         this.editingContextEventHandlers = parameters.getEditingContextEventHandlers();
         this.representationEventProcessorComposedFactory = parameters.getRepresentationEventProcessorComposedFactory();
         this.danglingRepresentationDeletionService = parameters.getDanglingRepresentationDeletionService();
-        this.executorService = parameters.getExecutorServiceProvider().getExecutorService(this.editingContext);
+        this.executorService = new DelegatingRequestContextExecutorService(parameters.getExecutorServiceProvider().getExecutorService(this.editingContext));
         this.changeDescriptionDisposable = this.setupChangeDescriptionSinkConsumer();
     }
 

--- a/backend/sirius-components-collaborative/src/main/java/org/eclipse/sirius/components/collaborative/requestcontext/DelegatingRequestContextCallable.java
+++ b/backend/sirius-components-collaborative/src/main/java/org/eclipse/sirius/components/collaborative/requestcontext/DelegatingRequestContextCallable.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.collaborative.requestcontext;
+
+import java.util.Objects;
+import java.util.concurrent.Callable;
+
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+
+/**
+ * Wraps a delegate {@link Callable} with logic for setting up a {@link RequestAttributes} before invoking the delegate
+ * {@link Callable} and then removing the {@link RequestAttributes} after the delegate has completed.
+ *
+ * @param <V>
+ *            the result type of method {@code call}
+ * @author rpage
+ */
+public class DelegatingRequestContextCallable<V> implements Callable<V> {
+    private final Callable<V> delegate;
+
+    private final RequestAttributes delegateRequestContext;
+
+    public DelegatingRequestContextCallable(Callable<V> delegate) {
+        this.delegate = Objects.requireNonNull(delegate);
+        this.delegateRequestContext = RequestContextHolder.getRequestAttributes();
+    }
+
+    @Override
+    public V call() throws Exception {
+        try {
+            RequestContextHolder.setRequestAttributes(this.delegateRequestContext, true);
+            return this.delegate.call();
+        } finally {
+            RequestContextHolder.resetRequestAttributes();
+        }
+    }
+
+    @Override
+    public String toString() {
+        return this.delegate.toString();
+    }
+}

--- a/backend/sirius-components-collaborative/src/main/java/org/eclipse/sirius/components/collaborative/requestcontext/DelegatingRequestContextExecutorService.java
+++ b/backend/sirius-components-collaborative/src/main/java/org/eclipse/sirius/components/collaborative/requestcontext/DelegatingRequestContextExecutorService.java
@@ -1,0 +1,116 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.collaborative.requestcontext;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
+
+import org.springframework.web.context.request.RequestAttributes;
+
+/**
+ * An {@link ExecutorService} which wraps each {@link Runnable} and {@link Callable} in a {@link RequestAttributes}.
+ *
+ * @author rpage
+ */
+public class DelegatingRequestContextExecutorService implements ExecutorService {
+    private final ExecutorService delegate;
+
+    public DelegatingRequestContextExecutorService(ExecutorService delegate) {
+        this.delegate = Objects.requireNonNull(delegate);
+    }
+
+    @Override
+    public void execute(Runnable command) {
+        this.delegate.execute(this.wrap(command));
+    }
+
+    @Override
+    public void shutdown() {
+        this.delegate.shutdown();
+    }
+
+    @Override
+    public List<Runnable> shutdownNow() {
+        return this.delegate.shutdownNow();
+    }
+
+    @Override
+    public boolean isShutdown() {
+        return this.delegate.isShutdown();
+    }
+
+    @Override
+    public boolean isTerminated() {
+        return this.delegate.isTerminated();
+    }
+
+    @Override
+    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+        return this.delegate.awaitTermination(timeout, unit);
+    }
+
+    @Override
+    public <T> Future<T> submit(Callable<T> task) {
+        return this.delegate.submit(this.wrap(task));
+    }
+
+    @Override
+    public <T> Future<T> submit(Runnable task, T result) {
+        return this.delegate.submit(this.wrap(task), result);
+    }
+
+    @Override
+    public Future<?> submit(Runnable task) {
+        return this.delegate.submit(this.wrap(task));
+    }
+
+    @Override
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
+        return this.delegate.invokeAll(this.wrap(tasks));
+    }
+
+    @Override
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException {
+        return this.delegate.invokeAll(this.wrap(tasks), timeout, unit);
+    }
+
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
+        return this.delegate.invokeAny(this.wrap(tasks));
+    }
+
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+        return this.delegate.invokeAny(this.wrap(tasks), timeout, unit);
+    }
+
+    private <T> Collection<Callable<T>> wrap(Collection<? extends Callable<T>> tasks) {
+        return tasks.stream().map(task -> this.wrap(task)).collect(Collectors.toList());
+    }
+
+    private Runnable wrap(Runnable task) {
+        return new DelegatingRequestContextRunnable(task);
+    }
+
+    private <T> Callable<T> wrap(Callable<T> task) {
+        return new DelegatingRequestContextCallable<>(task);
+    }
+}

--- a/backend/sirius-components-collaborative/src/main/java/org/eclipse/sirius/components/collaborative/requestcontext/DelegatingRequestContextRunnable.java
+++ b/backend/sirius-components-collaborative/src/main/java/org/eclipse/sirius/components/collaborative/requestcontext/DelegatingRequestContextRunnable.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.collaborative.requestcontext;
+
+import java.util.Objects;
+
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+
+/**
+ * Wraps a delegate {@link Runnable} with logic for setting up a {@link RequestAttributes} before invoking the delegate
+ * {@link Runnable} and then removing the {@link RequestAttributes} after the delegate has completed.
+ *
+ * @author rpage
+ */
+public class DelegatingRequestContextRunnable implements Runnable {
+    private final Runnable delegate;
+
+    private final RequestAttributes delegateRequestContext;
+
+    public DelegatingRequestContextRunnable(Runnable delegate) {
+        this.delegate = Objects.requireNonNull(delegate);
+        this.delegateRequestContext = RequestContextHolder.getRequestAttributes();
+    }
+
+    @Override
+    public void run() {
+        try {
+            RequestContextHolder.setRequestAttributes(this.delegateRequestContext, true);
+            this.delegate.run();
+        } finally {
+            RequestContextHolder.resetRequestAttributes();
+        }
+    }
+
+    @Override
+    public String toString() {
+        return this.delegate.toString();
+    }
+}

--- a/backend/sirius-components-compatibility/pom.xml
+++ b/backend/sirius-components-compatibility/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-compatibility</artifactId>
-	<version>2022.01.6</version>
+	<version>2022.01.7</version>
 	<name>sirius-components-compatibility</name>
 	<description>Sirius Components Compatibility</description>
 
@@ -63,7 +63,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -73,43 +73,43 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-core</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-diagrams</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-forms</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-forms</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-selection</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-trees</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-interpreter</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.emf</groupId>

--- a/backend/sirius-components-core/pom.xml
+++ b/backend/sirius-components-core/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-core</artifactId>
-	<version>2022.01.6</version>
+	<version>2022.01.7</version>
 	<name>sirius-components-core</name>
 	<description>Sirius Components Core</description>
 
@@ -51,17 +51,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend/sirius-components-diagrams-layout-api/pom.xml
+++ b/backend/sirius-components-diagrams-layout-api/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-diagrams-layout-api</artifactId>
-	<version>2022.01.6</version>
+	<version>2022.01.7</version>
 	<name>sirius-components-diagrams-layout-api</name>
 	<description>Sirius Components Diagrams Layout API</description>
 
@@ -42,12 +42,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-core</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 	</dependencies>
 

--- a/backend/sirius-components-diagrams-layout/pom.xml
+++ b/backend/sirius-components-diagrams-layout/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-diagrams-layout</artifactId>
-	<version>2022.01.6</version>
+	<version>2022.01.7</version>
 	<name>sirius-components-diagrams-layout</name>
 	<description>Sirius Components Diagrams layout</description>
 
@@ -65,17 +65,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-core</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-layout-api</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.elk</groupId>
@@ -112,7 +112,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -127,12 +127,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-tests</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/backend/sirius-components-diagrams-tests/pom.xml
+++ b/backend/sirius-components-diagrams-tests/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-diagrams-tests</artifactId>
-	<version>2022.01.6</version>
+	<version>2022.01.7</version>
 	<name>sirius-components-diagrams-tests</name>
 	<description>Sirius Components Diagrams Tests</description>
 
@@ -46,12 +46,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-core</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.assertj</groupId>

--- a/backend/sirius-components-diagrams/pom.xml
+++ b/backend/sirius-components-diagrams/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-diagrams</artifactId>
-	<version>2022.01.6</version>
+	<version>2022.01.7</version>
 	<name>sirius-components-diagrams</name>
 	<description>Sirius Components Diagrams</description>
 
@@ -42,7 +42,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -52,7 +52,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend/sirius-components-domain-design/pom.xml
+++ b/backend/sirius-components-domain-design/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-domain-design</artifactId>
-	<version>2022.01.6</version>
+	<version>2022.01.7</version>
 	<name>sirius-components-domain-design</name>
 	<description>Sirius Components Domain Definition DSL - Graphical Modeler Definition</description>
 
@@ -64,7 +64,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-domain</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 	</dependencies>
 	

--- a/backend/sirius-components-domain-edit/pom.xml
+++ b/backend/sirius-components-domain-edit/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-domain-edit</artifactId>
-	<version>2022.01.6</version>
+	<version>2022.01.7</version>
 	<name>sirius-components-domain-edit</name>
 	<description>Sirius Components Domain Definition DSL - Edit Support</description>
 
@@ -64,7 +64,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-domain</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 	</dependencies>
 	

--- a/backend/sirius-components-domain/pom.xml
+++ b/backend/sirius-components-domain/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-domain</artifactId>
-	<version>2022.01.6</version>
+	<version>2022.01.7</version>
 	<name>sirius-components-domain</name>
 	<description>Sirius Components Domain Definition DSL</description>
 

--- a/backend/sirius-components-emf/pom.xml
+++ b/backend/sirius-components-emf/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-emf</artifactId>
-	<version>2022.01.6</version>
+	<version>2022.01.7</version>
 	<name>sirius-components-emf</name>
 	<description>Sirius Components EMF</description>
 
@@ -62,52 +62,52 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql-api</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-diagrams</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-forms</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-trees</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-validation</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-compatibility</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-interpreter</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-domain</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.emf</groupId>
@@ -156,19 +156,19 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-tests</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend/sirius-components-forms-tests/pom.xml
+++ b/backend/sirius-components-forms-tests/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-forms-tests</artifactId>
-	<version>2022.01.6</version>
+	<version>2022.01.7</version>
 	<name>sirius-components-forms-tests</name>
 	<description>Sirius Components Forms Tests</description>
 
@@ -42,7 +42,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-forms</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.assertj</groupId>

--- a/backend/sirius-components-forms/pom.xml
+++ b/backend/sirius-components-forms/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-forms</artifactId>
-	<version>2022.01.6</version>
+	<version>2022.01.7</version>
 	<name>sirius-components-forms</name>
 	<description>Sirius Components Forms</description>
 
@@ -46,12 +46,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -61,7 +61,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/backend/sirius-components-graphiql/pom.xml
+++ b/backend/sirius-components-graphiql/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-graphiql</artifactId>
-	<version>2022.01.6</version>
+	<version>2022.01.7</version>
 	<name>sirius-components-graphiql</name>
 	<description>Sirius Components Graphiql support. This project contribute a GraphQL query tool on the /graphiql/index.html URI.</description>
 

--- a/backend/sirius-components-graphql-api/pom.xml
+++ b/backend/sirius-components-graphql-api/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-graphql-api</artifactId>
-	<version>2022.01.6</version>
+	<version>2022.01.7</version>
 	<name>sirius-components-graphql-api</name>
 	<description>Sirius Components GraphQL API</description>
 
@@ -48,7 +48,7 @@
     	<dependency>
         	<groupId>org.eclipse.sirius</groupId>
         	<artifactId>sirius-components-annotations-spring</artifactId>
-        	<version>2022.01.6</version>
+        	<version>2022.01.7</version>
     	</dependency>
 	</dependencies>
 

--- a/backend/sirius-components-graphql-utils/pom.xml
+++ b/backend/sirius-components-graphql-utils/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-graphql-utils</artifactId>
-	<version>2022.01.6</version>
+	<version>2022.01.7</version>
 	<name>sirius-components-graphql-utils</name>
 	<description>Sirius Components GraphQL Utils</description>
 
@@ -43,7 +43,7 @@
 		<dependency>
         	<groupId>org.eclipse.sirius</groupId>
         	<artifactId>sirius-components-annotations</artifactId>
-        	<version>2022.01.6</version>
+        	<version>2022.01.7</version>
     	</dependency>
 		<dependency>
         	<groupId>com.graphql-java</groupId>
@@ -53,7 +53,7 @@
     	<dependency>
    			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 			<scope>test</scope>
     	</dependency>
     	<dependency>

--- a/backend/sirius-components-graphql-voyager/pom.xml
+++ b/backend/sirius-components-graphql-voyager/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-graphql-voyager</artifactId>
-	<version>2022.01.6</version>
+	<version>2022.01.7</version>
 	<name>sirius-components-graphql-voyager</name>
 	<description>Sirius Components Graph Voyager. This project contribute a GraphQL API UX thanks to the https://github.com/APIs-guru/graphql-voyager project.</description>
 

--- a/backend/sirius-components-graphql/pom.xml
+++ b/backend/sirius-components-graphql/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-graphql</artifactId>
-	<version>2022.01.6</version>
+	<version>2022.01.7</version>
 	<name>sirius-components-graphql</name>
 	<description>Sirius Components GraphQL</description>
 
@@ -64,28 +64,28 @@
     	<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-annotations</artifactId>
-    		<version>2022.01.6</version>
+    		<version>2022.01.7</version>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-graphql-utils</artifactId>
-    		<version>2022.01.6</version>
+    		<version>2022.01.7</version>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-graphql-api</artifactId>
-    		<version>2022.01.6</version>
+    		<version>2022.01.7</version>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-tests</artifactId>
-    		<version>2022.01.6</version>
+    		<version>2022.01.7</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-spring-tests</artifactId>
-    		<version>2022.01.6</version>
+    		<version>2022.01.7</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>

--- a/backend/sirius-components-interpreter/pom.xml
+++ b/backend/sirius-components-interpreter/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-interpreter</artifactId>
-	<version>2022.01.6</version>
+	<version>2022.01.7</version>
 	<name>sirius-components-interpreter</name>
 	<description>Sirius Components Intepreter</description>
 

--- a/backend/sirius-components-representations/pom.xml
+++ b/backend/sirius-components-representations/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-representations</artifactId>
-	<version>2022.01.6</version>
+	<version>2022.01.7</version>
 	<name>sirius-components-representations</name>
 	<description>Sirius Components Representations</description>
 
@@ -46,7 +46,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 	</dependencies>
 

--- a/backend/sirius-components-selection/pom.xml
+++ b/backend/sirius-components-selection/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-selection</artifactId>
-	<version>2022.01.6</version>
+	<version>2022.01.7</version>
 	<name>sirius-components-selection</name>
 	<description>Sirius Components Selection</description>
 
@@ -42,17 +42,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend/sirius-components-spring-tests/pom.xml
+++ b/backend/sirius-components-spring-tests/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-spring-tests</artifactId>
-	<version>2022.01.6</version>
+	<version>2022.01.7</version>
 	<name>sirius-components-spring-tests</name>
 	<description>Sirius Components Spring Tests</description>
 
@@ -46,7 +46,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>

--- a/backend/sirius-components-starter/pom.xml
+++ b/backend/sirius-components-starter/pom.xml
@@ -15,7 +15,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-starter</artifactId>
-	<version>2022.01.6</version>
+	<version>2022.01.7</version>
 	<name>sirius-components-starter</name>
 	<description>Sirius Components Starter</description>
 
@@ -55,52 +55,52 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-layout</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-diagrams</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-forms</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-selection</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-trees</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-validation</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-emf</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-compatibility</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 	</dependencies>
 

--- a/backend/sirius-components-test-coverage/pom.xml
+++ b/backend/sirius-components-test-coverage/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-test-coverage</artifactId>
-	<version>2022.01.6</version>
+	<version>2022.01.7</version>
 	<name>sirius-components-test-coverage-aggregation</name>
 	<description>Sirius Web Test Coverage Aggregation</description>
 
@@ -42,142 +42,142 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations-spring</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-compatibility</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-core</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-layout</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-layout-api</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-domain</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-domain-design</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-domain-edit</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-emf</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-forms</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql-utils</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-interpreter</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-selection</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-diagrams</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-forms</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-selection</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-trees</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-validation</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql-api</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-trees</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-validation</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-edit</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 	</dependencies>
 

--- a/backend/sirius-components-tests/pom.xml
+++ b/backend/sirius-components-tests/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-tests</artifactId>
-	<version>2022.01.6</version>
+	<version>2022.01.7</version>
 	<name>sirius-components-tests</name>
 	<description>Sirius Components Tests</description>
 
@@ -51,7 +51,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 	</dependencies>
 

--- a/backend/sirius-components-tests/src/test/java/org/eclipse/sirius/components/tests/GeneralPurposeTests.java
+++ b/backend/sirius-components-tests/src/test/java/org/eclipse/sirius/components/tests/GeneralPurposeTests.java
@@ -61,6 +61,8 @@ public class GeneralPurposeTests {
 
     private static final String CHECKSTYLE_ILLEGAL_CATCH = "@SuppressWarnings(\"checkstyle:IllegalCatch\")"; //$NON-NLS-1$
 
+    private static final String CHECKSTYLE_MULTIPLE_STRING_LITERALS = "@SuppressWarnings(\"checkstyle:MultipleStringLiterals\")"; //$NON-NLS-1$
+
     private static final String BUILDER = "Builder"; //$NON-NLS-1$
 
     private static final String CHECKSTYLE_OFF = "CHECKSTYLE:OFF"; //$NON-NLS-1$
@@ -193,8 +195,9 @@ public class GeneralPurposeTests {
                 isValidUsage = isValidUsage && lines.get(index + 1).contains(BUILDER);
             } else if (line.contains(CHECKSTYLE_ILLEGAL_CATCH)) {
                 isValidUsage = true;
+            } else if (line.contains(CHECKSTYLE_MULTIPLE_STRING_LITERALS)) {
+                isValidUsage = true;
             }
-
             if (!isValidUsage) {
                 fail(this.createErrorMessage("@SuppressWarnings", javaFilePath, index)); //$NON-NLS-1$
             }

--- a/backend/sirius-components-trees/pom.xml
+++ b/backend/sirius-components-trees/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-trees</artifactId>
-	<version>2022.01.6</version>
+	<version>2022.01.7</version>
 	<name>sirius-components-trees</name>
 	<description>Sirius Components Trees</description>
 
@@ -42,17 +42,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/backend/sirius-components-validation/pom.xml
+++ b/backend/sirius-components-validation/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-validation</artifactId>
-	<version>2022.01.6</version>
+	<version>2022.01.7</version>
 	<name>sirius-components-validation</name>
 	<description>Sirius Components Validation</description>
 	
@@ -47,12 +47,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend/sirius-components-view-edit/pom.xml
+++ b/backend/sirius-components-view-edit/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-view-edit</artifactId>
-	<version>2022.01.6</version>
+	<version>2022.01.7</version>
 	<name>sirius-components-view-edit</name>
 	<description>Sirius Components View Definition DSL - Edit Support</description>
 
@@ -64,7 +64,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view</artifactId>
-			<version>2022.01.6</version>
+			<version>2022.01.7</version>
 		</dependency>
 	</dependencies>
 	

--- a/backend/sirius-components-view/pom.xml
+++ b/backend/sirius-components-view/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-view</artifactId>
-	<version>2022.01.6</version>
+	<version>2022.01.7</version>
 	<name>sirius-components-view</name>
 	<description>Sirius Components View Definition DSL</description>
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@eclipse-sirius/sirius-components",
-  "version": "2022.1.6",
+  "version": "2022.1.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@eclipse-sirius/sirius-components",
-      "version": "2022.1.6",
+      "version": "2022.1.7",
       "license": "EPL-2.0",
       "dependencies": {
         "uuid": "8.3.2"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-sirius/sirius-components",
-  "version": "2022.1.6",
+  "version": "2022.1.7",
   "author": "Eclipse Sirius",
   "license": "EPL-2.0",
   "description": "Reusable components used to build the Sirius Web frontend",

--- a/frontend/src/diagram/sprotty/views/EdgeView.tsx
+++ b/frontend/src/diagram/sprotty/views/EdgeView.tsx
@@ -33,7 +33,7 @@ export class EdgeView extends PolylineEdgeView {
       stroke: style.color,
       'stroke-width': style.size,
       'pointer-events': 'stroke',
-      fill: 'transparent',
+      fill: 'none',
     };
 
     if (style.lineStyle === 'Dash') {
@@ -193,7 +193,7 @@ export class EdgeView extends PolylineEdgeView {
   }
 
   buildInputArrow(path, p1, p2, styleObject) {
-    styleObject.fill = 'transparent';
+    styleObject.fill = 'none';
     const offsetX = p2.x;
     const offsetY = p2.y;
     const rotationAngle = toDegrees(angle(p1, p2));

--- a/frontend/src/tree/DiagramTreeItemContextMenuContribution.tsx
+++ b/frontend/src/tree/DiagramTreeItemContextMenuContribution.tsx
@@ -19,7 +19,7 @@ import React, { forwardRef, Fragment, useContext } from 'react';
 import { TreeItemContextMenuComponentProps } from 'tree/TreeItemContextMenuContribution.types';
 
 export const DiagramTreeItemContextMenuContribution = forwardRef(
-  ({ editingContextId, item, readOnly }: TreeItemContextMenuComponentProps) => {
+  ({ editingContextId, item, onClose }: TreeItemContextMenuComponentProps) => {
     const { httpOrigin } = useContext(ServerContext);
 
     return (
@@ -28,16 +28,15 @@ export const DiagramTreeItemContextMenuContribution = forwardRef(
           key="exportSVG"
           divider
           component="a"
+          onClick={onClose}
           href={`${httpOrigin}/api/editingcontexts/${editingContextId}/representations/${item.id}`}
           type="application/octet-stream"
           data-testid="exportSVG"
-          disabled={readOnly}
-          aria-disabled
         >
           <ListItemIcon>
             <GetAppIcon fontSize="small" />
           </ListItemIcon>
-          <ListItemText primary="Export to SVG" aria-disabled />
+          <ListItemText primary="Export to SVG" />
         </MenuItem>
       </Fragment>
     );

--- a/frontend/src/tree/DiagramTreeItemContextMenuContribution.tsx
+++ b/frontend/src/tree/DiagramTreeItemContextMenuContribution.tsx
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+import ListItemIcon from '@material-ui/core/ListItemIcon';
+import ListItemText from '@material-ui/core/ListItemText';
+import MenuItem from '@material-ui/core/MenuItem';
+import GetAppIcon from '@material-ui/icons/Image';
+import { ServerContext } from 'common/ServerContext';
+import React, { forwardRef, Fragment, useContext } from 'react';
+import { TreeItemContextMenuComponentProps } from 'tree/TreeItemContextMenuContribution.types';
+
+export const DiagramTreeItemContextMenuContribution = forwardRef(
+  ({ editingContextId, item, readOnly }: TreeItemContextMenuComponentProps) => {
+    const { httpOrigin } = useContext(ServerContext);
+
+    return (
+      <Fragment key="diagram-tree-item-context-menu-contribution">
+        <MenuItem
+          key="exportSVG"
+          divider
+          component="a"
+          href={`${httpOrigin}/api/editingcontexts/${editingContextId}/representations/${item.id}`}
+          type="application/octet-stream"
+          data-testid="exportSVG"
+          disabled={readOnly}
+          aria-disabled
+        >
+          <ListItemIcon>
+            <GetAppIcon fontSize="small" />
+          </ListItemIcon>
+          <ListItemText primary="Export to SVG" aria-disabled />
+        </MenuItem>
+      </Fragment>
+    );
+  }
+);

--- a/frontend/src/workbench/Workbench.tsx
+++ b/frontend/src/workbench/Workbench.tsx
@@ -20,6 +20,8 @@ import { HORIZONTAL, Panels, SECOND_PANEL } from 'core/panels/Panels';
 import gql from 'graphql-tag';
 import { OnboardArea } from 'onboarding/OnboardArea';
 import React, { useContext, useEffect } from 'react';
+import { DiagramTreeItemContextMenuContribution } from 'tree/DiagramTreeItemContextMenuContribution';
+import { TreeItemType } from 'tree/TreeItem.types';
 import { TreeItemContextMenuContext } from 'tree/TreeItemContextMenu';
 import { TreeItemContextMenuContribution } from 'tree/TreeItemContextMenuContribution';
 import { LeftSite } from 'workbench/LeftSite';
@@ -155,6 +157,13 @@ export const Workbench = ({
       treeItemContextMenuContributions.push(child);
     }
   });
+
+  treeItemContextMenuContributions.push(
+    <TreeItemContextMenuContribution
+      canHandle={(item: TreeItemType) => item.kind === 'siriusComponents://representation?type=Diagram'}
+      component={DiagramTreeItemContextMenuContribution}
+    />
+  );
 
   const leftSite = (
     <TreeItemContextMenuContext.Provider value={treeItemContextMenuContributions}>


### PR DESCRIPTION
### Type of this PR 

- [x] New feature or improvement

### Issue(s)

Feature: #937 & #938 & #1019

### What does this PR do?

This PR adds a new service,  SVGExportService,  supporting the SVG export of a diagram.

### How to test this PR?

Add the following code snippet to DiagramEventFlux#diagramRefreshed and refresh a diagram. The svg string should be displayed on the backend console.

```
        SVGExportService export = new SVGExportService("http://localhost:8080"); //$NON-NLS-1$
        String svg = export.toSVG(this.currentDiagram);
        System.out.println(svg);
```

### Checklist

- [x] I have read CONTRIBUTING carefully.
- [x] I have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All my commits are signed-off (`-s`) with my mail address of my Eclipse Account.
- [ ] I have covered my changes by unit tests or integration tests or manual tests.
- [x] All tests pass.
- [x] I have updated the documentation accordingly
- [ ] New React components are availables in storybook
