### PR TITLE
[915] Use failure messages to create error payload messages

### DIFF
--- a/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/handlers/DeleteFromDiagramEventHandler.java
+++ b/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/handlers/DeleteFromDiagramEventHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 Obeo.
+ * Copyright (c) 2019, 2022 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -118,6 +118,8 @@ public class DeleteFromDiagramEventHandler implements IDiagramEventHandler {
                 IStatus status = this.invokeDeleteEdgeTool(optionalElement.get(), editingContext, diagramContext);
                 if (status instanceof Success) {
                     atLeastOneOk = true;
+                } else {
+                    errors.add(((Failure) status).getMessage());
                 }
             } else {
                 String message = this.messageService.edgeNotFound(edgeId.toString());
@@ -130,6 +132,8 @@ public class DeleteFromDiagramEventHandler implements IDiagramEventHandler {
                 IStatus status = this.invokeDeleteNodeTool(optionalElement.get(), editingContext, diagramContext);
                 if (status instanceof Success) {
                     atLeastOneOk = true;
+                } else {
+                    errors.add(((Failure) status).getMessage());
                 }
             } else {
                 String message = this.messageService.nodeNotFound(nodeId.toString());
@@ -181,10 +185,12 @@ public class DeleteFromDiagramEventHandler implements IDiagramEventHandler {
             } else {
                 String message = this.messageService.semanticObjectNotFound(node.getTargetObjectId());
                 this.logger.debug(message);
+                result = new Failure(message);
             }
         } else {
             String message = this.messageService.nodeDescriptionNotFound(node.getId().toString());
             this.logger.debug(message);
+            result = new Failure(message);
         }
         return result;
     }
@@ -212,10 +218,12 @@ public class DeleteFromDiagramEventHandler implements IDiagramEventHandler {
             } else {
                 String message = this.messageService.semanticObjectNotFound(edge.getTargetObjectId());
                 this.logger.debug(message);
+                result = new Failure(message);
             }
         } else {
             String message = this.messageService.edgeDescriptionNotFound(edge.getId().toString());
             this.logger.debug(message);
+            result = new Failure(message);
         }
         return result;
     }

--- a/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/handlers/DropOnDiagramEventHandler.java
+++ b/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/handlers/DropOnDiagramEventHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 Obeo.
+ * Copyright (c) 2019, 2022 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -92,6 +92,8 @@ public class DropOnDiagramEventHandler implements IDiagramEventHandler {
                 if (status instanceof Success) {
                     changeDescription = new ChangeDescription(ChangeKind.SEMANTIC_CHANGE, diagramInput.getRepresentationId(), diagramInput);
                     payload = new DropOnDiagramSuccessPayload(diagramInput.getId(), diagram);
+                } else if (status instanceof Failure) {
+                    payload = new ErrorPayload(diagramInput.getId(), ((Failure) status).getMessage());
                 }
             }
         }

--- a/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/handlers/InvokeDeleteToolOnDiagramEventHandler.java
+++ b/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/handlers/InvokeDeleteToolOnDiagramEventHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Obeo and others.
+ * Copyright (c) 2021, 2022 Obeo and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -36,7 +36,6 @@ import org.eclipse.sirius.web.spring.collaborative.diagrams.api.IDiagramQuerySer
 import org.eclipse.sirius.web.spring.collaborative.diagrams.api.IToolService;
 import org.eclipse.sirius.web.spring.collaborative.diagrams.dto.InvokeDeleteToolOnDiagramInput;
 import org.eclipse.sirius.web.spring.collaborative.diagrams.dto.InvokeDeleteToolOnDiagramSuccessPayload;
-import org.eclipse.sirius.web.spring.collaborative.diagrams.dto.InvokeNodeToolOnDiagramInput;
 import org.eclipse.sirius.web.spring.collaborative.diagrams.messages.ICollaborativeDiagramMessageService;
 import org.springframework.stereotype.Service;
 
@@ -86,7 +85,7 @@ public class InvokeDeleteToolOnDiagramEventHandler implements IDiagramEventHandl
     public void handle(One<IPayload> payloadSink, Many<ChangeDescription> changeDescriptionSink, IEditingContext editingContext, IDiagramContext diagramContext, IDiagramInput diagramInput) {
         this.counter.increment();
 
-        String message = this.messageService.invalidInput(diagramInput.getClass().getSimpleName(), InvokeNodeToolOnDiagramInput.class.getSimpleName());
+        String message = this.messageService.invalidInput(diagramInput.getClass().getSimpleName(), InvokeDeleteToolOnDiagramInput.class.getSimpleName());
         IPayload payload = new ErrorPayload(diagramInput.getId(), message);
         ChangeDescription changeDescription = new ChangeDescription(ChangeKind.NOTHING, diagramInput.getRepresentationId(), diagramInput);
 
@@ -101,9 +100,10 @@ public class InvokeDeleteToolOnDiagramEventHandler implements IDiagramEventHandl
             if (optionalTool.isPresent()) {
                 IStatus status = this.executeTool(editingContext, diagramContext, input.getDiagramElementId(), optionalTool.get());
                 if (status instanceof Success) {
-
                     payload = new InvokeDeleteToolOnDiagramSuccessPayload(diagramInput.getId(), diagram);
                     changeDescription = new ChangeDescription(ChangeKind.SEMANTIC_CHANGE, diagramInput.getRepresentationId(), diagramInput);
+                } else if (status instanceof Failure) {
+                    payload = new ErrorPayload(diagramInput.getId(), ((Failure) status).getMessage());
                 }
             }
         }

--- a/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/handlers/InvokeEdgeToolOnDiagramEventHandler.java
+++ b/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/handlers/InvokeEdgeToolOnDiagramEventHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Obeo.
+ * Copyright (c) 2019, 2022 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -104,6 +104,8 @@ public class InvokeEdgeToolOnDiagramEventHandler implements IDiagramEventHandler
                 if (status instanceof Success) {
                     payload = new InvokeEdgeToolOnDiagramSuccessPayload(diagramInput.getId(), diagram);
                     changeDescription = new ChangeDescription(ChangeKind.SEMANTIC_CHANGE, diagramInput.getRepresentationId(), diagramInput);
+                } else if (status instanceof Failure) {
+                    payload = new ErrorPayload(diagramInput.getId(), ((Failure) status).getMessage());
                 }
             }
         }

--- a/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/handlers/InvokeNodeToolOnDiagramEventHandler.java
+++ b/backend/sirius-web-spring-collaborative-diagrams/src/main/java/org/eclipse/sirius/web/spring/collaborative/diagrams/handlers/InvokeNodeToolOnDiagramEventHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 Obeo and others.
+ * Copyright (c) 2019, 2022 Obeo and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -115,6 +115,8 @@ public class InvokeNodeToolOnDiagramEventHandler implements IDiagramEventHandler
                 if (status instanceof Success) {
                     payload = new InvokeNodeToolOnDiagramSuccessPayload(diagramInput.getId(), diagram);
                     changeDescription = new ChangeDescription(ChangeKind.SEMANTIC_CHANGE, diagramInput.getRepresentationId(), diagramInput);
+                } else if (status instanceof Failure) {
+                    payload = new ErrorPayload(diagramInput.getId(), ((Failure) status).getMessage());
                 }
             }
         }

--- a/backend/sirius-web-spring-collaborative-forms/src/main/java/org/eclipse/sirius/web/spring/collaborative/forms/handlers/DeleteListItemEventHandler.java
+++ b/backend/sirius-web-spring-collaborative-forms/src/main/java/org/eclipse/sirius/web/spring/collaborative/forms/handlers/DeleteListItemEventHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Obeo.
+ * Copyright (c) 2021, 2022 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -98,6 +98,8 @@ public class DeleteListItemEventHandler implements IFormEventHandler {
                 Success success = (Success) status;
                 changeDescription = new ChangeDescription(success.getChangeKind(), formInput.getRepresentationId(), formInput, success.getParameters());
                 payload = new DeleteListItemSuccessPayload(formInput.getId());
+            } else if (status instanceof Failure) {
+                payload = new ErrorPayload(formInput.getId(), ((Failure) status).getMessage());
             }
         }
 

--- a/backend/sirius-web-spring-collaborative-forms/src/main/java/org/eclipse/sirius/web/spring/collaborative/forms/handlers/EditRadioEventHandler.java
+++ b/backend/sirius-web-spring-collaborative-forms/src/main/java/org/eclipse/sirius/web/spring/collaborative/forms/handlers/EditRadioEventHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 Obeo.
+ * Copyright (c) 2019, 2022 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -70,8 +70,10 @@ public class EditRadioEventHandler implements IFormEventHandler {
     @Override
     public void handle(One<IPayload> payloadSink, Many<ChangeDescription> changeDescriptionSink, Form form, IFormInput formInput) {
         this.counter.increment();
+        String message = this.messageService.invalidInput(formInput.getClass().getSimpleName(), EditRadioInput.class.getSimpleName());
+        IPayload payload = new ErrorPayload(formInput.getId(), message);
+        ChangeDescription changeDescription = new ChangeDescription(ChangeKind.NOTHING, formInput.getRepresentationId(), formInput);
 
-        IStatus status = new Failure(""); //$NON-NLS-1$
         if (formInput instanceof EditRadioInput) {
             EditRadioInput input = (EditRadioInput) formInput;
 
@@ -80,19 +82,20 @@ public class EditRadioEventHandler implements IFormEventHandler {
                     .filter(Radio.class::isInstance)
                     .map(Radio.class::cast);
 
-            status = optionalRadio.map(Radio::getNewValueHandler)
+            IStatus status = optionalRadio.map(Radio::getNewValueHandler)
                     .map(handler -> handler.apply(input.getNewValue()))
                     .orElse(new Failure("")); //$NON-NLS-1$
             // @formatter:on
 
+            if (status instanceof Success) {
+                payload = new EditRadioSuccessPayload(formInput.getId());
+                changeDescription = new ChangeDescription(ChangeKind.SEMANTIC_CHANGE, formInput.getRepresentationId(), formInput);
+            } else if (status instanceof Failure) {
+                payload = new ErrorPayload(formInput.getId(), ((Failure) status).getMessage());
+            }
         }
-        if (status instanceof Success) {
-            payloadSink.tryEmitValue(new EditRadioSuccessPayload(formInput.getId()));
-            changeDescriptionSink.tryEmitNext(new ChangeDescription(ChangeKind.SEMANTIC_CHANGE, formInput.getRepresentationId(), formInput));
-        } else {
-            String message = this.messageService.invalidInput(formInput.getClass().getSimpleName(), EditRadioInput.class.getSimpleName());
-            payloadSink.tryEmitValue(new ErrorPayload(formInput.getId(), message));
-            changeDescriptionSink.tryEmitNext(new ChangeDescription(ChangeKind.NOTHING, formInput.getRepresentationId(), formInput));
-        }
+
+        changeDescriptionSink.tryEmitNext(changeDescription);
+        payloadSink.tryEmitValue(payload);
     }
 }

--- a/backend/sirius-web-spring-collaborative-trees/src/main/java/org/eclipse/sirius/web/spring/collaborative/trees/handlers/DeleteTreeItemEventHandler.java
+++ b/backend/sirius-web-spring-collaborative-trees/src/main/java/org/eclipse/sirius/web/spring/collaborative/trees/handlers/DeleteTreeItemEventHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Obeo.
+ * Copyright (c) 2021, 2022 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -17,6 +17,7 @@ import java.util.Objects;
 import org.eclipse.sirius.web.core.api.ErrorPayload;
 import org.eclipse.sirius.web.core.api.IEditingContext;
 import org.eclipse.sirius.web.core.api.IPayload;
+import org.eclipse.sirius.web.representations.Failure;
 import org.eclipse.sirius.web.representations.Success;
 import org.eclipse.sirius.web.representations.VariableManager;
 import org.eclipse.sirius.web.spring.collaborative.api.ChangeDescription;
@@ -99,6 +100,8 @@ public class DeleteTreeItemEventHandler implements ITreeEventHandler {
                     Success success = (Success) status;
                     changeDescription = new ChangeDescription(success.getChangeKind(), treeInput.getRepresentationId(), treeInput, success.getParameters());
                     payload = new DeleteTreeItemSuccessPayload(treeInput.getId());
+                } else if (status instanceof Failure) {
+                    payload = new ErrorPayload(treeInput.getId(), ((Failure) status).getMessage());
                 }
             }
         }

--- a/backend/sirius-web-spring-collaborative-trees/src/main/java/org/eclipse/sirius/web/spring/collaborative/trees/handlers/RenameTreeItemEventHandler.java
+++ b/backend/sirius-web-spring-collaborative-trees/src/main/java/org/eclipse/sirius/web/spring/collaborative/trees/handlers/RenameTreeItemEventHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Obeo.
+ * Copyright (c) 2021, 2022 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -17,6 +17,7 @@ import java.util.Objects;
 import org.eclipse.sirius.web.core.api.ErrorPayload;
 import org.eclipse.sirius.web.core.api.IEditingContext;
 import org.eclipse.sirius.web.core.api.IPayload;
+import org.eclipse.sirius.web.representations.Failure;
 import org.eclipse.sirius.web.representations.Success;
 import org.eclipse.sirius.web.representations.VariableManager;
 import org.eclipse.sirius.web.spring.collaborative.api.ChangeDescription;
@@ -100,6 +101,8 @@ public class RenameTreeItemEventHandler implements ITreeEventHandler {
                     Success success = (Success) status;
                     changeDescription = new ChangeDescription(success.getChangeKind(), treeInput.getRepresentationId(), treeInput, success.getParameters());
                     payload = new RenameTreeItemSuccessPayload(treeInput.getId());
+                } else if (status instanceof Failure) {
+                    payload = new ErrorPayload(treeInput.getId(), ((Failure) status).getMessage());
                 }
             }
         }


### PR DESCRIPTION
### Type of this PR 

- [ ] Bug fix
- [x] New feature or improvement
- [ ] Documentation
- [ ] Cleanup
- [ ] Test
- [ ] Build/Releng

### Issue(s)

https://github.com/eclipse-sirius/sirius-components/issues/915

### What does this PR do?

When a handler fails to execute, it uses its returned failure message to create an error payload.
 
### Potential side effects

Most of the time when handlers failed to execute, they were returning an _invalid input error_, now the message is empty because all handler failures are created with an empty message.
