### PR TITLE
[958] Fix connector tools when more than one tool can apply

### DIFF
--- a/frontend/src/diagram/DiagramWebSocketContainer.tsx
+++ b/frontend/src/diagram/DiagramWebSocketContainer.tsx
@@ -1020,14 +1020,14 @@ export const DiagramWebSocketContainer = ({
   }
   let contextualMenuContent;
   if (!readOnly && contextualMenu) {
-    const { sourceElement, targetElement, canvasBounds, tools: edgeTools } = contextualMenu;
+    const { sourceElement, targetElement, canvasBounds, tools: edgeTools, startPosition, endPosition } = contextualMenu;
     const style = {
       left: canvasBounds.x + 'px',
       top: canvasBounds.y + 'px',
     };
-    if (edgeTools && edgeTools.length > 1) {
+    if (edgeTools && edgeTools.length > 1 && !!startPosition && !!endPosition) {
       const invokeToolFromContextualMenu = (tool) => {
-        invokeTool(tool, sourceElement.id, targetElement.id);
+        invokeTool(tool, sourceElement.id, targetElement.id, startPosition, endPosition);
       };
       contextualMenuContent = (
         <div className={classes.contextualMenu} style={style}>

--- a/frontend/src/diagram/DiagramWebSocketContainer.types.ts
+++ b/frontend/src/diagram/DiagramWebSocketContainer.types.ts
@@ -66,6 +66,8 @@ export interface Menu {
   sourceElement: NodeDescription;
   targetElement: NodeDescription;
   tools: Tool[];
+  startPosition: Position | null;
+  endPosition: Position | null;
 }
 
 export interface ToolSection {

--- a/frontend/src/diagram/sprotty/DiagramServer.types.ts
+++ b/frontend/src/diagram/sprotty/DiagramServer.types.ts
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Obeo.
+ * Copyright (c) 2021, 2022 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -53,4 +53,12 @@ export interface SourceElement {
 export interface SetActiveConnectorToolsAction extends Action {
   kind: 'activeConnectorTools';
   tools: CreateEdgeTool[];
+}
+
+export interface ShowContextualMenuAction extends Action {
+  kind: 'showContextualMenu';
+  element: SModelElement | null;
+  tools: Tool[];
+  startPosition: Position | null;
+  endPosition: Position | null;
 }


### PR DESCRIPTION
### Type of this PR 

- [x] Bug fix
- [ ] New feature or improvement
- [ ] Documentation
- [ ] Cleanup
- [ ] Test
- [ ] Build/Releng

### Issue(s)

closes #958

### What does this PR do?

This PR fixes the connector tool when more than one edge tool can apply.

### How to test this PR?

- [x] Manual Test :
1. Create a project with a _Domain_ model
2. Create a _Domain_ diagram
3. Create two entities
4. Use the connector tool from the contextual palette to create any kind of relation

#### Expected behavior

The edge should be created and should be correctly positioned.
