### PR TITLE
[914] Consider that GQLNode#borderNodes and GQLNode#childNodes can be undefined

### DIFF
--- a/frontend/src/diagram/DiagramWebSocketContainer.types.ts
+++ b/frontend/src/diagram/DiagramWebSocketContainer.types.ts
@@ -155,8 +155,8 @@ export interface GQLNode {
   size: GQLSize;
   position: GQLPosition;
   style: GQLINodeStyle;
-  borderNodes: GQLNode[];
-  childNodes: GQLNode[];
+  borderNodes: GQLNode[] | undefined;
+  childNodes: GQLNode[] | undefined;
 }
 
 export interface GQLLabel {

--- a/frontend/src/diagram/sprotty/convertDiagram.tsx
+++ b/frontend/src/diagram/sprotty/convertDiagram.tsx
@@ -103,10 +103,12 @@ const convertNode = (gqlNode: GQLNode, httpOrigin: string, readOnly: boolean, au
   } = gqlNode;
 
   const convertedLabel = convertLabel(label, httpOrigin, readOnly);
-  const convertedBorderNodes = borderNodes.map((borderNode) =>
+  const convertedBorderNodes = (borderNodes ?? []).map((borderNode) =>
     convertNode(borderNode, httpOrigin, readOnly, autoLayout)
   );
-  const convertedChildNodes = childNodes.map((childNode) => convertNode(childNode, httpOrigin, readOnly, autoLayout));
+  const convertedChildNodes = (childNodes ?? []).map((childNode) =>
+    convertNode(childNode, httpOrigin, readOnly, autoLayout)
+  );
 
   const node: Node = new Node();
   node.id = id;


### PR DESCRIPTION
Bug: https://github.com/eclipse-sirius/sirius-components/issues/914
Signed-off-by: Stéphane Bégaudeau <stephane.begaudeau@obeo.fr>
