### PR TITLE
[1075] Use the proper icon feature for OperationAction

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -54,6 +54,7 @@
 - https://github.com/eclipse-sirius/sirius-components/issues/1051[#1051] [layout] Fix an issue resizing nodes when a child node was created even if it was not necessary
 - https://github.com/eclipse-sirius/sirius-components/issues/1073[#1073] [core] Add missing ErrorCallback on the canBeDisposed subscriber of the EditingContextEventProcessor
 - [diagram] Fix an issue preventing the resizing of a node if the cursor had not moved after a previous resizing
+- https://github.com/eclipse-sirius/sirius-components/issues/1075[#1075] [compatibility] Use the proper icon feature for OperationAction
 
 === Improvements
 

--- a/backend/sirius-components-emf/src/main/java/org/eclipse/sirius/components/emf/compatibility/diagrams/ToolImageProvider.java
+++ b/backend/sirius-components-emf/src/main/java/org/eclipse/sirius/components/emf/compatibility/diagrams/ToolImageProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 Obeo.
+ * Copyright (c) 2019, 2022 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -44,6 +44,8 @@ public class ToolImageProvider implements Supplier<String> {
 
     private static final String ICON_PATH = "iconPath"; //$NON-NLS-1$
 
+    private static final String ICON = "icon"; //$NON-NLS-1$
+
     private static final Pattern SEPARATOR = Pattern.compile("(::?|\\.)"); //$NON-NLS-1$
 
     private final IObjectService objectService;
@@ -70,6 +72,9 @@ public class ToolImageProvider implements Supplier<String> {
     private Optional<String> getImagePathFromIconPath() {
         var optionalIconPathEAttribute = Optional.ofNullable(this.abstractToolDescription.eClass().getEStructuralFeature(ICON_PATH));
 
+        if (optionalIconPathEAttribute.isEmpty()) {
+            optionalIconPathEAttribute = Optional.ofNullable(this.abstractToolDescription.eClass().getEStructuralFeature(ICON));
+        }
         // @formatter:off
         return optionalIconPathEAttribute.map(this.abstractToolDescription::eGet)
                 .filter(String.class::isInstance)

--- a/backend/sirius-components-emf/src/test/java/org/eclipse/sirius/components/emf/compatibility/diagrams/ToolImageProviderTests.java
+++ b/backend/sirius-components-emf/src/test/java/org/eclipse/sirius/components/emf/compatibility/diagrams/ToolImageProviderTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 Obeo.
+ * Copyright (c) 2019, 2022 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -16,6 +16,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.eclipse.emf.ecore.EPackage;
 import org.eclipse.sirius.components.core.api.IObjectService;
+import org.eclipse.sirius.viewpoint.description.tool.OperationAction;
 import org.eclipse.sirius.viewpoint.description.tool.ToolDescription;
 import org.eclipse.sirius.viewpoint.description.tool.ToolFactory;
 import org.junit.jupiter.api.Test;
@@ -37,6 +38,19 @@ public class ToolImageProviderTests {
         IObjectService objectService = new IObjectService.NoOp();
         EPackage.Registry ePackageRegistry = EPackage.Registry.INSTANCE;
         ToolImageProvider toolImageProvider = new ToolImageProvider(objectService, ePackageRegistry, toolDescription);
+
+        String convertedIconPath = toolImageProvider.get();
+        assertThat(convertedIconPath.equals(ICON_PATH.substring(ICON_PATH.indexOf('/', 1)))).isTrue();
+    }
+
+    @Test
+    public void testIconNormalization() {
+        OperationAction operationAction = ToolFactory.eINSTANCE.createOperationAction();
+        operationAction.setIcon(ICON_PATH);
+
+        IObjectService objectService = new IObjectService.NoOp();
+        EPackage.Registry ePackageRegistry = EPackage.Registry.INSTANCE;
+        ToolImageProvider toolImageProvider = new ToolImageProvider(objectService, ePackageRegistry, operationAction);
 
         String convertedIconPath = toolImageProvider.get();
         assertThat(convertedIconPath.equals(ICON_PATH.substring(ICON_PATH.indexOf('/', 1)))).isTrue();


### PR DESCRIPTION
### Type of this PR 

- [ ] Bug fix
- [x] New feature or improvement
- [ ] Documentation
- [ ] Cleanup
- [ ] Test
- [ ] Build/Releng

### Issue(s)

Bug: https://github.com/eclipse-sirius/sirius-components/issues/1075

### What does this PR do?

Unlike many others concept in the odesign, OperationAction handles
custom icon through the icon property instead of the iconPath property.
Update ToolImageProvider to also handles icon property in addtion to
iconPath property.

### How to test this PR?

- [ ] Frontend Unit tests
- [x] Backend Unit tests
- [ ] Cypress : please specify
- [ ] Manual Test : please specify
