### PR TITLE
[1014] Add variable 'self' to preconditions of representations

### DIFF
--- a/backend/sirius-components-collaborative/src/main/java/org/eclipse/sirius/components/collaborative/dto/EditingContextRepresentationDescriptionsInput.java
+++ b/backend/sirius-components-collaborative/src/main/java/org/eclipse/sirius/components/collaborative/dto/EditingContextRepresentationDescriptionsInput.java
@@ -27,12 +27,12 @@ public final class EditingContextRepresentationDescriptionsInput implements IInp
 
     private final String editingContextId;
 
-    private final String kind;
+    private final String objectId;
 
-    public EditingContextRepresentationDescriptionsInput(UUID id, String editingContextId, String kind) {
+    public EditingContextRepresentationDescriptionsInput(UUID id, String editingContextId, String objectId) {
         this.id = Objects.requireNonNull(id);
         this.editingContextId = Objects.requireNonNull(editingContextId);
-        this.kind = Objects.requireNonNull(kind);
+        this.objectId = Objects.requireNonNull(objectId);
     }
 
     @Override
@@ -44,7 +44,7 @@ public final class EditingContextRepresentationDescriptionsInput implements IInp
         return this.editingContextId;
     }
 
-    public String getKind() {
-        return this.kind;
+    public String getObjectId() {
+        return this.objectId;
     }
 }

--- a/backend/sirius-components-collaborative/src/main/resources/schema/core.graphqls
+++ b/backend/sirius-components-collaborative/src/main/resources/schema/core.graphqls
@@ -16,7 +16,7 @@ type EditingContext {
   domains: [Domain!]!
   representation(representationId: ID!): RepresentationMetadata
   representations: EditingContextRepresentationConnection!
-  representationDescriptions(kind: ID!): EditingContextRepresentationDescriptionConnection!
+  representationDescriptions(objectId: ID!): EditingContextRepresentationDescriptionConnection!
   stereotypeDescriptions: EditingContextStereotypeDescriptionConnection!
   rootObjectCreationDescriptions(domainId: ID!, suggested: Boolean!): [ChildCreationDescription!]!
   childCreationDescriptions(kind: ID!): [ChildCreationDescription!]!

--- a/frontend/src/modals/new-representation/NewRepresentationModal.tsx
+++ b/frontend/src/modals/new-representation/NewRepresentationModal.tsx
@@ -135,7 +135,7 @@ export const NewRepresentationModal = ({
     error: representationDescriptionsError,
   } = useQuery<GQLGetRepresentationDescriptionsQueryData, GQLGetRepresentationDescriptionsQueryVariables>(
     getRepresentationDescriptionsQuery,
-    { variables: { editingContextId, objectId: item.id} }
+    { variables: { editingContextId, objectId: item.id } }
   );
 
   useEffect(() => {

--- a/frontend/src/modals/new-representation/NewRepresentationModal.tsx
+++ b/frontend/src/modals/new-representation/NewRepresentationModal.tsx
@@ -71,10 +71,10 @@ const createRepresentationMutation = gql`
 `;
 
 const getRepresentationDescriptionsQuery = gql`
-  query getRepresentationDescriptions($editingContextId: ID!, $kind: ID!) {
+  query getRepresentationDescriptions($editingContextId: ID!, $objectId: ID!) {
     viewer {
       editingContext(editingContextId: $editingContextId) {
-        representationDescriptions(kind: $kind) {
+        representationDescriptions(objectId: $objectId) {
           edges {
             node {
               id
@@ -135,7 +135,7 @@ export const NewRepresentationModal = ({
     error: representationDescriptionsError,
   } = useQuery<GQLGetRepresentationDescriptionsQueryData, GQLGetRepresentationDescriptionsQueryVariables>(
     getRepresentationDescriptionsQuery,
-    { variables: { editingContextId, kind: item.kind } }
+    { variables: { editingContextId, objectId: item.id} }
   );
 
   useEffect(() => {

--- a/frontend/src/modals/new-representation/NewRepresentationModal.types.ts
+++ b/frontend/src/modals/new-representation/NewRepresentationModal.types.ts
@@ -20,7 +20,7 @@ export interface NewRepresentationModalProps {
 
 export interface GQLGetRepresentationDescriptionsQueryVariables {
   editingContextId: string;
-  kind: string;
+  objectId: string;
 }
 
 export interface GQLGetRepresentationDescriptionsQueryData {

--- a/frontend/src/onboarding/OnboardArea.tsx
+++ b/frontend/src/onboarding/OnboardArea.tsx
@@ -20,7 +20,7 @@ import styles from './OnboardArea.module.css';
 import { OnboardAreaProps } from './OnboardArea.types';
 
 const getOnboardDataQuery = gql`
-  query getOnboardData($editingContextId: ID!, $kind: ID!) {
+  query getOnboardData($editingContextId: ID!, $objectId: ID!) {
     viewer {
       editingContext(editingContextId: $editingContextId) {
         stereotypeDescriptions {
@@ -32,7 +32,7 @@ const getOnboardDataQuery = gql`
             }
           }
         }
-        representationDescriptions(kind: $kind) {
+        representationDescriptions(objectId: $objectId) {
           edges {
             node {
               id
@@ -64,12 +64,12 @@ export const OnboardArea = ({ editingContextId, selection, setSelection, readOnl
   const [state, setState] = useState(INITIAL_STATE);
   const { stereotypeDescriptions, representationDescriptions, representations } = state;
 
-  const kind = selection.entries.length > 0 ? selection.entries[0].kind : '';
+  const objectId = selection.entries.length > 0 ? selection.entries[0].id : '';
 
   const [getOnboardData, { loading, data, error }] = useLazyQuery(getOnboardDataQuery);
   useEffect(() => {
-    getOnboardData({ variables: { editingContextId, kind } });
-  }, [editingContextId, kind, getOnboardData]);
+    getOnboardData({ variables: { editingContextId, objectId } });
+  }, [editingContextId, objectId, getOnboardData]);
   useEffect(() => {
     if (!loading && !error && data?.viewer) {
       const { viewer } = data;
@@ -85,7 +85,7 @@ export const OnboardArea = ({ editingContextId, selection, setSelection, readOnl
         representationDescriptions,
       });
     }
-  }, [editingContextId, kind, loading, data, error]);
+  }, [editingContextId, objectId, loading, data, error]);
 
   return (
     <div className={styles.onboardArea}>


### PR DESCRIPTION
Signed-off-by: Denis Nikiforov <denis.nikif@gmail.com>

### Type of this PR 

- [ ] Bug fix
- [x] New feature or improvement
- [ ] Documentation
- [ ] Cleanup
- [ ] Test
- [ ] Build/Releng

### Issue(s)

Issue #1014

### What does this PR do?

Allows to use `self` variable in preconditions for representations. Such a preconditions are supported in a desktop version of Sirius. We have a lot of such a specifications.

### Screenshot/screencast of this PR

No.

### Potential side effects

It can break starting page for projects (OnboardArea) and a representation creation dialog. But shouldn't.

It brakes Sirius Web sample application. Query parameter `kind` should be renamed to `objectId` in `backend/sirius-web-graphql/src/main/java/org/eclipse/sirius/web/graphql/datafetchers/editingcontext/EditingContextRepresentationDescriptionsDataFetcher.java`. A separate pull request will be send for the sample application.

Maybe variable `class` should be removed from `EditingContextRepresentationDescriptionsEventHandler`? It's left unchanged for backward compatibility. But I think it's not required anymore and can be replaced by `self.eClass()` in AQL expressions?..

### How to test this PR?

- [ ] Frontend Unit tests
- [ ] Backend Unit tests
- [ ] Cypress : please specify
- [x] Manual Test :
1) Add an AQL precondition with `self` variable for some representation
2) Try to create it
3) AQL expression should be successfuly evaluated
4) User is able to select representation to create

### Checklist

- [x] I have read CONTRIBUTING carefully.
- [x] I have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All my commits are signed-off (`-s`) with my mail address of my Eclipse Account.
- [x] I have covered my changes by unit tests or integration tests or manual tests.
- [x] All tests pass.
- [ ] I have updated the documentation accordingly
- [ ] New React components are availables in storybook
