### PR TITLE
[962] [1051] Fix various node resize issues when creating a child node

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -36,6 +36,7 @@
 - https://github.com/eclipse-sirius/sirius-components/issues/991[#991] [diagram] Restore edge creation tools feedback
 - https://github.com/eclipse-sirius/sirius-components/issues/1056[#1056] [core] Fix an invalid usage of `forwardRef` in  `DiagramTreeItemContextMenuContribution`
 - https://github.com/eclipse-sirius/sirius-components/issues/962[#962] [layout] Fix an issue preventing nodes from being properly resized when a child node is created
+- https://github.com/eclipse-sirius/sirius-components/issues/1051[#1051] [layout] Fix an issue resizing nodes when a child node was created even if it was not necessary
 
 === Improvements
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -35,6 +35,7 @@
 - https://github.com/eclipse-sirius/sirius-components/issues/992[#992] [view] Let the `ViewValidator` consider statically contributed `EPackages` when validating domain types
 - https://github.com/eclipse-sirius/sirius-components/issues/991[#991] [diagram] Restore edge creation tools feedback
 - https://github.com/eclipse-sirius/sirius-components/issues/1056[#1056] [core] Fix an invalid usage of `forwardRef` in  `DiagramTreeItemContextMenuContribution`
+- https://github.com/eclipse-sirius/sirius-components/issues/962[#962] [layout] Fix an issue preventing nodes from being properly resized when a child node is created
 
 === Improvements
 

--- a/backend/sirius-components-diagrams-layout/src/test/java/org/eclipse/sirius/components/diagrams/layout/incremental/NodeCreationTests.java
+++ b/backend/sirius-components-diagrams-layout/src/test/java/org/eclipse/sirius/components/diagrams/layout/incremental/NodeCreationTests.java
@@ -14,6 +14,7 @@ package org.eclipse.sirius.components.diagrams.layout.incremental;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.sirius.components.diagrams.tests.DiagramAssertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -60,30 +61,96 @@ public class NodeCreationTests {
 
     @Test
     public void testNodeCreationNoResizeNeeded() {
+        Path path = Paths.get("src", "test", "resources", "editing-contexts", "testNodeCreation"); //$NON-NLS-1$//$NON-NLS-2$//$NON-NLS-3$//$NON-NLS-4$ //$NON-NLS-5$
+        JsonBasedEditingContext editingContext = new JsonBasedEditingContext(path);
+
         Position eventCreationPosition = Position.at(10, 10);
         Diagram diagram = this.createParentNotResizedDiagram();
-        this.createNewNode(diagram, eventCreationPosition);
+        this.createNewNode(diagram, editingContext, eventCreationPosition);
+        Diagram layoutedDiagram = this.createNewNode(diagram, editingContext, eventCreationPosition);
+
+        this.testThatChildIsInParentBounds(layoutedDiagram);
     }
 
     @Test
     public void testNodeCreationWithResizeNeeded() {
+        Path path = Paths.get("src", "test", "resources", "editing-contexts", "testNodeCreation"); //$NON-NLS-1$//$NON-NLS-2$//$NON-NLS-3$//$NON-NLS-4$ //$NON-NLS-5$
+        JsonBasedEditingContext editingContext = new JsonBasedEditingContext(path);
+
         Position eventCreationPosition = Position.at(199, 199);
         Diagram diagram = this.createParentNotResizedDiagram();
-        this.createNewNode(diagram, eventCreationPosition);
+        this.createNewNode(diagram, editingContext, eventCreationPosition);
+        Diagram layoutedDiagram = this.createNewNode(diagram, editingContext, eventCreationPosition);
+
+        this.testThatChildIsInParentBounds(layoutedDiagram);
     }
 
     @Test
     public void testNodeCreationInResizedParentNoResizeNeeded() {
+        Path path = Paths.get("src", "test", "resources", "editing-contexts", "testNodeCreation"); //$NON-NLS-1$//$NON-NLS-2$//$NON-NLS-3$//$NON-NLS-4$ //$NON-NLS-5$
+        JsonBasedEditingContext editingContext = new JsonBasedEditingContext(path);
+
         Position eventCreationPosition = Position.at(10, 10);
         Diagram diagram = this.createParentResizedDiagram();
-        this.createNewNode(diagram, eventCreationPosition);
+        this.createNewNode(diagram, editingContext, eventCreationPosition);
+        Diagram layoutedDiagram = this.createNewNode(diagram, editingContext, eventCreationPosition);
+
+        this.testThatChildIsInParentBounds(layoutedDiagram);
     }
 
     @Test
     public void testNodeCreationInResizedParentWithResizeNeeded() {
+        Path path = Paths.get("src", "test", "resources", "editing-contexts", "testNodeCreation"); //$NON-NLS-1$//$NON-NLS-2$//$NON-NLS-3$//$NON-NLS-4$ //$NON-NLS-5$
+        JsonBasedEditingContext editingContext = new JsonBasedEditingContext(path);
+
         Position eventCreationPosition = Position.at(199, 199);
         Diagram diagram = this.createParentResizedDiagram();
-        this.createNewNode(diagram, eventCreationPosition);
+        Diagram layoutedDiagram = this.createNewNode(diagram, editingContext, eventCreationPosition);
+
+        this.testThatChildIsInParentBounds(layoutedDiagram);
+    }
+
+    @Test
+    public void testNodeCreationOutsideItsParent() {
+        Path path = Paths.get("src", "test", "resources", "editing-contexts", "testNodeCreationOutsideItsParent"); //$NON-NLS-1$//$NON-NLS-2$//$NON-NLS-3$//$NON-NLS-4$ //$NON-NLS-5$
+        JsonBasedEditingContext editingContext = new JsonBasedEditingContext(path);
+
+        Position eventCreationPosition = Position.at(100, 100);
+        // @formatter:off
+        Diagram diagram = TestLayoutDiagramBuilder.diagram("Root") //$NON-NLS-1$
+                .nodes()
+                    .rectangleNode("A").at(10, 10).of(200, 300).and() //$NON-NLS-1$
+                    .rectangleNode("B").at(500, 500).of(200, 300).and() //$NON-NLS-1$
+                .and()
+            .build();
+        // @formatter:on
+
+        // we create a child of B by clicking inside of A
+        Diagram layoutedDiagram = this.createNewNode(diagram, editingContext, eventCreationPosition);
+
+        Optional<Node> optionalA = this.getNode(layoutedDiagram.getNodes(), "A"); //$NON-NLS-1$
+        assertThat(optionalA).isPresent();
+        Optional<Node> optionalB = this.getNode(layoutedDiagram.getNodes(), "B"); //$NON-NLS-1$
+        assertThat(optionalB).isPresent();
+        Optional<Node> optionalChild = this.getNode(layoutedDiagram.getNodes(), "Child"); //$NON-NLS-1$
+        assertThat(optionalChild).isPresent();
+
+        // A should not have been resized
+        Node aNode = optionalA.get();
+        double epsilon = 0.000001d;
+        assertEquals(aNode.getPosition().getX(), 10, epsilon);
+        assertEquals(aNode.getPosition().getY(), 10, epsilon);
+        assertEquals(aNode.getSize().getWidth(), 200, epsilon);
+        assertEquals(aNode.getSize().getHeight(), 300, epsilon);
+
+        Node bNode = optionalB.get();
+        // Child should be within B
+        assertThat(bNode).hasEveryChildWithinItsBounds();
+        // B should not haven been resized
+        assertEquals(bNode.getPosition().getX(), 500, epsilon);
+        assertEquals(bNode.getPosition().getY(), 500, epsilon);
+        assertEquals(bNode.getSize().getWidth(), 200, epsilon);
+        assertEquals(bNode.getSize().getHeight(), 300, epsilon);
     }
 
     private Diagram createParentNotResizedDiagram() {
@@ -97,6 +164,16 @@ public class NodeCreationTests {
         // @formatter:on
     }
 
+    private void testThatChildIsInParentBounds(Diagram diagram) {
+        Optional<Node> optionalParent = this.getNode(diagram.getNodes(), "Parent"); //$NON-NLS-1$
+        assertThat(optionalParent).isPresent();
+        Optional<Node> optionalChild = this.getNode(diagram.getNodes(), "Child"); //$NON-NLS-1$
+        assertThat(optionalChild).isPresent();
+
+        Node layoutedParent = optionalParent.get();
+        assertThat(layoutedParent).hasEveryChildWithinItsBounds();
+    }
+
     private Diagram createParentResizedDiagram() {
         // @formatter:off
         return TestLayoutDiagramBuilder.diagram("Root") //$NON-NLS-1$
@@ -108,10 +185,7 @@ public class NodeCreationTests {
         // @formatter:on
     }
 
-    private void createNewNode(Diagram diagram, Position eventCreationPosition) {
-        Path path = Paths.get("src", "test", "resources", "editing-contexts", "testNodeCreation"); //$NON-NLS-1$//$NON-NLS-2$//$NON-NLS-3$//$NON-NLS-4$ //$NON-NLS-5$
-        JsonBasedEditingContext editingContext = new JsonBasedEditingContext(path);
-
+    private Diagram createNewNode(Diagram diagram, IEditingContext editingContext, Position eventCreationPosition) {
         TestDiagramCreationService diagramCreationService = this.createDiagramCreationService(diagram);
 
         Optional<Diagram> optionalRefreshedDiagram = diagramCreationService.performRefresh(editingContext, diagram);
@@ -119,15 +193,7 @@ public class NodeCreationTests {
         Diagram refreshedDiagram = optionalRefreshedDiagram.get();
 
         IDiagramEvent diagramEvent = new NodeCreationEvent(eventCreationPosition);
-        Diagram layoutedDiagram = diagramCreationService.performLayout(editingContext, refreshedDiagram, diagramEvent);
-
-        Optional<Node> optionalParent = this.getNode(layoutedDiagram.getNodes(), "Parent"); //$NON-NLS-1$
-        assertThat(optionalParent).isPresent();
-        Optional<Node> optionalChild = this.getNode(layoutedDiagram.getNodes(), "Child"); //$NON-NLS-1$
-        assertThat(optionalChild).isPresent();
-
-        Node layoutedParent = optionalParent.get();
-        assertThat(layoutedParent).hasEveryChildWithinItsBounds();
+        return diagramCreationService.performLayout(editingContext, refreshedDiagram, diagramEvent);
     }
 
     private TestDiagramCreationService createDiagramCreationService(Diagram diagram) {

--- a/backend/sirius-components-diagrams-layout/src/test/java/org/eclipse/sirius/components/diagrams/layout/incremental/NodeCreationTests.java
+++ b/backend/sirius-components-diagrams-layout/src/test/java/org/eclipse/sirius/components/diagrams/layout/incremental/NodeCreationTests.java
@@ -1,0 +1,171 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.diagrams.layout.incremental;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.sirius.components.diagrams.tests.DiagramAssertions.assertThat;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import org.eclipse.sirius.components.core.api.IEditingContext;
+import org.eclipse.sirius.components.core.api.IRepresentationDescriptionSearchService;
+import org.eclipse.sirius.components.diagrams.CustomizableProperties;
+import org.eclipse.sirius.components.diagrams.Diagram;
+import org.eclipse.sirius.components.diagrams.Node;
+import org.eclipse.sirius.components.diagrams.Position;
+import org.eclipse.sirius.components.diagrams.description.DiagramDescription;
+import org.eclipse.sirius.components.diagrams.events.IDiagramEvent;
+import org.eclipse.sirius.components.diagrams.events.NodeCreationEvent;
+import org.eclipse.sirius.components.diagrams.layout.ELKLayoutedDiagramProvider;
+import org.eclipse.sirius.components.diagrams.layout.IELKDiagramConverter;
+import org.eclipse.sirius.components.diagrams.layout.LayoutConfiguratorRegistry;
+import org.eclipse.sirius.components.diagrams.layout.LayoutService;
+import org.eclipse.sirius.components.diagrams.layout.incremental.provider.ImageSizeProvider;
+import org.eclipse.sirius.components.diagrams.layout.incremental.provider.NodeSizeProvider;
+import org.eclipse.sirius.components.diagrams.layout.services.DefaultTestDiagramDescriptionProvider;
+import org.eclipse.sirius.components.diagrams.layout.services.TestDiagramCreationService;
+import org.eclipse.sirius.components.diagrams.layout.services.TestLayoutObjectService;
+import org.eclipse.sirius.components.diagrams.tests.builder.JsonBasedEditingContext;
+import org.eclipse.sirius.components.diagrams.tests.builder.TestLayoutDiagramBuilder;
+import org.eclipse.sirius.components.representations.IRepresentationDescription;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests the creation of a node and the resizing of its parent.
+ *
+ * @author rpage
+ */
+@SuppressWarnings("checkstyle:MultipleStringLiterals")
+public class NodeCreationTests {
+    private TestLayoutObjectService objectService = new TestLayoutObjectService();
+
+    private DefaultTestDiagramDescriptionProvider defaultTestDiagramDescriptionProvider = new DefaultTestDiagramDescriptionProvider(this.objectService);
+
+    @Test
+    public void testNodeCreationNoResizeNeeded() {
+        Position eventCreationPosition = Position.at(10, 10);
+        Diagram diagram = this.createParentNotResizedDiagram();
+        this.createNewNode(diagram, eventCreationPosition);
+    }
+
+    @Test
+    public void testNodeCreationWithResizeNeeded() {
+        Position eventCreationPosition = Position.at(199, 199);
+        Diagram diagram = this.createParentNotResizedDiagram();
+        this.createNewNode(diagram, eventCreationPosition);
+    }
+
+    @Test
+    public void testNodeCreationInResizedParentNoResizeNeeded() {
+        Position eventCreationPosition = Position.at(10, 10);
+        Diagram diagram = this.createParentResizedDiagram();
+        this.createNewNode(diagram, eventCreationPosition);
+    }
+
+    @Test
+    public void testNodeCreationInResizedParentWithResizeNeeded() {
+        Position eventCreationPosition = Position.at(199, 199);
+        Diagram diagram = this.createParentResizedDiagram();
+        this.createNewNode(diagram, eventCreationPosition);
+    }
+
+    private Diagram createParentNotResizedDiagram() {
+        // @formatter:off
+        return TestLayoutDiagramBuilder.diagram("Root") //$NON-NLS-1$
+                .nodes()
+                    .rectangleNode("Parent").at(10, 10).of(200, 200) //$NON-NLS-1$
+                    .and()
+                .and()
+            .build();
+        // @formatter:on
+    }
+
+    private Diagram createParentResizedDiagram() {
+        // @formatter:off
+        return TestLayoutDiagramBuilder.diagram("Root") //$NON-NLS-1$
+                .nodes()
+                    .rectangleNode("Parent").at(10, 10).of(200, 200).customizedProperties(Set.of(CustomizableProperties.Size)) //$NON-NLS-1$
+                    .and()
+                .and()
+            .build();
+        // @formatter:on
+    }
+
+    private void createNewNode(Diagram diagram, Position eventCreationPosition) {
+        Path path = Paths.get("src", "test", "resources", "editing-contexts", "testNodeCreation"); //$NON-NLS-1$//$NON-NLS-2$//$NON-NLS-3$//$NON-NLS-4$ //$NON-NLS-5$
+        JsonBasedEditingContext editingContext = new JsonBasedEditingContext(path);
+
+        TestDiagramCreationService diagramCreationService = this.createDiagramCreationService(diagram);
+
+        Optional<Diagram> optionalRefreshedDiagram = diagramCreationService.performRefresh(editingContext, diagram);
+        assertThat(optionalRefreshedDiagram).isNotEmpty();
+        Diagram refreshedDiagram = optionalRefreshedDiagram.get();
+
+        IDiagramEvent diagramEvent = new NodeCreationEvent(eventCreationPosition);
+        Diagram layoutedDiagram = diagramCreationService.performLayout(editingContext, refreshedDiagram, diagramEvent);
+
+        Optional<Node> optionalParent = this.getNode(layoutedDiagram.getNodes(), "Parent"); //$NON-NLS-1$
+        assertThat(optionalParent).isPresent();
+        Optional<Node> optionalChild = this.getNode(layoutedDiagram.getNodes(), "Child"); //$NON-NLS-1$
+        assertThat(optionalChild).isPresent();
+
+        Node layoutedParent = optionalParent.get();
+        assertThat(layoutedParent).hasEveryChildWithinItsBounds();
+    }
+
+    private TestDiagramCreationService createDiagramCreationService(Diagram diagram) {
+        IRepresentationDescriptionSearchService.NoOp representationDescriptionSearchService = new IRepresentationDescriptionSearchService.NoOp() {
+            @Override
+            public Optional<IRepresentationDescription> findById(IEditingContext editingContext, UUID representationDescriptionId) {
+                DiagramDescription diagramDescription = NodeCreationTests.this.defaultTestDiagramDescriptionProvider.getDefaultDiagramDescription(diagram);
+                return Optional.of(diagramDescription);
+            }
+        };
+
+        NodeSizeProvider nodeSizeProvider = new NodeSizeProvider(new ImageSizeProvider());
+        IncrementalLayoutEngine incrementalLayoutEngine = new IncrementalLayoutEngine(nodeSizeProvider);
+
+        LayoutService layoutService = new LayoutService(new IELKDiagramConverter.NoOp(), new IncrementalLayoutDiagramConverter(), new LayoutConfiguratorRegistry(List.of()),
+                new ELKLayoutedDiagramProvider(), new IncrementalLayoutedDiagramProvider(), representationDescriptionSearchService, incrementalLayoutEngine);
+
+        return new TestDiagramCreationService(this.objectService, representationDescriptionSearchService, layoutService);
+    }
+
+    private Optional<Node> getNode(List<Node> nodes, String targetObjectId) {
+        Optional<Node> optionalNode = Optional.empty();
+        List<Node> deeperNode = new ArrayList<>();
+
+        Iterator<Node> nodeIt = nodes.iterator();
+        while (optionalNode.isEmpty() && nodeIt.hasNext()) {
+            Node node = nodeIt.next();
+            if (targetObjectId.equals(node.getTargetObjectId())) {
+                optionalNode = Optional.of(node);
+            } else {
+                deeperNode.addAll(node.getChildNodes());
+            }
+        }
+
+        if (optionalNode.isEmpty() && !deeperNode.isEmpty()) {
+            optionalNode = this.getNode(deeperNode, targetObjectId);
+        }
+
+        return optionalNode;
+    }
+}

--- a/backend/sirius-components-diagrams-layout/src/test/java/org/eclipse/sirius/components/diagrams/layout/incremental/NodePositionProviderTests.java
+++ b/backend/sirius-components-diagrams-layout/src/test/java/org/eclipse/sirius/components/diagrams/layout/incremental/NodePositionProviderTests.java
@@ -44,9 +44,13 @@ public class NodePositionProviderTests {
 
     private static final Position ZERO_POSITION = Position.at(0, 0);
 
-    private static final double STARTX = 1000;
+    private static final double START_X_WITHIN_PARENT = 75;
 
-    private static final double STARTY = 1000;
+    private static final double START_Y_WITHIN_PARENT = 35;
+
+    private static final double START_X_OUTSIDE_PARENT = 1000;
+
+    private static final double START_Y_OUTSIDE_PARENT = 1000;
 
     @Test
     public void testDiagramSeveralNewNodesAtOnce() {
@@ -96,16 +100,27 @@ public class NodePositionProviderTests {
         assertThat(nextPosition).extracting(Position::getX).isEqualTo(Double.valueOf(0));
         assertThat(nextPosition).extracting(Position::getY).isEqualTo(Double.valueOf(DEFAULT_NODE_SIZE.getHeight() + 30));
 
-        // Test creation of a new node at a given position (creation tool)
-        Position startingPosition = Position.at(STARTX, STARTY);
+        // Test creation of a new node at a given position within parent (creation tool)
+        Position startingPosition = Position.at(START_X_WITHIN_PARENT, START_Y_WITHIN_PARENT);
         nodePositionProvider = new NodePositionProvider();
         nodeLayoutData = this.createNodeLayoutData(Position.UNDEFINED, DEFAULT_NODE_SIZE, diagramLayoutData, NodeType.NODE_RECTANGLE);
         nodes.add(nodeLayoutData);
 
         Optional<IDiagramEvent> optionalEvent = Optional.of(new NodeCreationEvent(startingPosition));
         nextPosition = nodePositionProvider.getPosition(optionalEvent, nodeLayoutData);
-        assertThat(nextPosition).extracting(Position::getX).isEqualTo(STARTX);
-        assertThat(nextPosition).extracting(Position::getY).isEqualTo(STARTY);
+        assertThat(nextPosition).extracting(Position::getX).isEqualTo(START_X_WITHIN_PARENT);
+        assertThat(nextPosition).extracting(Position::getY).isEqualTo(START_Y_WITHIN_PARENT);
+
+        // Test creation of a new node at a given position outside parent (creation tool)
+        Position startingPositionOutside = Position.at(START_X_OUTSIDE_PARENT, START_Y_OUTSIDE_PARENT);
+        nodePositionProvider = new NodePositionProvider();
+        nodeLayoutData = this.createNodeLayoutData(Position.UNDEFINED, DEFAULT_NODE_SIZE, diagramLayoutData, NodeType.NODE_RECTANGLE);
+        nodes.add(nodeLayoutData);
+
+        Optional<IDiagramEvent> optionalEventOutside = Optional.of(new NodeCreationEvent(startingPositionOutside));
+        nextPosition = nodePositionProvider.getPosition(optionalEventOutside, nodeLayoutData);
+        assertThat(nextPosition).extracting(Position::getX).isEqualTo(Double.valueOf(10));
+        assertThat(nextPosition).extracting(Position::getY).isEqualTo(Double.valueOf(10));
     }
 
     @Test
@@ -159,15 +174,25 @@ public class NodePositionProviderTests {
         assertThat(nextPosition).extracting(Position::getX).isEqualTo(Double.valueOf(0));
         assertThat(nextPosition).extracting(Position::getY).isEqualTo(Double.valueOf(DEFAULT_NODE_SIZE.getHeight() + 30));
 
-        // Test creation of a new node at a given position (creation tool)
+        // Test creation of a new node at a given position within parent (creation tool)
         nodeLayoutData = this.createNodeLayoutData(Position.UNDEFINED, DEFAULT_NODE_SIZE, parentNodeLayoutData, NodeType.NODE_RECTANGLE);
-        Position startingPosition = Position.at(STARTX, STARTY);
+        Position startingPosition = Position.at(START_X_WITHIN_PARENT, START_Y_WITHIN_PARENT);
         nodes.add(nodeLayoutData);
 
         nodePositionProvider = new NodePositionProvider();
         nextPosition = nodePositionProvider.getPosition(Optional.of(new NodeCreationEvent(startingPosition)), nodeLayoutData);
-        assertThat(nextPosition).extracting(Position::getX).isEqualTo(STARTX);
-        assertThat(nextPosition).extracting(Position::getY).isEqualTo(STARTY);
+        assertThat(nextPosition).extracting(Position::getX).isEqualTo(START_X_WITHIN_PARENT);
+        assertThat(nextPosition).extracting(Position::getY).isEqualTo(START_Y_WITHIN_PARENT);
+
+        // Test creation of a new node at a given position outside parent (creation tool)
+        nodeLayoutData = this.createNodeLayoutData(Position.UNDEFINED, DEFAULT_NODE_SIZE, parentNodeLayoutData, NodeType.NODE_RECTANGLE);
+        Position startingPositionOutside = Position.at(START_X_OUTSIDE_PARENT, START_Y_OUTSIDE_PARENT);
+        nodes.add(nodeLayoutData);
+
+        nodePositionProvider = new NodePositionProvider();
+        nextPosition = nodePositionProvider.getPosition(Optional.of(new NodeCreationEvent(startingPositionOutside)), nodeLayoutData);
+        assertThat(nextPosition).extracting(Position::getX).isEqualTo(Double.valueOf(10));
+        assertThat(nextPosition).extracting(Position::getY).isEqualTo(Double.valueOf(10));
     }
 
     @Test

--- a/backend/sirius-components-diagrams-layout/src/test/java/org/eclipse/sirius/components/diagrams/layout/incremental/NodeResizeTests.java
+++ b/backend/sirius-components-diagrams-layout/src/test/java/org/eclipse/sirius/components/diagrams/layout/incremental/NodeResizeTests.java
@@ -1,0 +1,253 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.diagrams.layout.incremental;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.eclipse.sirius.components.core.api.IEditingContext;
+import org.eclipse.sirius.components.core.api.IRepresentationDescriptionSearchService;
+import org.eclipse.sirius.components.diagrams.CustomizableProperties;
+import org.eclipse.sirius.components.diagrams.Diagram;
+import org.eclipse.sirius.components.diagrams.Node;
+import org.eclipse.sirius.components.diagrams.Position;
+import org.eclipse.sirius.components.diagrams.Size;
+import org.eclipse.sirius.components.diagrams.description.DiagramDescription;
+import org.eclipse.sirius.components.diagrams.events.IDiagramEvent;
+import org.eclipse.sirius.components.diagrams.events.ResizeEvent;
+import org.eclipse.sirius.components.diagrams.layout.ELKLayoutedDiagramProvider;
+import org.eclipse.sirius.components.diagrams.layout.IELKDiagramConverter;
+import org.eclipse.sirius.components.diagrams.layout.LayoutConfiguratorRegistry;
+import org.eclipse.sirius.components.diagrams.layout.LayoutService;
+import org.eclipse.sirius.components.diagrams.layout.incremental.provider.ImageSizeProvider;
+import org.eclipse.sirius.components.diagrams.layout.incremental.provider.NodeSizeProvider;
+import org.eclipse.sirius.components.diagrams.layout.services.DefaultTestDiagramDescriptionProvider;
+import org.eclipse.sirius.components.diagrams.layout.services.TestDiagramCreationService;
+import org.eclipse.sirius.components.diagrams.layout.services.TestLayoutObjectService;
+import org.eclipse.sirius.components.diagrams.tests.builder.JsonBasedEditingContext;
+import org.eclipse.sirius.components.diagrams.tests.builder.TestLayoutDiagramBuilder;
+import org.eclipse.sirius.components.representations.IRepresentationDescription;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests the manual resize of a node.
+ *
+ * @author rpage
+ */
+public class NodeResizeTests {
+    private TestLayoutObjectService objectService = new TestLayoutObjectService();
+
+    private DefaultTestDiagramDescriptionProvider defaultTestDiagramDescriptionProvider = new DefaultTestDiagramDescriptionProvider(this.objectService);
+
+    @Test
+    public void testDownsizeFromN() {
+        Position positionDelta = Position.at(0, -100);
+        Size newSize = Size.of(200, 200);
+        this.testResizeNode(positionDelta, Position.at(100, 200), newSize);
+    }
+
+    @Test
+    public void testDownsizeFromNE() {
+        Position positionDelta = Position.at(0, -100);
+        Size newSize = Size.of(100, 200);
+        this.testResizeNode(positionDelta, Position.at(100, 200), newSize);
+    }
+
+    @Test
+    public void testDownsizeFromE() {
+        Position positionDelta = Position.at(0, 0);
+        Size newSize = Size.of(100, 300);
+        this.testResizeNode(positionDelta, Position.at(100, 100), newSize);
+    }
+
+    @Test
+    public void testDownsizeFromSE() {
+        Position positionDelta = Position.at(0, 0);
+        Size newSize = Size.of(100, 200);
+        this.testResizeNode(positionDelta, Position.at(100, 100), newSize);
+    }
+
+    @Test
+    public void testDownsizeFromS() {
+        Position positionDelta = Position.at(0, 0);
+        Size newSize = Size.of(200, 200);
+        this.testResizeNode(positionDelta, Position.at(100, 100), newSize);
+    }
+
+    @Test
+    public void testDownsizeFromSW() {
+        Position positionDelta = Position.at(-100, 0);
+        Size newSize = Size.of(100, 200);
+        this.testResizeNode(positionDelta, Position.at(200, 100), newSize);
+    }
+
+    @Test
+    public void testDownsizeFromW() {
+        Position positionDelta = Position.at(-100, 0);
+        Size newSize = Size.of(100, 300);
+        this.testResizeNode(positionDelta, Position.at(200, 100), newSize);
+    }
+
+    @Test
+    public void testDownsizeFromNW() {
+        Position positionDelta = Position.at(-100, -100);
+        Size newSize = Size.of(100, 200);
+        this.testResizeNode(positionDelta, Position.at(200, 200), newSize);
+    }
+
+    @Test
+    public void testExpandFromN() {
+        Position positionDelta = Position.at(0, 100);
+        Size newSize = Size.of(200, 400);
+        this.testResizeNode(positionDelta, Position.at(100, 0), newSize);
+    }
+
+    @Test
+    public void testExpandFromNE() {
+        Position positionDelta = Position.at(0, 100);
+        Size newSize = Size.of(300, 400);
+        this.testResizeNode(positionDelta, Position.at(100, 0), newSize);
+    }
+
+    @Test
+    public void testExpandFromE() {
+        Position positionDelta = Position.at(0, 0);
+        Size newSize = Size.of(300, 300);
+        this.testResizeNode(positionDelta, Position.at(100, 100), newSize);
+    }
+
+    @Test
+    public void testExpandFromSE() {
+        Position positionDelta = Position.at(0, 0);
+        Size newSize = Size.of(300, 400);
+        this.testResizeNode(positionDelta, Position.at(100, 100), newSize);
+    }
+
+    @Test
+    public void testExpandFromS() {
+        Position positionDelta = Position.at(0, 0);
+        Size newSize = Size.of(200, 400);
+        this.testResizeNode(positionDelta, Position.at(100, 100), newSize);
+    }
+
+    @Test
+    public void testExpandFromSW() {
+        Position positionDelta = Position.at(100, 0);
+        Size newSize = Size.of(300, 400);
+        this.testResizeNode(positionDelta, Position.at(0, 100), newSize);
+    }
+
+    @Test
+    public void testExpandFromW() {
+        Position positionDelta = Position.at(100, 0);
+        Size newSize = Size.of(300, 300);
+        this.testResizeNode(positionDelta, Position.at(0, 100), newSize);
+    }
+
+    @Test
+    public void testExpandFromNW() {
+        Position positionDelta = Position.at(100, 100);
+        Size newSize = Size.of(300, 400);
+        this.testResizeNode(positionDelta, Position.at(0, 0), newSize);
+    }
+
+    private void testResizeNode(Position positionDelta, Position expectedPosition, Size newSize) {
+        String firstParentTargetObjectId = "First Parent"; //$NON-NLS-1$
+
+        Diagram diagram = this.createDiagramWithOneNode(firstParentTargetObjectId);
+
+        Optional<Node> optionalResizedFirstParent = this.resizeNode(firstParentTargetObjectId, diagram, positionDelta, newSize);
+
+        Node resizedFirstParent = optionalResizedFirstParent.get();
+        assertTrue(newSize.equals(resizedFirstParent.getSize()));
+        assertTrue(expectedPosition.equals(resizedFirstParent.getPosition()));
+        assertTrue(resizedFirstParent.getCustomizedProperties().stream().anyMatch(prop -> prop.equals(CustomizableProperties.Size)));
+    }
+
+    private Diagram createDiagramWithOneNode(String firstParentTargetObjectId) {
+        // @formatter:off
+        Diagram diagram = TestLayoutDiagramBuilder.diagram("Root") //$NON-NLS-1$
+                .nodes()
+                    .rectangleNode(firstParentTargetObjectId).at(100, 100).of(200, 300)
+                    .and()
+                .and()
+            .build();
+        // @formatter:on
+        return diagram;
+    }
+
+    private Optional<Node> resizeNode(String objectId, Diagram diagram, Position positionDelta, Size newSize) {
+        Path path = Paths.get("src", "test", "resources", "editing-contexts", "testResizeWithNoPositionDelta"); //$NON-NLS-1$//$NON-NLS-2$//$NON-NLS-3$//$NON-NLS-4$ //$NON-NLS-5$
+        JsonBasedEditingContext editingContext = new JsonBasedEditingContext(path);
+
+        TestDiagramCreationService diagramCreationService = this.createDiagramCreationService(diagram);
+
+        Optional<Node> optionalFirstParent = this.getNode(diagram.getNodes(), objectId);
+        assertThat(optionalFirstParent).isPresent();
+        Node firstParent = optionalFirstParent.get();
+
+        IDiagramEvent resizeEvent = new ResizeEvent(firstParent.getId(), positionDelta, newSize);
+        Diagram layoutedDiagram = diagramCreationService.performLayout(editingContext, diagram, resizeEvent);
+
+        Optional<Node> optionalResizedFirstParent = this.getNode(layoutedDiagram.getNodes(), objectId);
+        assertThat(optionalResizedFirstParent).isPresent();
+        return optionalResizedFirstParent;
+    }
+
+    private TestDiagramCreationService createDiagramCreationService(Diagram diagram) {
+        IRepresentationDescriptionSearchService.NoOp representationDescriptionSearchService = new IRepresentationDescriptionSearchService.NoOp() {
+            @Override
+            public Optional<IRepresentationDescription> findById(IEditingContext editingContext, UUID representationDescriptionId) {
+                DiagramDescription diagramDescription = NodeResizeTests.this.defaultTestDiagramDescriptionProvider.getDefaultDiagramDescription(diagram);
+                return Optional.of(diagramDescription);
+            }
+        };
+
+        NodeSizeProvider nodeSizeProvider = new NodeSizeProvider(new ImageSizeProvider());
+        IncrementalLayoutEngine incrementalLayoutEngine = new IncrementalLayoutEngine(nodeSizeProvider);
+
+        LayoutService layoutService = new LayoutService(new IELKDiagramConverter.NoOp(), new IncrementalLayoutDiagramConverter(), new LayoutConfiguratorRegistry(List.of()),
+                new ELKLayoutedDiagramProvider(), new IncrementalLayoutedDiagramProvider(), representationDescriptionSearchService, incrementalLayoutEngine);
+
+        return new TestDiagramCreationService(this.objectService, representationDescriptionSearchService, layoutService);
+    }
+
+    private Optional<Node> getNode(List<Node> nodes, String targetObjectId) {
+        Optional<Node> optionalNode = Optional.empty();
+        List<Node> deeperNode = new ArrayList<>();
+
+        Iterator<Node> nodeIt = nodes.iterator();
+        while (optionalNode.isEmpty() && nodeIt.hasNext()) {
+            Node node = nodeIt.next();
+            if (targetObjectId.equals(node.getTargetObjectId())) {
+                optionalNode = Optional.of(node);
+            } else {
+                deeperNode.addAll(node.getChildNodes());
+            }
+        }
+
+        if (optionalNode.isEmpty() && !deeperNode.isEmpty()) {
+            optionalNode = this.getNode(deeperNode, targetObjectId);
+        }
+
+        return optionalNode;
+    }
+}

--- a/backend/sirius-components-diagrams-layout/src/test/resources/editing-contexts/testNodeCreation
+++ b/backend/sirius-components-diagrams-layout/src/test/resources/editing-contexts/testNodeCreation
@@ -1,0 +1,14 @@
+{
+  "name": "diag:Root",
+  "children": [
+    {
+      "name": "rect:Parent",
+      "children": [
+        {
+          "name": "rect:Child",
+          "children": []
+        }
+      ]
+    }
+  ]
+}

--- a/backend/sirius-components-diagrams-layout/src/test/resources/editing-contexts/testNodeCreationOutsideItsParent
+++ b/backend/sirius-components-diagrams-layout/src/test/resources/editing-contexts/testNodeCreationOutsideItsParent
@@ -1,0 +1,18 @@
+{
+  "name": "diag:Root",
+  "children": [
+    {
+      "name": "rect:A",
+      "children": []
+    },
+    {
+      "name": "rect:B",
+      "children": [
+        {
+          "name": "rect:Child",
+          "children": []
+        }
+      ]
+    }
+  ]
+}

--- a/backend/sirius-components-diagrams-layout/src/test/resources/editing-contexts/testResizeWithNoPositionDelta
+++ b/backend/sirius-components-diagrams-layout/src/test/resources/editing-contexts/testResizeWithNoPositionDelta
@@ -1,0 +1,8 @@
+{
+  "name": "diag:Root",
+  "children": [
+    {
+      "name": "rect:First Parent"
+    }
+  ]
+}

--- a/backend/sirius-components-diagrams-tests/src/main/java/org/eclipse/sirius/components/diagrams/tests/NodeAssert.java
+++ b/backend/sirius-components-diagrams-tests/src/main/java/org/eclipse/sirius/components/diagrams/tests/NodeAssert.java
@@ -121,4 +121,52 @@ public class NodeAssert extends AbstractAssert<NodeAssert, Node> {
 
         return this;
     }
+
+    public NodeAssert hasEveryChildWithinItsBounds() {
+        this.isNotNull();
+        assertThat(this.actual.getChildNodes()).allMatch(child -> {
+            assertThat(child).hasEveryChildWithinItsBounds();
+            boolean isChildInParentBounds = this.isChildWithinParentBounds(this.actual, child);
+            boolean areChildBorderNodesInParentBounds = child.getBorderNodes().stream().allMatch(border -> this.isChildWithinParentBounds(this.actual, border));
+            return isChildInParentBounds && areChildBorderNodesInParentBounds;
+        });
+        return this;
+    }
+
+    private boolean isChildWithinParentBounds(Node parent, Node child) {
+        Position parentPosition = parent.getPosition();
+        Size parentSize = parent.getSize();
+
+        Position childPosition = child.getPosition();
+        Size childSize = child.getSize();
+
+        double parentX = parentPosition.getX();
+        double parentY = parentPosition.getY();
+        double parentWidth = parentSize.getWidth();
+        double parentHeight = parentSize.getHeight();
+
+        double childX = parentX + childPosition.getX();
+        double childY = parentY + childPosition.getY();
+        double childWidth = childSize.getWidth();
+        double childHeight = childSize.getHeight();
+
+        if (childX < parentX || childY < parentY) {
+            return false;
+        }
+
+        boolean top = this.compareDimensions(parentX, parentWidth, childX, childWidth);
+        boolean side = this.compareDimensions(parentY, parentHeight, childY, childHeight);
+
+        return top && side;
+    }
+
+    private boolean compareDimensions(double parentStart, double parentDimension, double childStart, double childDimension) {
+        double parentEnd = parentStart + parentDimension;
+        double childEnd = childStart + childDimension;
+        if (childEnd <= childStart) {
+            return !(parentEnd >= parentStart || childEnd > parentEnd);
+        } else {
+            return !(parentEnd >= parentStart && childEnd > parentEnd);
+        }
+    }
 }


### PR DESCRIPTION
Bugs: https://github.com/eclipse-sirius/sirius-components/issues/962 , https://github.com/eclipse-sirius/sirius-components/issues/1051

### Type of this PR 

- [x] Bug fix
- [ ] New feature or improvement
- [ ] Documentation
- [ ] Cleanup
- [ ] Test
- [ ] Build/Releng

### Issue(s)

- If a parent node has been previously resized, it is not resized again when creating a child not contained by its bounds.
- When the position of the event creating a child node is outside the parent node boundaries, the parent node is resized.

### What does this PR do?

This PR fixes this issues and provide new tests to detect them.

### Screenshot/screencast of this PR

...
 

### Potential side effects

...

### How to test this PR?

- [ ] Frontend Unit tests
- [x] Backend Unit tests
- [ ] Cypress : please specify
- [ ] Manual Test : please specify

### Checklist

- [x] I have read CONTRIBUTING carefully.
- [x] I have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All my commits are signed-off (`-s`) with my mail address of my Eclipse Account.
- [x] I have covered my changes by unit tests or integration tests or manual tests.
- [x] All tests pass.
- [ ] I have updated the documentation accordingly
- [ ] New React components are availables in storybook
