### PR TITLE
[992] Accept static domain types

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -13,6 +13,10 @@
 - [core] Switch to the `org.eclipse.sirius` groupId in order to prepare for a future publication of our backend on maven central
 - https://github.com/eclipse-sirius/sirius-components/issues/808[#808] [core] Update the namespace of the packages from `org.eclipse.sirius.web.xxx` to `org.eclipse.sirius.components.xxx`.
 
+=== Bug fixes
+
+- https://github.com/eclipse-sirius/sirius-components/issues/992[#992] [view] Let the `ViewValidator` consider statically contributed `EPackages` when validating domain types
+
 == v2022.01.0
 
 === Architectural decision records

--- a/backend/sirius-components-emf/src/main/java/org/eclipse/sirius/components/emf/view/ViewValidator.java
+++ b/backend/sirius-components-emf/src/main/java/org/eclipse/sirius/components/emf/view/ViewValidator.java
@@ -58,8 +58,6 @@ public class ViewValidator implements EValidator {
 
     public static final String SIRIUS_COMPONENTS_EMF_PACKAGE = "org.eclipse.sirius.components.emf"; //$NON-NLS-1$
 
-    private static final String DOMAIN_URI_SCHEME = "domain://"; //$NON-NLS-1$
-
     @Override
     public boolean validate(EObject eObject, DiagnosticChain diagnostics, Map<Object, Object> context) {
         return true;
@@ -142,7 +140,7 @@ public class ViewValidator implements EValidator {
         boolean isValid = false;
         ResourceSet resourceSet = diagramDescription.eResource().getResourceSet();
         List<Entity> entities = this.getDomainEntitiesFromResourceSet(resourceSet);
-        List<EPackage> ePackages = this.getDomainEPackagesFromRegistry(resourceSet.getPackageRegistry());
+        List<EPackage> ePackages = this.getEPackagesFromRegistry(resourceSet.getPackageRegistry());
 
         String domainType = Optional.ofNullable(diagramDescription.getDomainType()).orElse(""); //$NON-NLS-1$
         isValid = entities.stream().anyMatch(entity -> this.describesEntity(domainType, entity));
@@ -180,7 +178,7 @@ public class ViewValidator implements EValidator {
         boolean isValid = false;
         ResourceSet resourceSet = diagramElementDescription.eResource().getResourceSet();
         List<Entity> entities = this.getDomainEntitiesFromResourceSet(resourceSet);
-        List<EPackage> ePackages = this.getDomainEPackagesFromRegistry(resourceSet.getPackageRegistry());
+        List<EPackage> ePackages = this.getEPackagesFromRegistry(resourceSet.getPackageRegistry());
 
         String domainType = Optional.ofNullable(diagramElementDescription.getDomainType()).orElse(""); //$NON-NLS-1$
         isValid = entities.stream().anyMatch(entity -> this.describesEntity(domainType, entity));
@@ -218,7 +216,7 @@ public class ViewValidator implements EValidator {
         boolean isValid = false;
         ResourceSet resourceSet = createInstance.eResource().getResourceSet();
         List<Entity> entities = this.getDomainEntitiesFromResourceSet(resourceSet);
-        List<EPackage> ePackages = this.getDomainEPackagesFromRegistry(resourceSet.getPackageRegistry());
+        List<EPackage> ePackages = this.getEPackagesFromRegistry(resourceSet.getPackageRegistry());
 
         String domainType = Optional.ofNullable(createInstance.getTypeName()).orElse(""); //$NON-NLS-1$
         isValid = entities.stream().anyMatch(entity -> this.describesEntity(domainType, entity));
@@ -276,12 +274,11 @@ public class ViewValidator implements EValidator {
         // @formatter:on
     }
 
-    private List<EPackage> getDomainEPackagesFromRegistry(EPackage.Registry ePackageRegistry) {
+    private List<EPackage> getEPackagesFromRegistry(EPackage.Registry ePackageRegistry) {
         List<EPackage> allEPackage = new ArrayList<>();
 
         // @formatter:off
         List<EPackage> ePackages = ePackageRegistry.entrySet().stream()
-                .filter(entry -> entry.getKey().startsWith(DOMAIN_URI_SCHEME))
                 .map(Entry::getValue)
                 .filter(EPackage.class::isInstance)
                 .map(EPackage.class::cast)


### PR DESCRIPTION
Make ViewValidator a little less strict. There is no reason to prevent
the creation of views on plain/classical EPackages. From the
ViewConverter point of view, where an EPackage comes from/how it was
created should not matter (if it does, it's a bug in the ViewConverter
part).

Bug: https://github.com/eclipse-sirius/sirius-components/issues/992
Signed-off-by: Pierre-Charles David <pierre-charles.david@obeo.fr>

### Type of this PR 

- [ ] Bug fix
- [ ] New feature or improvement
- [ ] Documentation
- [ ] Cleanup
- [ ] Test
- [ ] Build/Releng

### Issue(s)

...

### What does this PR do?

...

### Screenshot/screencast of this PR

...
 

### Potential side effects

...

### How to test this PR?

- [ ] Frontend Unit tests
- [ ] Backend Unit tests
- [ ] Cypress : please specify
- [ ] Manual Test : please specify

### Checklist

- [ ] I have read CONTRIBUTING carefully.
- [ ] I have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [ ] All my commits are signed-off (`-s`) with my mail address of my Eclipse Account.
- [ ] I have covered my changes by unit tests or integration tests or manual tests.
- [ ] All tests pass.
- [ ] I have updated the documentation accordingly
- [ ] New React components are availables in storybook
