### PR TITLE
[878] Fix tooltips for tree items

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -60,6 +60,7 @@ Currently it is not possible to compute different values for width and height.
 - https://github.com/eclipse-sirius/sirius-components/issues/925[#925] [diagram] Perform a fit to screen after the first render of a diagram
 - https://github.com/eclipse-sirius/sirius-components/issues/944[#944] [core] Add the ability to dispose the editing context
 - https://github.com/eclipse-sirius/sirius-components/issues/936[#936] [view] Add support for `preconditionExpression` in dynamic representations
+- https://github.com/eclipse-sirius/sirius-components/issues/878[#878] [explorer] Update the tooltips of the tree items by parsing the kind of the tree item
 
 === Bug fixes
 

--- a/frontend/src/tree/TreeItem.tsx
+++ b/frontend/src/tree/TreeItem.tsx
@@ -337,6 +337,21 @@ export const TreeItem = ({
     event.stopPropagation();
   };
 
+  let tooltipText = '';
+  if (item.kind.startsWith('siriusComponents://semantic')) {
+    const query = item.kind.substring(item.kind.indexOf('?') + 1, item.kind.length);
+    const params = new URLSearchParams(query);
+    if (params.has('domain') && params.has('entity')) {
+      tooltipText = params.get('domain') + '::' + params.get('entity');
+    }
+  } else if (item.kind.startsWith('siriusComponents://representation')) {
+    const query = item.kind.substring(item.kind.indexOf('?') + 1, item.kind.length);
+    const params = new URLSearchParams(query);
+    if (params.has('type')) {
+      tooltipText = params.get('type');
+    }
+  }
+
   /* ref, tabindex and onFocus are used to set the React component focusabled and to set the focus to the corresponding DOM part */
   return (
     <>
@@ -361,7 +376,7 @@ export const TreeItem = ({
             className={styles.imageAndLabel}
             onClick={onClick}
             onDoubleClick={() => item.hasChildren && onExpand(item.id, depth)}
-            title={item.kind}
+            title={tooltipText}
             data-testid={item.label}
           >
             {image}


### PR DESCRIPTION
Do not render the raw `kind` as we used to do, as it is now more
confusing than anything for the end-user.

For the kinds which are defined by Sirius Components itself, interpret
them to show the same tooltip as before. Default to an empty tooltip
for the others instead of exposing the raw kind value.

---

I'm setting this as "to review soon" because its seems relatively small and safe, but it can be dropped from the release if time is too short.