### PR TITLE
[948] Fix edge label positioning

### DIFF
--- a/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/incremental/provider/EdgeLabelPositionProvider.java
+++ b/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/incremental/provider/EdgeLabelPositionProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 THALES GLOBAL SERVICES.
+ * Copyright (c) 2021, 2022 THALES GLOBAL SERVICES.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -41,25 +41,25 @@ public class EdgeLabelPositionProvider {
         if (spacingEdgeLabel == null) {
             spacingEdgeLabel = CoreOptions.SPACING_EDGE_LABEL.getDefault();
         }
-        Position position = null;
+        Position position = Position.UNDEFINED;
         List<Position> routingPoints = edge.getRoutingPoints();
-        if (routingPoints.size() < 2) {
-            position = Position.UNDEFINED;
-        }
 
-        if (position == null && edge.getSource().equals(edge.getTarget())) {
-            double x = ((edge.getRoutingPoints().get(1).getX() + edge.getRoutingPoints().get(2).getX()) / 2) - (label.getTextBounds().getSize().getWidth() / 2);
-            double y = edge.getRoutingPoints().get(1).getY() - spacingEdgeLabel - label.getTextBounds().getSize().getHeight();
-            position = Position.at(x, y);
-        }
-
-        if (position == null) {
+        if (edge.getRoutingPoints().size() == 2 && !edge.getSource().equals(edge.getTarget())) {
+            // Straight edge between two elements.
             Position sourceAnchor = routingPoints.get(0);
             Position targetAnchor = routingPoints.get(routingPoints.size() - 1);
             double x = ((sourceAnchor.getX() + targetAnchor.getX()) / 2) - (label.getTextBounds().getSize().getWidth() / 2);
             double y = (sourceAnchor.getY() + targetAnchor.getY()) / 2 + spacingEdgeLabel;
             position = Position.at(x, y);
         }
+
+        if (edge.getRoutingPoints().size() == 4 && edge.getSource().equals(edge.getTarget())) {
+            // Self loop edge
+            double x = ((edge.getRoutingPoints().get(1).getX() + edge.getRoutingPoints().get(2).getX()) / 2) - (label.getTextBounds().getSize().getWidth() / 2);
+            double y = edge.getRoutingPoints().get(1).getY() - spacingEdgeLabel - label.getTextBounds().getSize().getHeight();
+            position = Position.at(x, y);
+        }
+
         return position;
     }
 }

--- a/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/incremental/provider/EdgeRoutingPointsProvider.java
+++ b/backend/sirius-web-diagrams-layout/src/main/java/org/eclipse/sirius/web/diagrams/layout/incremental/provider/EdgeRoutingPointsProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 THALES GLOBAL SERVICES.
+ * Copyright (c) 2021, 2022 THALES GLOBAL SERVICES.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -31,20 +31,22 @@ public class EdgeRoutingPointsProvider {
 
     public List<Position> getRoutingPoints(EdgeLayoutData edge) {
         List<Position> positions = List.of();
-        Bounds sourceBounds = this.getAbsoluteBounds(edge.getSource());
-        Bounds targetBounds = this.getAbsoluteBounds(edge.getTarget());
-
-        this.supportOldDiagramWithExistingEdge(edge);
-        Position sourceAbsolutePosition = this.toAbsolutePosition(edge.getSourceAnchorRelativePosition(), sourceBounds);
-        Position targetAbsolutePosition = this.toAbsolutePosition(edge.getTargetAnchorRelativePosition(), targetBounds);
-
-        Geometry geometry = new Geometry();
-        Optional<Position> optionalSourceIntersection = geometry.getIntersection(targetAbsolutePosition, sourceAbsolutePosition, sourceBounds);
-        Optional<Position> optionalTargetIntersection = geometry.getIntersection(sourceAbsolutePosition, targetAbsolutePosition, targetBounds);
-        if (optionalSourceIntersection.isPresent() && optionalTargetIntersection.isPresent()) {
-            positions = List.of(optionalSourceIntersection.get(), optionalTargetIntersection.get());
-        } else if (edge.getSource().equals(edge.getTarget())) {
+        if (edge.getSource().equals(edge.getTarget())) {
             positions = this.getRoutingPointsToMyself(edge.getSource().getPosition(), edge.getSource().getSize().getWidth());
+        } else {
+            Bounds sourceBounds = this.getAbsoluteBounds(edge.getSource());
+            Bounds targetBounds = this.getAbsoluteBounds(edge.getTarget());
+
+            this.supportOldDiagramWithExistingEdge(edge);
+            Position sourceAbsolutePosition = this.toAbsolutePosition(edge.getSourceAnchorRelativePosition(), sourceBounds);
+            Position targetAbsolutePosition = this.toAbsolutePosition(edge.getTargetAnchorRelativePosition(), targetBounds);
+
+            Geometry geometry = new Geometry();
+            Optional<Position> optionalSourceIntersection = geometry.getIntersection(targetAbsolutePosition, sourceAbsolutePosition, sourceBounds);
+            Optional<Position> optionalTargetIntersection = geometry.getIntersection(sourceAbsolutePosition, targetAbsolutePosition, targetBounds);
+            if (optionalSourceIntersection.isPresent() && optionalTargetIntersection.isPresent()) {
+                positions = List.of(optionalSourceIntersection.get(), optionalTargetIntersection.get());
+            }
         }
         return positions;
     }


### PR DESCRIPTION
### Type of this PR 

- [x] Bug fix
- [ ] New feature or improvement
- [ ] Documentation
- [ ] Cleanup
- [ ] Test
- [ ] Build/Releng

### Issue(s)

https://github.com/eclipse-sirius/sirius-components/issues/948

### What does this PR do?

This PR fixes the edge label positioning for self-loop edges.

### How to test this PR?

- [x] Manual Test: 
1. Create a project with a domain
2. Create a _Domain_ diagram
3. Create an _Entity_
4. Create an edge from the entity to itself

#### Expected behavior

- The edge should be visible
- The edge label should be well-positioned
