### PR TITLE
[fix] Fix the resize when resizing twice

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -45,6 +45,7 @@
 - https://github.com/eclipse-sirius/sirius-components/issues/962[#962] [layout] Fix an issue preventing nodes from being properly resized when a child node is created
 - https://github.com/eclipse-sirius/sirius-components/issues/1051[#1051] [layout] Fix an issue resizing nodes when a child node was created even if it was not necessary
 - https://github.com/eclipse-sirius/sirius-components/issues/1073[#1073] [core] Add missing ErrorCallback on the canBeDisposed subscriber of the EditingContextEventProcessor
+- [diagram] Fix an issue preventing the resizing of a node if the cursor had not moved after a previous resizing
 
 === Improvements
 

--- a/frontend/src/diagram/sprotty/siriusDragAndDropMouseListener.ts
+++ b/frontend/src/diagram/sprotty/siriusDragAndDropMouseListener.ts
@@ -60,7 +60,7 @@ export class SiriusDragAndDropMouseListener extends MoveMouseListener {
   public mouseMove(target: SModelElement, event: MouseEvent): Action[] {
     if (this.isResizing()) {
       const result: Action[] = [];
-      const action = this.getMouseMoveResizeAction(event);
+      const action = this.getMouseMoveResizeAction(event, false);
       if (action) {
         result.push(action);
       }
@@ -77,7 +77,7 @@ export class SiriusDragAndDropMouseListener extends MoveMouseListener {
     let result: Action[];
     if (this.isResizing()) {
       result = [];
-      const action = this.getMouseUpResizeAction();
+      const action = this.getMouseMoveResizeAction(event, true);
       if (action) {
         result.push(action);
       }
@@ -212,7 +212,7 @@ export class SiriusDragAndDropMouseListener extends MoveMouseListener {
    * Computes the potential new position and new size of the element being resized.
    * It is only "potential" because the ResizeAction can prevent the resize.
    */
-  protected getMouseMoveResizeAction(event: MouseEvent): ResizeAction | undefined {
+  protected getMouseMoveResizeAction(event: MouseEvent, finished: boolean): ResizeAction | undefined {
     if (!this.startResizePosition) return undefined;
     const viewport = findParentByFeature(this.intialTarget, isViewport);
     const zoom = viewport ? viewport.zoom : 1;
@@ -222,24 +222,9 @@ export class SiriusDragAndDropMouseListener extends MoveMouseListener {
     };
     const resizeElement = this.computeElementResize(delta);
     if (resizeElement) {
-      return new ResizeAction(resizeElement, false);
+      return new ResizeAction(resizeElement, finished);
     }
     return undefined;
-  }
-
-  /**
-   * When the mouse up comes, the size and the position of the element being resize have already
-   * been calculated by the last ResizeAction during the mouseMove, and thus, it only returns a
-   * new ResizeAction with the size and position of the element being resize and mark the ResizeAction as finished.
-   */
-  protected getMouseUpResizeAction(): ResizeAction | undefined {
-    if (!this.startResizePosition) return undefined;
-    const resizeElement = {
-      newSize: this.intialTarget.size,
-      newPosition: this.intialTarget.position,
-      elementId: this.intialTarget.id,
-    };
-    return new ResizeAction(resizeElement, true);
   }
 
   private computeElementResize(delta: Point): ElementResize {


### PR DESCRIPTION
When moving twice the side of a node without moving the cursor between
the two resizes, the second resize kept the initial size of the node.
Now, at mouseUp event,  we recompute the ResizeAction properly.

Signed-off-by: Laurent Fasani <laurent.fasani@obeo.fr>

### Type of this PR 

- [X ] Bug fix
- [ ] New feature or improvement
- [ ] Documentation
- [ ] Cleanup
- [ ] Test
- [ ] Build/Releng

### Issue(s)

...

### What does this PR do?

...

### Screenshot/screencast of this PR

...
 

### Potential side effects

...

### How to test this PR?

- [ ] Frontend Unit tests
- [ ] Backend Unit tests
- [ ] Cypress : please specify
- [ ] Manual Test : please specify

### Checklist

- [ ] I have read CONTRIBUTING carefully.
- [ ] I have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [ ] All my commits are signed-off (`-s`) with my mail address of my Eclipse Account.
- [ ] I have covered my changes by unit tests or integration tests or manual tests.
- [ ] All tests pass.
- [ ] I have updated the documentation accordingly
- [ ] New React components are availables in storybook
