### PR TITLE
[988] Make the newSelection field optional

### DIFF
--- a/backend/sirius-components-collaborative-diagrams/src/main/resources/schema/diagram.graphqls
+++ b/backend/sirius-components-collaborative-diagrams/src/main/resources/schema/diagram.graphqls
@@ -280,7 +280,7 @@ union InvokeEdgeToolOnDiagramPayload = ErrorPayload | InvokeEdgeToolOnDiagramSuc
 
 type InvokeEdgeToolOnDiagramSuccessPayload {
   id: ID!
-  newSelection: WorkbenchSelection!
+  newSelection: WorkbenchSelection
 }
 
 input InvokeNodeToolOnDiagramInput {
@@ -298,7 +298,7 @@ union InvokeNodeToolOnDiagramPayload = ErrorPayload | InvokeNodeToolOnDiagramSuc
 
 type InvokeNodeToolOnDiagramSuccessPayload {
   id: ID!
-  newSelection: WorkbenchSelection!
+  newSelection: WorkbenchSelection
 }
 
 input UpdateNodeBoundsInput {


### PR DESCRIPTION
Bug: https://github.com/eclipse-sirius/sirius-components/issues/988
Signed-off-by: Stéphane Bégaudeau <stephane.begaudeau@obeo.fr>
