### PR TITLE
[cleanup] Use the existing EditingDomainFactory in tests

### DIFF
--- a/backend/sirius-components-emf/src/test/java/org/eclipse/sirius/components/emf/compatibility/operations/CreateInstanceOperationHandlerTests.java
+++ b/backend/sirius-components-emf/src/test/java/org/eclipse/sirius/components/emf/compatibility/operations/CreateInstanceOperationHandlerTests.java
@@ -19,22 +19,14 @@ import java.text.MessageFormat;
 import java.util.List;
 import java.util.UUID;
 
-import org.eclipse.emf.common.command.BasicCommandStack;
 import org.eclipse.emf.ecore.ENamedElement;
-import org.eclipse.emf.ecore.EPackage;
-import org.eclipse.emf.ecore.EcorePackage;
-import org.eclipse.emf.ecore.impl.EPackageRegistryImpl;
-import org.eclipse.emf.ecore.resource.ResourceSet;
-import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
-import org.eclipse.emf.ecore.util.EcoreAdapterFactory;
 import org.eclipse.emf.edit.domain.AdapterFactoryEditingDomain;
-import org.eclipse.emf.edit.provider.ComposedAdapterFactory;
-import org.eclipse.emf.edit.provider.ReflectiveItemProviderAdapterFactory;
 import org.eclipse.sirius.components.core.api.IEditingContext;
 import org.eclipse.sirius.components.emf.compatibility.EPackageService;
 import org.eclipse.sirius.components.emf.compatibility.modeloperations.ChildModelOperationHandler;
 import org.eclipse.sirius.components.emf.compatibility.modeloperations.CreateInstanceOperationHandler;
 import org.eclipse.sirius.components.emf.services.EditingContext;
+import org.eclipse.sirius.components.emf.services.EditingDomainFactory;
 import org.eclipse.sirius.components.representations.IStatus;
 import org.eclipse.sirius.components.representations.Success;
 import org.eclipse.sirius.viewpoint.description.tool.ChangeContext;
@@ -65,17 +57,7 @@ public class CreateInstanceOperationHandlerTests {
     public void initialize() {
         this.operationTestContext = new OperationTestContext();
 
-        ComposedAdapterFactory composedAdapterFactory = new ComposedAdapterFactory();
-        composedAdapterFactory.addAdapterFactory(new EcoreAdapterFactory());
-        composedAdapterFactory.addAdapterFactory(new ReflectiveItemProviderAdapterFactory());
-
-        EPackage.Registry ePackageRegistry = new EPackageRegistryImpl();
-        ePackageRegistry.put(EcorePackage.eINSTANCE.getNsURI(), EcorePackage.eINSTANCE);
-
-        ResourceSet resourceSet = new ResourceSetImpl();
-        resourceSet.setPackageRegistry(ePackageRegistry);
-
-        AdapterFactoryEditingDomain editingDomain = new AdapterFactoryEditingDomain(composedAdapterFactory, new BasicCommandStack(), resourceSet);
+        AdapterFactoryEditingDomain editingDomain = new EditingDomainFactory().create();
         EditingContext editingContext = new EditingContext(UUID.randomUUID().toString(), editingDomain);
         this.operationTestContext.getVariables().put(IEditingContext.EDITING_CONTEXT, editingContext);
 

--- a/backend/sirius-components-emf/src/test/java/org/eclipse/sirius/components/emf/compatibility/operations/CreateViewOperationHandlerTests.java
+++ b/backend/sirius-components-emf/src/test/java/org/eclipse/sirius/components/emf/compatibility/operations/CreateViewOperationHandlerTests.java
@@ -21,17 +21,8 @@ import java.util.List;
 import java.util.UUID;
 import java.util.function.Function;
 
-import org.eclipse.emf.common.command.BasicCommandStack;
 import org.eclipse.emf.ecore.ENamedElement;
-import org.eclipse.emf.ecore.EPackage;
-import org.eclipse.emf.ecore.EcorePackage;
-import org.eclipse.emf.ecore.impl.EPackageRegistryImpl;
-import org.eclipse.emf.ecore.resource.ResourceSet;
-import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
-import org.eclipse.emf.ecore.util.EcoreAdapterFactory;
 import org.eclipse.emf.edit.domain.AdapterFactoryEditingDomain;
-import org.eclipse.emf.edit.provider.ComposedAdapterFactory;
-import org.eclipse.emf.edit.provider.ReflectiveItemProviderAdapterFactory;
 import org.eclipse.sirius.components.collaborative.diagrams.api.IDiagramContext;
 import org.eclipse.sirius.components.core.api.IEditingContext;
 import org.eclipse.sirius.components.diagrams.Diagram;
@@ -49,6 +40,7 @@ import org.eclipse.sirius.components.diagrams.description.SynchronizationPolicy;
 import org.eclipse.sirius.components.emf.compatibility.modeloperations.ChildModelOperationHandler;
 import org.eclipse.sirius.components.emf.compatibility.modeloperations.CreateViewOperationHandler;
 import org.eclipse.sirius.components.emf.services.EditingContext;
+import org.eclipse.sirius.components.emf.services.EditingDomainFactory;
 import org.eclipse.sirius.components.representations.Failure;
 import org.eclipse.sirius.components.representations.IStatus;
 import org.eclipse.sirius.components.representations.Success;
@@ -84,16 +76,6 @@ public class CreateViewOperationHandlerTests {
     public void initialize() {
         this.operationTestContext = new OperationTestContext();
 
-        ComposedAdapterFactory composedAdapterFactory = new ComposedAdapterFactory();
-        composedAdapterFactory.addAdapterFactory(new EcoreAdapterFactory());
-        composedAdapterFactory.addAdapterFactory(new ReflectiveItemProviderAdapterFactory());
-
-        EPackage.Registry ePackageRegistry = new EPackageRegistryImpl();
-        ePackageRegistry.put(EcorePackage.eINSTANCE.getNsURI(), EcorePackage.eINSTANCE);
-
-        ResourceSet resourceSet = new ResourceSetImpl();
-        resourceSet.setPackageRegistry(ePackageRegistry);
-
         // @formatter:off
         DiagramDescription diagramDescription = DiagramDescription.newDiagramDescription(UUID.randomUUID())
                 .label("DiagramDescriptionTest") //$NON-NLS-1$
@@ -125,7 +107,7 @@ public class CreateViewOperationHandlerTests {
         this.operationTestContext.getVariables().put(IDiagramContext.DIAGRAM_CONTEXT, diagramContext);
         // @formatter:on
 
-        AdapterFactoryEditingDomain editingDomain = new AdapterFactoryEditingDomain(composedAdapterFactory, new BasicCommandStack(), resourceSet);
+        AdapterFactoryEditingDomain editingDomain = new EditingDomainFactory().create();
         EditingContext editingContext = new EditingContext(UUID.randomUUID().toString(), editingDomain);
         this.operationTestContext.getVariables().put(IEditingContext.EDITING_CONTEXT, editingContext);
         this.operationTestContext.getVariables().put(CONTAINER_VIEW, diagram);

--- a/backend/sirius-components-emf/src/test/java/org/eclipse/sirius/components/emf/compatibility/operations/DeleteViewOperationHandlerTests.java
+++ b/backend/sirius-components-emf/src/test/java/org/eclipse/sirius/components/emf/compatibility/operations/DeleteViewOperationHandlerTests.java
@@ -19,16 +19,7 @@ import java.util.List;
 import java.util.UUID;
 import java.util.function.Function;
 
-import org.eclipse.emf.common.command.BasicCommandStack;
-import org.eclipse.emf.ecore.EPackage;
-import org.eclipse.emf.ecore.EcorePackage;
-import org.eclipse.emf.ecore.impl.EPackageRegistryImpl;
-import org.eclipse.emf.ecore.resource.ResourceSet;
-import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
-import org.eclipse.emf.ecore.util.EcoreAdapterFactory;
 import org.eclipse.emf.edit.domain.AdapterFactoryEditingDomain;
-import org.eclipse.emf.edit.provider.ComposedAdapterFactory;
-import org.eclipse.emf.edit.provider.ReflectiveItemProviderAdapterFactory;
 import org.eclipse.sirius.components.collaborative.diagrams.api.IDiagramContext;
 import org.eclipse.sirius.components.core.api.IEditingContext;
 import org.eclipse.sirius.components.diagrams.Diagram;
@@ -50,6 +41,7 @@ import org.eclipse.sirius.components.diagrams.description.SynchronizationPolicy;
 import org.eclipse.sirius.components.emf.compatibility.modeloperations.ChildModelOperationHandler;
 import org.eclipse.sirius.components.emf.compatibility.modeloperations.DeleteViewOperationHandler;
 import org.eclipse.sirius.components.emf.services.EditingContext;
+import org.eclipse.sirius.components.emf.services.EditingDomainFactory;
 import org.eclipse.sirius.components.representations.Failure;
 import org.eclipse.sirius.components.representations.IStatus;
 import org.eclipse.sirius.components.representations.Success;
@@ -84,16 +76,6 @@ public class DeleteViewOperationHandlerTests {
     @BeforeEach
     public void initialize() {
         this.operationTestContext = new OperationTestContext();
-
-        ComposedAdapterFactory composedAdapterFactory = new ComposedAdapterFactory();
-        composedAdapterFactory.addAdapterFactory(new EcoreAdapterFactory());
-        composedAdapterFactory.addAdapterFactory(new ReflectiveItemProviderAdapterFactory());
-
-        EPackage.Registry ePackageRegistry = new EPackageRegistryImpl();
-        ePackageRegistry.put(EcorePackage.eINSTANCE.getNsURI(), EcorePackage.eINSTANCE);
-
-        ResourceSet resourceSet = new ResourceSetImpl();
-        resourceSet.setPackageRegistry(ePackageRegistry);
 
         // @formatter:off
         DiagramDescription diagramDescription = DiagramDescription.newDiagramDescription(UUID.randomUUID())
@@ -147,7 +129,7 @@ public class DeleteViewOperationHandlerTests {
         this.operationTestContext.getVariables().put(IDiagramContext.DIAGRAM_CONTEXT, diagramContext);
         // @formatter:on
 
-        AdapterFactoryEditingDomain editingDomain = new AdapterFactoryEditingDomain(composedAdapterFactory, new BasicCommandStack(), resourceSet);
+        AdapterFactoryEditingDomain editingDomain = new EditingDomainFactory().create();
         EditingContext editingContext = new EditingContext(UUID.randomUUID().toString(), editingDomain);
         this.operationTestContext.getVariables().put(IEditingContext.EDITING_CONTEXT, editingContext);
         this.operationTestContext.getVariables().put(CONTAINER_VIEW, diagram);


### PR DESCRIPTION
Signed-off-by: Pierre-Charles David <pierre-charles.david@obeo.fr>

### Type of this PR 

- [ ] Bug fix
- [ ] New feature or improvement
- [ ] Documentation
- [ ] Cleanup
- [ ] Test
- [ ] Build/Releng

### Issue(s)

...

### What does this PR do?

...

### Screenshot/screencast of this PR

...
 

### Potential side effects

...

### How to test this PR?

- [ ] Frontend Unit tests
- [ ] Backend Unit tests
- [ ] Cypress : please specify
- [ ] Manual Test : please specify

### Checklist

- [ ] I have read CONTRIBUTING carefully.
- [ ] I have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [ ] All my commits are signed-off (`-s`) with my mail address of my Eclipse Account.
- [ ] I have covered my changes by unit tests or integration tests or manual tests.
- [ ] All tests pass.
- [ ] I have updated the documentation accordingly
- [ ] New React components are availables in storybook
