### PR TITLE
[1063] Fix layout regression on tree items without children

### DIFF
--- a/frontend/src/tree/TreeItem.tsx
+++ b/frontend/src/tree/TreeItem.tsx
@@ -76,7 +76,7 @@ const ItemCollapseToggle = ({ item, depth, onExpand, dataTestid }) => {
       );
     }
   }
-  return null;
+  return <div></div>;
 };
 
 export const TreeItem = ({


### PR DESCRIPTION
Make sure there is always the same number of children element inside the tree item's main div so the layout is the same whether or not the item has children.

Bug: https://github.com/eclipse-sirius/sirius-components/issues/1063
Signed-off-by: Pierre-Charles David <pierre-charles.david@obeo.fr>

### Type of this PR 

- [x] Bug fix
- [ ] New feature or improvement
- [ ] Documentation
- [ ] Cleanup
- [ ] Test
- [ ] Build/Releng

### Issue(s)

#1063 

### What does this PR do?

This fixes a regression introduced in https://github.com/eclipse-sirius/sirius-components/commit/48913d175c88a80d0dc10fd16f51a149bcaeee58 where tree items without children (and thus without the collaps/expand arrow) were no longer properly aligned with the others:

### Screenshot/screencast of this PR

![KO](https://user-images.githubusercontent.com/10608/154288592-0095e175-8658-4eb7-878f-d0bf6fa00d89.png)
