### PR TITLE
[919] Support the parent container resize for the border nodes on the backend

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -57,6 +57,7 @@
 - https://github.com/eclipse-sirius/sirius-components/issues/956[#956] [diagram] Add the border node concept on front-end and implement the border node snap. The user can move the border node only on the side of its parent node. The border node enters its parent node with 8px. The ELK automatic layout is adapated to have the same behavior.
 - https://github.com/eclipse-sirius/sirius-components/issues/1081[#1081] [workbench] It is now possible to specify the component to display in the main area when no representation is open instead of the `OnboardArea` (which is still the default when there is no override)
 - https://github.com/eclipse-sirius/sirius-components/issues/1070[#1070] [explorer] When selecting an element or opening a representation (for example from its URL or from the onboard area), it is automatically made visible and selected in the explorer.
+- https://github.com/eclipse-sirius/sirius-components/issues/919[#919] [diagram] Support the parent container resize for the border nodes on back-end
 
 === New features
 

--- a/backend/sirius-components-diagrams-layout/src/main/java/org/eclipse/sirius/components/diagrams/layout/incremental/utils/Geometry.java
+++ b/backend/sirius-components-diagrams-layout/src/main/java/org/eclipse/sirius/components/diagrams/layout/incremental/utils/Geometry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 THALES GLOBAL SERVICES.
+ * Copyright (c) 2021, 2022 THALES GLOBAL SERVICES.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -12,9 +12,12 @@
  *******************************************************************************/
 package org.eclipse.sirius.components.diagrams.layout.incremental.utils;
 
+import java.util.EnumMap;
+import java.util.Map.Entry;
 import java.util.Optional;
 
 import org.eclipse.sirius.components.diagrams.Position;
+import org.eclipse.sirius.components.diagrams.Size;
 
 /**
  * A Geometry Helper.
@@ -22,7 +25,6 @@ import org.eclipse.sirius.components.diagrams.Position;
  * @author fbarbin
  */
 public final class Geometry {
-
     /**
      * Computes intersection points between the given rectangle (Bounds) and the segment(source,target), then returns
      * the closest one from the source point.
@@ -118,6 +120,114 @@ public final class Geometry {
         double ac = Math.abs(target.getY() - source.getY());
         double cb = Math.abs(target.getX() - source.getX());
         return Math.hypot(ac, cb);
+    }
+
+    /**
+     * Returns the distance between the point p and the segment made of p1 and p2.
+     *
+     * @param p
+     *            the point
+     * @param p1
+     *            the first point of the segment
+     * @param p2
+     *            the second point of the segment
+     */
+    public Position closestPointOnSegment(Position p, Position p1, Position p2) {
+        double p1pVectordx = p.getX() - p1.getX();
+        double p1pVectordy = p.getY() - p1.getY();
+        double p2p1Vectordx = p2.getX() - p1.getX();
+        double p2p1Vectordy = p2.getY() - p1.getY();
+
+        double dot = p1pVectordx * p2p1Vectordx + p1pVectordy * p2p1Vectordy;
+        double lengthSquare = p2p1Vectordx * p2p1Vectordx + p2p1Vectordy * p2p1Vectordy;
+        // param is the projection distance from p1 on the segment. This is the fraction of the segment that p is
+        // closest to.
+        double param = -1;
+        if (lengthSquare != 0) {
+            // if the line has 0 length
+            param = dot / lengthSquare;
+        }
+
+        Position nearestPoint = null;
+
+        if (param < 0) {
+            // The point is not "in front of" the segment. It is "away" on the p1 side
+            nearestPoint = Position.at(p1.getX(), p1.getY());
+        } else if (param > 1) {
+            // The point is not "in front of" the segment. It is "away" on the p1 side
+            nearestPoint = Position.at(p2.getX(), p2.getY());
+        } else {
+            // The point is "in front of" the segment
+            // get the projection of p on the segment
+            nearestPoint = Position.at(p1.getX() + param * p2p1Vectordx, p1.getY() + param * p2p1Vectordy);
+        }
+
+        return nearestPoint;
+    }
+
+    /**
+     * Gets the closest point on the parentRectangleSize from the given borderNodeRectangle rectangle.
+     *
+     * @return the position of the point (given in the parentRectangleSize upper right corner coordinates system) and
+     *         the side on the parent rectangle.
+     */
+    public PointOnRectangleInfo snapBorderNodeOnRectangle(Bounds borderNodeRectangle, Size parentRectangleSize, double portOffset) {
+        Position borderNodePosition = borderNodeRectangle.getPosition();
+        Size borderNodeSize = borderNodeRectangle.getSize();
+        Position borderNodeCenterPosition = Position.at(borderNodePosition.getX() + borderNodeSize.getWidth() / 2, borderNodePosition.getY() + borderNodeSize.getHeight() / 2);
+
+        Position parentUpperLeftCorner = Position.at(0, 0);
+        Position parentUpperRightCorner = Position.at(parentRectangleSize.getWidth(), 0);
+        Position parentBottomRightCorner = Position.at(parentRectangleSize.getWidth(), parentRectangleSize.getHeight());
+        Position parentBottomLeftCorner = Position.at(0, parentRectangleSize.getHeight());
+
+        EnumMap<RectangleSide, Position> closestPointOnSide = new EnumMap<>(RectangleSide.class);
+        closestPointOnSide.put(RectangleSide.NORTH, this.closestPointOnSegment(borderNodeCenterPosition, parentUpperLeftCorner, parentUpperRightCorner));
+        closestPointOnSide.put(RectangleSide.EAST, this.closestPointOnSegment(borderNodeCenterPosition, parentUpperRightCorner, parentBottomRightCorner));
+        closestPointOnSide.put(RectangleSide.SOUTH, this.closestPointOnSegment(borderNodeCenterPosition, parentBottomRightCorner, parentBottomLeftCorner));
+        closestPointOnSide.put(RectangleSide.WEST, this.closestPointOnSegment(borderNodeCenterPosition, parentBottomLeftCorner, parentUpperLeftCorner));
+
+        double currentClosestDistance = Double.MAX_VALUE;
+        RectangleSide currentClosestSide = RectangleSide.NORTH;
+        Position curentCenterPositionOnSide = borderNodeCenterPosition;
+        for (Entry<RectangleSide, Position> entry : closestPointOnSide.entrySet()) {
+            RectangleSide side = entry.getKey();
+            Position positionOnSide = entry.getValue();
+
+            double distance = this.computeDistance(borderNodeCenterPosition, positionOnSide);
+            if (currentClosestDistance >= distance) {
+                boolean updateTheClosestSide = true;
+                if (currentClosestDistance == distance) {
+                    // Manage the case when borderNodeCenterPosition is outside the rectangle, near a corner of the
+                    // parent rectangle, to get the best side
+                    if (RectangleSide.NORTH.equals(side) || RectangleSide.SOUTH.equals(side)) {
+                        updateTheClosestSide = Math.abs(borderNodeCenterPosition.getY() - positionOnSide.getY()) > Math.abs(borderNodeCenterPosition.getX() - positionOnSide.getX());
+                    } else if (RectangleSide.EAST.equals(side) || RectangleSide.WEST.equals(side)) {
+                        updateTheClosestSide = Math.abs(borderNodeCenterPosition.getY() - positionOnSide.getY()) < Math.abs(borderNodeCenterPosition.getX() - positionOnSide.getX());
+                    }
+                }
+
+                if (updateTheClosestSide) {
+                    currentClosestDistance = distance;
+                    currentClosestSide = side;
+                    curentCenterPositionOnSide = positionOnSide;
+                }
+            }
+        }
+
+        // Get the new upper right corner position of the border node according to the side and the offset
+        Position newBorderNodePosition = Position.at(0, 0);
+        if (RectangleSide.NORTH.equals(currentClosestSide)) {
+            newBorderNodePosition = Position.at(curentCenterPositionOnSide.getX() - borderNodeSize.getWidth() / 2, curentCenterPositionOnSide.getY() - borderNodeSize.getHeight() - portOffset);
+        } else if (RectangleSide.SOUTH.equals(currentClosestSide)) {
+            newBorderNodePosition = Position.at(curentCenterPositionOnSide.getX() - borderNodeSize.getWidth() / 2, curentCenterPositionOnSide.getY() + portOffset);
+        } else if (RectangleSide.WEST.equals(currentClosestSide)) {
+            newBorderNodePosition = Position.at(curentCenterPositionOnSide.getX() - borderNodeSize.getWidth() - portOffset, curentCenterPositionOnSide.getY() - borderNodeSize.getHeight() / 2);
+        } else if (RectangleSide.EAST.equals(currentClosestSide)) {
+            newBorderNodePosition = Position.at(curentCenterPositionOnSide.getX() + portOffset, curentCenterPositionOnSide.getY() - borderNodeSize.getHeight() / 2);
+        }
+
+        return new PointOnRectangleInfo(newBorderNodePosition, currentClosestSide);
     }
 
 }

--- a/backend/sirius-components-diagrams-layout/src/main/java/org/eclipse/sirius/components/diagrams/layout/incremental/utils/PointOnRectangleInfo.java
+++ b/backend/sirius-components-diagrams-layout/src/main/java/org/eclipse/sirius/components/diagrams/layout/incremental/utils/PointOnRectangleInfo.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.diagrams.layout.incremental.utils;
+
+import java.util.Objects;
+
+import org.eclipse.sirius.components.diagrams.Position;
+
+/**
+ * This class represents a point on a given side of a rectangle.
+ *
+ * @author lfasani
+ */
+public class PointOnRectangleInfo {
+    private final Position position;
+
+    private final RectangleSide side;
+
+    public PointOnRectangleInfo(Position position, RectangleSide side) {
+        this.position = Objects.requireNonNull(position);
+        this.side = Objects.requireNonNull(side);
+    }
+
+    public Position getPosition() {
+        return this.position;
+    }
+
+    public RectangleSide getSide() {
+        return this.side;
+    }
+}

--- a/backend/sirius-components-diagrams-layout/src/main/java/org/eclipse/sirius/components/diagrams/layout/incremental/utils/RectangleSide.java
+++ b/backend/sirius-components-diagrams-layout/src/main/java/org/eclipse/sirius/components/diagrams/layout/incremental/utils/RectangleSide.java
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.diagrams.layout.incremental.utils;
+
+/**
+ * Represents the 4 different sides of a rectangle.
+ *
+ * @author lfasani
+ */
+public enum RectangleSide {
+    NORTH, EAST, SOUTH, WEST
+}

--- a/backend/sirius-components-diagrams-layout/src/test/java/org/eclipse/sirius/components/diagrams/layout/incremental/BorderNodePositionTests.java
+++ b/backend/sirius-components-diagrams-layout/src/test/java/org/eclipse/sirius/components/diagrams/layout/incremental/BorderNodePositionTests.java
@@ -1,0 +1,247 @@
+/*******************************************************************************
+ * Copyright (c) 2022 THALES GLOBAL SERVICES.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.diagrams.layout.incremental;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.eclipse.elk.alg.layered.options.LayeredOptions;
+import org.eclipse.elk.core.data.LayoutMetaDataService;
+import org.eclipse.sirius.components.diagrams.NodeType;
+import org.eclipse.sirius.components.diagrams.Position;
+import org.eclipse.sirius.components.diagrams.Size;
+import org.eclipse.sirius.components.diagrams.TextBounds;
+import org.eclipse.sirius.components.diagrams.events.IDiagramEvent;
+import org.eclipse.sirius.components.diagrams.events.MoveEvent;
+import org.eclipse.sirius.components.diagrams.events.ResizeEvent;
+import org.eclipse.sirius.components.diagrams.layout.LayoutConfiguratorRegistry;
+import org.eclipse.sirius.components.diagrams.layout.incremental.data.DiagramLayoutData;
+import org.eclipse.sirius.components.diagrams.layout.incremental.data.IContainerLayoutData;
+import org.eclipse.sirius.components.diagrams.layout.incremental.data.LabelLayoutData;
+import org.eclipse.sirius.components.diagrams.layout.incremental.data.NodeLayoutData;
+import org.eclipse.sirius.components.diagrams.layout.incremental.provider.ImageSizeProvider;
+import org.eclipse.sirius.components.diagrams.layout.incremental.provider.NodeSizeProvider;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test cases for border nodes.
+ *
+ * @author lfasani
+ */
+public class BorderNodePositionTests {
+
+    private static final Size DEFAULT_NODE_SIZE = Size.of(200, 100);
+
+    private static final Size DEFAULT_BORDER_NODE_SIZE = Size.of(24, 20);
+
+    private static final Position ZERO_POSITION = Position.at(0, 0);
+
+    @BeforeAll
+    private static void initTest() {
+        LayoutMetaDataService.getInstance().registerLayoutMetaDataProviders(new LayeredOptions());
+    }
+
+    /**
+     * Test the snap of the border nodes on their parent container.<br/>
+     * The border nodes are voluntary at an invalid position to make sure they properly snap done at the first layout
+     */
+    @Test
+    public void testSnap() {
+        DiagramLayoutData initializeDiagram = this.initializeDiagram();
+        List<NodeLayoutData> borderNodes = initializeDiagram.getChildrenNodes().get(0).getBorderNodes();
+
+        NodeSizeProvider nodeSizeProvider = new NodeSizeProvider(new ImageSizeProvider());
+        IncrementalLayoutEngine incrementalLayoutEngine = new IncrementalLayoutEngine(nodeSizeProvider);
+
+        incrementalLayoutEngine.layout(Optional.empty(), initializeDiagram, new LayoutConfiguratorRegistry(List.of()).getDefaultLayoutConfigurator());
+
+        this.checkBorderNodesAtInitialPosition(borderNodes);
+    }
+
+    @Test
+    public void testMoveParentNodeEvent() {
+        DiagramLayoutData initializeDiagram = this.initializeDiagram();
+        List<NodeLayoutData> borderNodes = initializeDiagram.getChildrenNodes().get(0).getBorderNodes();
+        String nodeId = initializeDiagram.getChildrenNodes().get(0).getId();
+
+        NodeSizeProvider nodeSizeProvider = new NodeSizeProvider(new ImageSizeProvider());
+        IncrementalLayoutEngine incrementalLayoutEngine = new IncrementalLayoutEngine(nodeSizeProvider);
+
+        Optional<IDiagramEvent> resizeEvent = Optional.of(new MoveEvent(nodeId, Position.at(50, -100)));
+        incrementalLayoutEngine.layout(resizeEvent, initializeDiagram, new LayoutConfiguratorRegistry(List.of()).getDefaultLayoutConfigurator());
+
+        this.checkBorderNodesAtInitialPosition(borderNodes);
+    }
+
+    private void checkBorderNodesAtInitialPosition(List<NodeLayoutData> borderNodes) {
+        assertThat(borderNodes.get(0).getPosition()).isEqualTo(Position.at(28, -12));
+        assertThat(borderNodes.get(1).getPosition()).isEqualTo(Position.at(38, -12));
+        assertThat(borderNodes.get(2).getPosition()).isEqualTo(Position.at(192, 40));
+        assertThat(borderNodes.get(3).getPosition()).isEqualTo(Position.at(192, 90));
+        assertThat(borderNodes.get(4).getPosition()).isEqualTo(Position.at(188, 92));
+        assertThat(borderNodes.get(5).getPosition()).isEqualTo(Position.at(88, 92));
+        assertThat(borderNodes.get(6).getPosition()).isEqualTo(Position.at(-16, 40));
+        assertThat(borderNodes.get(7).getPosition()).isEqualTo(Position.at(-16, -10));
+    }
+
+    @Test
+    public void testResizeParentNodeSouthEastEvent() {
+        DiagramLayoutData initializeDiagram = this.initializeDiagram();
+        String nodeId = initializeDiagram.getChildrenNodes().get(0).getId();
+        List<NodeLayoutData> borderNodes = initializeDiagram.getChildrenNodes().get(0).getBorderNodes();
+
+        NodeSizeProvider nodeSizeProvider = new NodeSizeProvider(new ImageSizeProvider());
+        IncrementalLayoutEngine incrementalLayoutEngine = new IncrementalLayoutEngine(nodeSizeProvider);
+
+        // Decrease the parent node size
+        Optional<IDiagramEvent> resizeEvent = Optional.of(new ResizeEvent(nodeId, ZERO_POSITION, Size.of(100, 50)));
+        incrementalLayoutEngine.layout(resizeEvent, initializeDiagram, new LayoutConfiguratorRegistry(List.of()).getDefaultLayoutConfigurator());
+
+        this.checkBorderNodesAfterResize(borderNodes);
+
+        // Increase the parent node size to get the initial size
+        resizeEvent = Optional.of(new ResizeEvent(nodeId, ZERO_POSITION, DEFAULT_NODE_SIZE));
+        incrementalLayoutEngine.layout(resizeEvent, initializeDiagram, new LayoutConfiguratorRegistry(List.of()).getDefaultLayoutConfigurator());
+
+        this.checkBorderNodesAtInitialPosition(borderNodes);
+    }
+
+    @Test
+    public void testResizeParentNodeNorthWestEvent() {
+        DiagramLayoutData initializeDiagram = this.initializeDiagram();
+        String nodeId = initializeDiagram.getChildrenNodes().get(0).getId();
+        List<NodeLayoutData> borderNodes = initializeDiagram.getChildrenNodes().get(0).getBorderNodes();
+
+        NodeSizeProvider nodeSizeProvider = new NodeSizeProvider(new ImageSizeProvider());
+        IncrementalLayoutEngine incrementalLayoutEngine = new IncrementalLayoutEngine(nodeSizeProvider);
+
+        // Decrease the parent node size
+        Optional<IDiagramEvent> resizeEvent = Optional.of(new ResizeEvent(nodeId, Position.at(100, 50), Size.of(100, 50)));
+        incrementalLayoutEngine.layout(resizeEvent, initializeDiagram, new LayoutConfiguratorRegistry(List.of()).getDefaultLayoutConfigurator());
+
+        this.checkBorderNodesAfterResize(borderNodes);
+
+        // Increase the parent node size to get the initial size
+        resizeEvent = Optional.of(new ResizeEvent(nodeId, ZERO_POSITION, DEFAULT_NODE_SIZE));
+        incrementalLayoutEngine.layout(resizeEvent, initializeDiagram, new LayoutConfiguratorRegistry(List.of()).getDefaultLayoutConfigurator());
+
+        this.checkBorderNodesAtInitialPosition(borderNodes);
+
+    }
+
+    private void checkBorderNodesAfterResize(List<NodeLayoutData> borderNodes) {
+        assertThat(borderNodes.get(0).getPosition()).isEqualTo(Position.at(8, -12));
+        assertThat(borderNodes.get(1).getPosition()).isEqualTo(Position.at(13, -12));
+        assertThat(borderNodes.get(2).getPosition()).isEqualTo(Position.at(92, 15));
+        assertThat(borderNodes.get(3).getPosition()).isEqualTo(Position.at(92, 40));
+        assertThat(borderNodes.get(4).getPosition()).isEqualTo(Position.at(88, 42));
+        assertThat(borderNodes.get(5).getPosition()).isEqualTo(Position.at(38, 42));
+        assertThat(borderNodes.get(6).getPosition()).isEqualTo(Position.at(-16, 15));
+        assertThat(borderNodes.get(7).getPosition()).isEqualTo(Position.at(-16, -10));
+    }
+
+    /**
+     * Initialize the diagram with 1 node containing many border nodes.<br/>
+     * The border nodes are voluntary at an invalid position to make sure they properly positioned after nay layout
+     * event.
+     */
+    private DiagramLayoutData initializeDiagram() {
+        DiagramLayoutData diagramLayoutData = this.createDiagramLayoutData();
+        diagramLayoutData.setEdges(new ArrayList<>());
+
+        NodeLayoutData nodeLayoutData = this.createNodeLayoutData(Position.at(100, 100), DEFAULT_NODE_SIZE, diagramLayoutData, NodeType.NODE_RECTANGLE);
+        List<NodeLayoutData> nodes = new ArrayList<>();
+        nodes.add(nodeLayoutData);
+        diagramLayoutData.setChildrenNodes(nodes);
+
+        List<NodeLayoutData> borderNodes = new ArrayList<>();
+
+        // Position of the border if it was located centered at the origin of its parent
+        Position borderNodeCenterAtOrigin = Position.at(-DEFAULT_BORDER_NODE_SIZE.getWidth() / 2, -DEFAULT_BORDER_NODE_SIZE.getHeight() / 2);
+        // border nodes on north
+        borderNodes.add(this.createBorderNodeLayoutData(Position.at(borderNodeCenterAtOrigin.getX() + 40, borderNodeCenterAtOrigin.getY() - 20), DEFAULT_BORDER_NODE_SIZE, nodeLayoutData,
+                NodeType.NODE_RECTANGLE));
+        borderNodes.add(
+                this.createBorderNodeLayoutData(Position.at(borderNodeCenterAtOrigin.getX() + 50, borderNodeCenterAtOrigin.getY()), DEFAULT_BORDER_NODE_SIZE, nodeLayoutData, NodeType.NODE_RECTANGLE));
+        // border nodes on east
+        borderNodes.add(
+                this.createBorderNodeLayoutData(Position.at(borderNodeCenterAtOrigin.getX() + DEFAULT_NODE_SIZE.getWidth() + 10, borderNodeCenterAtOrigin.getY() + DEFAULT_NODE_SIZE.getHeight() / 2),
+                        DEFAULT_BORDER_NODE_SIZE, nodeLayoutData, NodeType.NODE_RECTANGLE));
+        borderNodes.add(
+                this.createBorderNodeLayoutData(Position.at(borderNodeCenterAtOrigin.getX() + DEFAULT_NODE_SIZE.getWidth() + 10, borderNodeCenterAtOrigin.getY() + DEFAULT_NODE_SIZE.getHeight() + 5),
+                        DEFAULT_BORDER_NODE_SIZE, nodeLayoutData, NodeType.NODE_RECTANGLE));
+        // border nodes on south
+        borderNodes.add(
+                this.createBorderNodeLayoutData(Position.at(borderNodeCenterAtOrigin.getX() + DEFAULT_NODE_SIZE.getWidth() + 5, borderNodeCenterAtOrigin.getY() + DEFAULT_NODE_SIZE.getHeight() + 10),
+                        DEFAULT_BORDER_NODE_SIZE, nodeLayoutData, NodeType.NODE_RECTANGLE));
+        borderNodes.add(
+                this.createBorderNodeLayoutData(Position.at(borderNodeCenterAtOrigin.getX() + DEFAULT_NODE_SIZE.getWidth() / 2, borderNodeCenterAtOrigin.getY() + DEFAULT_NODE_SIZE.getHeight() - 20),
+                        DEFAULT_BORDER_NODE_SIZE, nodeLayoutData, NodeType.NODE_RECTANGLE));
+        // border nodes on west
+        borderNodes.add(this.createBorderNodeLayoutData(Position.at(borderNodeCenterAtOrigin.getX(), borderNodeCenterAtOrigin.getY() + DEFAULT_NODE_SIZE.getHeight() / 2), DEFAULT_BORDER_NODE_SIZE,
+                nodeLayoutData, NodeType.NODE_RECTANGLE));
+        borderNodes.add(this.createBorderNodeLayoutData(Position.at(borderNodeCenterAtOrigin.getX() - 2, borderNodeCenterAtOrigin.getY() - 1), DEFAULT_BORDER_NODE_SIZE, nodeLayoutData,
+                NodeType.NODE_RECTANGLE));
+
+        nodeLayoutData.setBorderNodes(borderNodes);
+
+        return diagramLayoutData;
+    }
+
+    private DiagramLayoutData createDiagramLayoutData() {
+        DiagramLayoutData diagramLayoutData = new DiagramLayoutData();
+        diagramLayoutData.setId(UUID.randomUUID().toString());
+        diagramLayoutData.setPosition(Position.at(0, 0));
+        diagramLayoutData.setSize(Size.of(1000, 1000));
+
+        return diagramLayoutData;
+    }
+
+    private NodeLayoutData createBorderNodeLayoutData(Position position, Size size, IContainerLayoutData parent, String nodeType) {
+        NodeLayoutData nodeLayoutData = new NodeLayoutData();
+        nodeLayoutData.setId(UUID.randomUUID().toString());
+        nodeLayoutData.setParent(parent);
+        nodeLayoutData.setPosition(position);
+        nodeLayoutData.setSize(size);
+        nodeLayoutData.setNodeType(nodeType);
+        nodeLayoutData.setBorderNode(true);
+        return nodeLayoutData;
+    }
+
+    private NodeLayoutData createNodeLayoutData(Position position, Size size, IContainerLayoutData parent, String nodeType) {
+        NodeLayoutData nodeLayoutData = new NodeLayoutData();
+        nodeLayoutData.setId(UUID.randomUUID().toString());
+        nodeLayoutData.setParent(parent);
+        nodeLayoutData.setPosition(position);
+        nodeLayoutData.setSize(size);
+        nodeLayoutData.setNodeType(nodeType);
+        nodeLayoutData.setChildrenNodes(new ArrayList<>());
+        nodeLayoutData.setLabel(this.createLabelLayoutData(Position.at(0, 0), Size.of(0, 0), nodeLayoutData, "inside")); //$NON-NLS-1$
+        return nodeLayoutData;
+    }
+
+    private LabelLayoutData createLabelLayoutData(Position position, Size size, IContainerLayoutData parent, String labelType) {
+        LabelLayoutData labelLayoutData = new LabelLayoutData();
+        labelLayoutData.setId(UUID.randomUUID().toString());
+        labelLayoutData.setPosition(position);
+        labelLayoutData.setLabelType(labelType);
+        labelLayoutData.setTextBounds(new TextBounds(Size.of(0, 0), Position.at(0, 0)));
+        return labelLayoutData;
+    }
+
+}


### PR DESCRIPTION
back-end

Bug: https://github.com/eclipse-sirius/sirius-components/issues/919
Signed-off-by: Laurent Fasani <laurent.fasani@obeo.fr>

### Type of this PR 

- [ ] Bug fix
- [ ] New feature or improvement
- [ ] Documentation
- [ ] Cleanup
- [ ] Test
- [ ] Build/Releng

### Issue(s)

...

### What does this PR do?

...

### Screenshot/screencast of this PR

...
 

### Potential side effects

...

### How to test this PR?

- [ ] Frontend Unit tests
- [ ] Backend Unit tests
- [ ] Cypress : please specify
- [ ] Manual Test : please specify

### Checklist

- [ ] I have read CONTRIBUTING carefully.
- [ ] I have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [ ] All my commits are signed-off (`-s`) with my mail address of my Eclipse Account.
- [ ] I have covered my changes by unit tests or integration tests or manual tests.
- [ ] All tests pass.
- [ ] I have updated the documentation accordingly
- [ ] New React components are availables in storybook
