### PR TITLE
[1097] Update the label edit initial area to avoid the scroll bar 

### DIFF
--- a/frontend/src/diagram/sprotty/EditLabelUIWithInitialContent.ts
+++ b/frontend/src/diagram/sprotty/EditLabelUIWithInitialContent.ts
@@ -34,7 +34,8 @@ export class EditLabelUIWithInitialContent extends EditLabelUI {
     let width = 100;
     let height = 20;
     // used to avoid the scrollbar
-    const extraSize: number = 10;
+    const extraWidth: number = 50;
+    const extraHeight: number = 10;
 
     if (this.label) {
       const nbLines: number = this.label.text.split('\n').length;
@@ -43,8 +44,8 @@ export class EditLabelUIWithInitialContent extends EditLabelUI {
       // make the edit area centered on the label
       x = bounds.x + (bounds.width * (1 - 1 / zoom)) / 2;
       y = bounds.y;
-      height = height * nbLines + extraSize;
-      width = bounds.width / zoom + extraSize;
+      height = height * nbLines + extraHeight;
+      width = bounds.width / zoom + extraWidth;
     }
 
     containerElement.style.left = `${x}px`;


### PR DESCRIPTION
### Type of this PR 

- [X] Bug fix
- [ ] New feature or improvement
- [ ] Documentation
- [ ] Cleanup
- [ ] Test
- [ ] Build/Releng

### Issue(s)

When the zoom is too low, a scroll bar appears in the label edit area in diagram 

### What does this PR do?
It enlarge initial label edit area in diagram to avoid the scroll bar

It works with small and large zoom

### How to test this PR?

- [ ] Frontend Unit tests
- [ ] Backend Unit tests
- [ ] Cypress : please specify
- [X] Manual Test :  
Diagram Edition - Direct edit 

