### PR TITLE
[1073] Add missing error callback on the canBeDisposed subscriber

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -39,6 +39,7 @@
 - https://github.com/eclipse-sirius/sirius-components/issues/1056[#1056] [core] Fix an invalid usage of `forwardRef` in  `DiagramTreeItemContextMenuContribution`
 - https://github.com/eclipse-sirius/sirius-components/issues/962[#962] [layout] Fix an issue preventing nodes from being properly resized when a child node is created
 - https://github.com/eclipse-sirius/sirius-components/issues/1051[#1051] [layout] Fix an issue resizing nodes when a child node was created even if it was not necessary
+- https://github.com/eclipse-sirius/sirius-components/issues/1073[#1073] [core] Add missing ErrorCallback on the canBeDisposed subscriber of the EditingContextEventProcessor
 
 === Improvements
 

--- a/backend/sirius-components-collaborative/src/main/java/org/eclipse/sirius/components/collaborative/editingcontext/EditingContextEventProcessor.java
+++ b/backend/sirius-components-collaborative/src/main/java/org/eclipse/sirius/components/collaborative/editingcontext/EditingContextEventProcessor.java
@@ -352,7 +352,7 @@ public class EditingContextEventProcessor implements IEditingContextEventProcess
                             } else {
                                 this.logger.trace("Stopping the disposal of the representation event processor {}", configuration.getId()); //$NON-NLS-1$
                             }
-                        });
+                        }, throwable -> this.logger.warn(throwable.getMessage(), throwable));
                 // @formatter:on
 
                 var representationEventProcessorEntry = new RepresentationEventProcessorEntry(representationEventProcessor, subscription);


### PR DESCRIPTION
Bug: https://github.com/eclipse-sirius/sirius-components/issues/1073
Signed-off-by: Stéphane Bégaudeau <stephane.begaudeau@obeo.fr>
