### PR TITLE
[1054] Add missing variables to compute the label of an edge

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -38,6 +38,7 @@
 - https://github.com/eclipse-sirius/sirius-components/issues/985[#985] [core] Provide a variable to detect which environment is used. The value of the variable will change to something specific for the integrating application (for example siriusWeb). This is only available for the diagram for now
 - https://github.com/eclipse-sirius/sirius-components/issues/1025[#1025] [diagram] Add a new API to perform tests of our layout algorithm
 - https://github.com/eclipse-sirius/sirius-components/issues/699[#699] [core] Provide the `IEditingContext` to find all the `RepresentationMetadata` for a specific object
+- https://github.com/eclipse-sirius/sirius-components/issues/1054[#1054] [diagram] Add missing variables to compute the label of an edge
 
 
 === New features

--- a/backend/sirius-components-diagrams/src/main/java/org/eclipse/sirius/components/diagrams/components/EdgeComponent.java
+++ b/backend/sirius-components-diagrams/src/main/java/org/eclipse/sirius/components/diagrams/components/EdgeComponent.java
@@ -114,7 +114,7 @@ public class EdgeComponent implements IComponent {
                                 List<Position> routingPoints = optionalPreviousEdge.map(Edge::getRoutingPoints).orElse(List.of());
                                 Ratio sourceAnchorRelativePosition = optionalPreviousEdge.map(Edge::getSourceAnchorRelativePosition).orElse(Ratio.UNDEFINED);
                                 Ratio targetAnchorRelativePosition = optionalPreviousEdge.map(Edge::getTargetAnchorRelativePosition).orElse(Ratio.UNDEFINED);
-                                List<Element> labelChildren = this.getLabelsChildren(edgeDescription, edgeVariableManager, optionalPreviousEdge, id, routingPoints);
+                                List<Element> labelChildren = this.getLabelsChildren(edgeDescription, edgeInstanceVariableManager, optionalPreviousEdge, id, routingPoints);
                                 EdgeElementProps edgeElementProps = EdgeElementProps.newEdgeElementProps(id)
                                         .type(edgeType)
                                         .descriptionId(edgeDescription.getId())


### PR DESCRIPTION
Bug: https://github.com/eclipse-sirius/sirius-components/issues/1054
Signed-off-by: Stéphane Bégaudeau <stephane.begaudeau@obeo.fr>
