### PR TITLE
[957] Fix the fit to screen triggered by initialize canvas bounds

### DIFF
--- a/frontend/src/diagram/sprotty/DiagramServer.tsx
+++ b/frontend/src/diagram/sprotty/DiagramServer.tsx
@@ -118,6 +118,8 @@ export class DiagramServer extends ModelSource {
 
   httpOrigin;
 
+  firstOpen: boolean = true;
+
   initialize(registry: ActionHandlerRegistry) {
     super.initialize(registry);
     registry.register(ApplyLabelEditAction.KIND, this);
@@ -264,7 +266,10 @@ export class DiagramServer extends ModelSource {
   }
 
   handleInitializeCanvasBoundsAction(action: InitializeCanvasBoundsAction) {
-    this.actionDispatcher.dispatch(new FitToScreenAction([], 20));
+    if (this.firstOpen && this.currentRoot.id !== INITIAL_ROOT.id) {
+      this.actionDispatcher.dispatch(new FitToScreenAction([], 20, 1));
+      this.firstOpen = false;
+    }
   }
 
   handleSprottySelectAction(action: SprottySelectAction) {


### PR DESCRIPTION
### Type of this PR 

- [x] Bug fix
- [ ] New feature or improvement
- [ ] Documentation
- [ ] Cleanup
- [ ] Test
- [ ] Build/Releng

### Issue(s)

https://github.com/eclipse-sirius/sirius-components/issues/957

### What does this PR do?

This PR makes sure the fit to screen made when a diagram is opened, is made only when the diagram is opened.

### How to test this PR?

- [ ] Manual Test :
 1. Open the diagram
 2. Make sure the fit to screen has been made
 3. Resize the browser window
 4. Make sure the fit to screen has *NOT* been made
