### PR TITLE
[958] Use the right edge start and edge end position

### DIFF
--- a/frontend/src/diagram/DiagramWebSocketContainer.tsx
+++ b/frontend/src/diagram/DiagramWebSocketContainer.tsx
@@ -603,7 +603,6 @@ export const DiagramWebSocketContainer = ({
       const selectSprottyAction: SprottySelectAction = {
         kind: 'sprottySelectElement',
         element: selectedElement,
-        position,
       };
       diagramServer.actionDispatcher.dispatch(selectSprottyAction);
     };

--- a/frontend/src/diagram/DiagramWebSocketContainer.tsx
+++ b/frontend/src/diagram/DiagramWebSocketContainer.tsx
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 Obeo and others.
+ * Copyright (c) 2019, 2022 Obeo and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -719,7 +719,7 @@ export const DiagramWebSocketContainer = ({
 
   useEffect(() => {
     if (selectedObjectId && activeTool && contextualPalette) {
-      invokeTool(activeTool, contextualPalette.element.id, contextualPalette.startingPosition);
+      invokeTool(activeTool, contextualPalette.element.id, contextualPalette.palettePosition);
       const sourceElementAction: SourceElementAction = { kind: SOURCE_ELEMENT_ACTION, sourceElement: null };
       diagramServer.actionDispatcher.dispatch(sourceElementAction);
       const resetSelectedObjectInSelectionDialogEvent: ResetSelectedObjectInSelectionDialogEvent = {
@@ -910,13 +910,13 @@ export const DiagramWebSocketContainer = ({
   if (!readOnly && contextualPalette) {
     const {
       element,
-      startingPosition,
+      palettePosition,
       canvasBounds,
-      edgeStartPosition: origin,
+      edgeStartPosition: edgeStartPosition,
       renameable,
       deletable,
     } = contextualPalette;
-    const { x, y } = origin;
+    const { x, y } = edgeStartPosition;
     const style = {
       left: canvasBounds.x + 'px',
       top: canvasBounds.y + 'px',
@@ -945,7 +945,10 @@ export const DiagramWebSocketContainer = ({
         dispatch(setContextualPaletteEvent);
         edgeCreationFeedback.init(x, y);
 
-        const action: SourceElementAction = { kind: 'sourceElement', sourceElement: { element, position: { x, y } } };
+        const action: SourceElementAction = {
+          kind: 'sourceElement',
+          sourceElement: { element, position: { ...palettePosition } },
+        };
         diagramServer.actionDispatcher.dispatch(action);
       } else if (tool.__typename === 'CreateNodeTool') {
         if (tool.selectionDescriptionId) {
@@ -955,7 +958,7 @@ export const DiagramWebSocketContainer = ({
           };
           dispatch(showSelectionDialogEvent);
         } else {
-          invokeTool(tool, element.id, startingPosition);
+          invokeTool(tool, element.id, palettePosition);
           const sourceElementAction: SourceElementAction = { kind: SOURCE_ELEMENT_ACTION, sourceElement: null };
           diagramServer.actionDispatcher.dispatch(sourceElementAction);
         }
@@ -967,7 +970,7 @@ export const DiagramWebSocketContainer = ({
           contextualPalette: null,
         };
         dispatch(setContextualPaletteEvent);
-        invokeTool(tool, element.id, startingPosition);
+        invokeTool(tool, element.id, palettePosition);
         const sourceElementAction: SourceElementAction = { kind: SOURCE_ELEMENT_ACTION, sourceElement: null };
         diagramServer.actionDispatcher.dispatch(sourceElementAction);
       }
@@ -995,7 +998,10 @@ export const DiagramWebSocketContainer = ({
       dispatch(setActiveConnectorToolsEvent);
       edgeCreationFeedback.init(x, y);
 
-      const action: SourceElementAction = { kind: 'sourceElement', sourceElement: { element, position: { x, y } } };
+      const action: SourceElementAction = {
+        kind: 'sourceElement',
+        sourceElement: { element, position: { ...palettePosition } },
+      };
       diagramServer.actionDispatcher.dispatch(action);
     };
     contextualPaletteContent = (

--- a/frontend/src/diagram/DiagramWebSocketContainer.types.ts
+++ b/frontend/src/diagram/DiagramWebSocketContainer.types.ts
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Obeo and others.
+ * Copyright (c) 2021, 2022 Obeo and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -53,7 +53,7 @@ export interface Position {
 }
 
 export interface Palette {
-  startingPosition: Position;
+  palettePosition: Position;
   canvasBounds: Bounds;
   edgeStartPosition: Position;
   element: any;

--- a/frontend/src/diagram/sprotty/DiagramServer.tsx
+++ b/frontend/src/diagram/sprotty/DiagramServer.tsx
@@ -107,7 +107,7 @@ export class DiagramServer extends ModelSource {
   deleteElements;
 
   invokeTool;
-  setContextualPalette;
+  setContextualPalette: (contextualPalette: Palette) => void;
   setContextualMenu;
   setActiveTool;
   onSelectElement;
@@ -273,7 +273,7 @@ export class DiagramServer extends ModelSource {
   }
 
   handleSprottySelectAction(action: SprottySelectAction) {
-    const { element, position } = action;
+    const { element } = action;
     if (this.activeConnectorTools?.length > 0) {
       const filteredTools = this.activeConnectorTools.filter((edgeTool) =>
         edgeTool.edgeCandidates.some(
@@ -292,7 +292,7 @@ export class DiagramServer extends ModelSource {
           this.diagramSource.element.id,
           element.id,
           this.diagramSource.position,
-          position
+          this.mousePositionTracker.lastPositionOnDiagram
         );
       } else {
         this.actionDispatcher.dispatch({
@@ -310,7 +310,7 @@ export class DiagramServer extends ModelSource {
           this.diagramSource.element.id,
           element.id,
           this.diagramSource.position,
-          position
+          this.mousePositionTracker.lastPositionOnDiagram
         );
       } else if (this.activeTool.__typename === 'DeleteTool') {
         this.invokeTool(this.activeTool, element.id);
@@ -415,10 +415,10 @@ export class DiagramServer extends ModelSource {
             };
           }
           const contextualPalette: Palette = {
-            startingPosition: lastPositionOnDiagram,
+            palettePosition: lastPositionOnDiagram,
             canvasBounds: bounds,
-            edgeStartPosition: edgeStartPosition,
-            element: element,
+            edgeStartPosition,
+            element,
             renameable: !(element instanceof SGraph),
             deletable: !(element instanceof SGraph),
           };
@@ -578,7 +578,7 @@ export class DiagramServer extends ModelSource {
     this.invokeTool = invokeTool;
   }
 
-  setContextualPaletteListener(setContextualPalette) {
+  setContextualPaletteListener(setContextualPalette: (contextualPalette: Palette) => void) {
     this.setContextualPalette = setContextualPalette;
   }
 

--- a/frontend/src/diagram/sprotty/DiagramServer.types.ts
+++ b/frontend/src/diagram/sprotty/DiagramServer.types.ts
@@ -33,7 +33,6 @@ export interface SiriusSelectAction extends Action {
 export interface SprottySelectAction extends Action {
   kind: 'sprottySelectElement';
   element: SModelElement;
-  position: Position;
 }
 
 export interface ZoomToAction extends Action {


### PR DESCRIPTION
### Type of this PR 

- [x] Bug fix
- [ ] New feature or improvement
- [ ] Documentation
- [ ] Cleanup
- [ ] Test
- [ ] Build/Releng

### Issue(s)

https://github.com/eclipse-sirius/sirius-components/issues/958

### What does this PR do?

Use positions relative to the diagram origin and not positions relative
to the viewport.

### How to test this PR?

- [x] Manual Test : Using the palette, create an edge between two elements. 
It can be using a create edge tool or the connector tool.
