### PR TITLE
[releng] Fix package name in the sirius-components-starter

### DIFF
--- a/backend/sirius-components-starter/src/main/java/org/eclipse/sirius/components/starter/SiriusWebStarterConfiguration.java
+++ b/backend/sirius-components-starter/src/main/java/org/eclipse/sirius/components/starter/SiriusWebStarterConfiguration.java
@@ -39,13 +39,13 @@ import org.springframework.web.socket.WebSocketSession;
 // @formatter:off
 @ComponentScan(basePackages = {
         "org.eclipse.sirius.components.diagrams.layout",
-        "org.eclipse.sirius.components.spring.graphql",
-        "org.eclipse.sirius.components.spring.collaborative",
-        "org.eclipse.sirius.components.spring.collaborative.diagrams",
-        "org.eclipse.sirius.components.spring.collaborative.forms",
-        "org.eclipse.sirius.components.spring.collaborative.selection",
-        "org.eclipse.sirius.components.spring.collaborative.trees",
-        "org.eclipse.sirius.components.spring.collaborative.validation",
+        "org.eclipse.sirius.components.graphql",
+        "org.eclipse.sirius.components.collaborative",
+        "org.eclipse.sirius.components.collaborative.diagrams",
+        "org.eclipse.sirius.components.collaborative.forms",
+        "org.eclipse.sirius.components.collaborative.selection",
+        "org.eclipse.sirius.components.collaborative.trees",
+        "org.eclipse.sirius.components.collaborative.validation",
     }
 )
 // @formatter:on


### PR DESCRIPTION
Fix un-renamed packages in [#808](https://github.com/eclipse-sirius/sirius-components/issues/808)
