### PR TITLE
[925] Perform a fit to screen after the first render of a diagram

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -47,6 +47,7 @@ Currently it is not possible to compute different values for width and height.
 - https://github.com/eclipse-sirius/sirius-components/issues/897[#897] [compatibility] The Bordered Node Dot Style is now handled in the compatibility layer
 - https://github.com/eclipse-sirius/sirius-components/issues/565[#565] [diagram] Improve the layout of multiple edges between the same nodes
 - https://github.com/eclipse-sirius/sirius-components/issues/914[#914] [diagram] Add the graphical selection to the semantic ones while clicking on diagram elements
+- https://github.com/eclipse-sirius/sirius-components/issues/925[#925] [diagram] Perform a fit to screen after the first render of a diagram
 
 === Bug fixes
 

--- a/frontend/src/diagram/sprotty/DiagramServer.tsx
+++ b/frontend/src/diagram/sprotty/DiagramServer.tsx
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 Obeo and others.
+ * Copyright (c) 2019, 2022 Obeo and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -28,11 +28,13 @@ import {
   ApplyLabelEditAction,
   CenterAction,
   EditLabelAction,
+  FitToScreenAction,
   GetSelectionAction,
   GetViewportAction,
   getWindowScroll,
   ILogger,
   IModelFactory,
+  InitializeCanvasBoundsAction,
   ModelSource,
   MousePositionTracker,
   MoveAction,
@@ -123,6 +125,7 @@ export class DiagramServer extends ModelSource {
     registry.register(UpdateModelAction.KIND, this);
     registry.register(MoveCommand.KIND, this);
     registry.register(SiriusResizeCommand.KIND, this);
+    registry.register(InitializeCanvasBoundsAction.KIND, this);
     registry.register(SIRIUS_UPDATE_MODEL_ACTION, this);
     registry.register(SIRIUS_SELECT_ACTION, this);
     registry.register(SPROTTY_SELECT_ACTION, this);
@@ -161,6 +164,9 @@ export class DiagramServer extends ModelSource {
         break;
       case SiriusResizeCommand.KIND:
         this.handleResizeAction(action as ResizeAction);
+        break;
+      case InitializeCanvasBoundsAction.KIND:
+        this.handleInitializeCanvasBoundsAction(action as InitializeCanvasBoundsAction);
         break;
       case SIRIUS_UPDATE_MODEL_ACTION:
         this.handleSiriusUpdateModelAction(action as SiriusUpdateModelAction);
@@ -255,6 +261,10 @@ export class DiagramServer extends ModelSource {
       const { elementId, newPosition, newSize } = resize;
       this.resizeElement(elementId, newPosition?.x, newPosition?.y, newSize.width, newSize.height);
     }
+  }
+
+  handleInitializeCanvasBoundsAction(action: InitializeCanvasBoundsAction) {
+    this.actionDispatcher.dispatch(new FitToScreenAction([], 20));
   }
 
   handleSprottySelectAction(action: SprottySelectAction) {


### PR DESCRIPTION
### Type of this PR 

- [x] Bug fix
- [ ] New feature or improvement
- [ ] Documentation
- [ ] Cleanup
- [ ] Test
- [ ] Build/Releng

### Issue(s)

#925

### What does this PR do?

This PR perform a fit to screen after the first render of a diagram

### Screenshot/screencast of this PR

...
 

### Potential side effects

It may happen that some diagrams will have big elements and some others will have small elements depending on diagram bounds are small or big.

### How to test this PR?

- [x] Manual Test : Open any diagram

### Checklist

- [x] I have read CONTRIBUTING carefully.
- [x] I have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All my commits are signed-off (`-s`) with my mail address of my Eclipse Account.
- [ ] I have covered my changes by unit tests or integration tests or manual tests.
- [x] All tests pass.
- [x] I have updated the documentation accordingly
