### PR TITLE
[1096] Add direct edit tool to edges

### DIFF
--- a/backend/sirius-components-compatibility/src/main/java/org/eclipse/sirius/components/compatibility/services/diagrams/CompatibilityToolSectionsProvider.java
+++ b/backend/sirius-components-compatibility/src/main/java/org/eclipse/sirius/components/compatibility/services/diagrams/CompatibilityToolSectionsProvider.java
@@ -36,8 +36,8 @@ import org.eclipse.sirius.components.diagrams.description.DiagramDescription;
 import org.eclipse.sirius.components.diagrams.description.EdgeDescription;
 import org.eclipse.sirius.components.diagrams.description.NodeDescription;
 import org.eclipse.sirius.components.diagrams.description.SynchronizationPolicy;
-import org.eclipse.sirius.components.diagrams.tools.SingleClickOnDiagramElementTool;
 import org.eclipse.sirius.components.diagrams.tools.ITool;
+import org.eclipse.sirius.components.diagrams.tools.SingleClickOnDiagramElementTool;
 import org.eclipse.sirius.components.diagrams.tools.ToolSection;
 import org.eclipse.sirius.components.interpreter.AQLInterpreter;
 import org.eclipse.sirius.components.interpreter.Result;
@@ -273,7 +273,8 @@ public class CompatibilityToolSectionsProvider implements IToolSectionsProvider 
 
         Function<VariableManager, IStatus> fakeHandler = variableManager -> new Success();
 
-        if (diagramElementDescription instanceof NodeDescription) {
+        // Graphical Delete Tool for unsynchronized mapping only (the handler is never called)
+        if (diagramElementDescription instanceof NodeDescription || diagramElementDescription instanceof EdgeDescription) {
             // Edit Tool (the handler is never called)
             SingleClickOnDiagramElementTool editTool = SingleClickOnDiagramElementTool.newSingleClickOnDiagramElementTool("edit") //$NON-NLS-1$
                     .label("Edit") //$NON-NLS-1$
@@ -288,10 +289,7 @@ public class CompatibilityToolSectionsProvider implements IToolSectionsProvider 
                     .tools(List.of(editTool))
                     .build();
             extraToolSections.add(editToolSection);
-        }
 
-        // Graphical Delete Tool for unsynchronized mapping only (the handler is never called)
-        if (diagramElementDescription instanceof NodeDescription || diagramElementDescription instanceof EdgeDescription) {
             if (unsynchronizedMapping) {
                 SingleClickOnDiagramElementTool graphicalDeleteTool = SingleClickOnDiagramElementTool.newSingleClickOnDiagramElementTool("graphical-delete") //$NON-NLS-1$
                         .label("Delete from diagram") //$NON-NLS-1$

--- a/backend/sirius-components-emf/src/main/java/org/eclipse/sirius/components/emf/view/diagram/ViewToolSectionsProvider.java
+++ b/backend/sirius-components-emf/src/main/java/org/eclipse/sirius/components/emf/view/diagram/ViewToolSectionsProvider.java
@@ -27,9 +27,9 @@ import org.eclipse.sirius.components.diagrams.description.DiagramDescription;
 import org.eclipse.sirius.components.diagrams.description.EdgeDescription;
 import org.eclipse.sirius.components.diagrams.description.NodeDescription;
 import org.eclipse.sirius.components.diagrams.description.SynchronizationPolicy;
-import org.eclipse.sirius.components.diagrams.tools.SingleClickOnTwoDiagramElementsTool;
-import org.eclipse.sirius.components.diagrams.tools.SingleClickOnDiagramElementTool;
 import org.eclipse.sirius.components.diagrams.tools.ITool;
+import org.eclipse.sirius.components.diagrams.tools.SingleClickOnDiagramElementTool;
+import org.eclipse.sirius.components.diagrams.tools.SingleClickOnTwoDiagramElementsTool;
 import org.eclipse.sirius.components.diagrams.tools.ToolSection;
 import org.eclipse.sirius.components.representations.IStatus;
 import org.eclipse.sirius.components.representations.Success;
@@ -104,8 +104,8 @@ public class ViewToolSectionsProvider implements IToolSectionsProvider {
 
     private boolean isValidTool(ITool tool, NodeDescription nodeDescription) {
         boolean isValidTool = tool instanceof SingleClickOnDiagramElementTool && ((SingleClickOnDiagramElementTool) tool).getTargetDescriptions().contains(nodeDescription);
-        isValidTool = isValidTool
-                || tool instanceof SingleClickOnTwoDiagramElementsTool && ((SingleClickOnTwoDiagramElementsTool) tool).getCandidates().stream().anyMatch(edgeCandidate -> edgeCandidate.getSources().contains(nodeDescription));
+        isValidTool = isValidTool || tool instanceof SingleClickOnTwoDiagramElementsTool
+                && ((SingleClickOnTwoDiagramElementsTool) tool).getCandidates().stream().anyMatch(edgeCandidate -> edgeCandidate.getSources().contains(nodeDescription));
         return isValidTool;
     }
 
@@ -126,7 +126,8 @@ public class ViewToolSectionsProvider implements IToolSectionsProvider {
 
         Function<VariableManager, IStatus> fakeHandler = variableManager -> new Success();
 
-        if (diagramElementDescription instanceof NodeDescription) {
+        // Graphical Delete Tool for unsynchronized mapping only (the handler is never called)
+        if (diagramElementDescription instanceof NodeDescription || diagramElementDescription instanceof EdgeDescription) {
             // Edit Tool (the handler is never called)
             SingleClickOnDiagramElementTool editTool = SingleClickOnDiagramElementTool.newSingleClickOnDiagramElementTool("edit") //$NON-NLS-1$
                     .label("Edit") //$NON-NLS-1$
@@ -141,10 +142,6 @@ public class ViewToolSectionsProvider implements IToolSectionsProvider {
                     .tools(List.of(editTool))
                     .build();
             extraToolSections.add(editToolSection);
-        }
-
-        // Graphical Delete Tool for unsynchronized mapping only (the handler is never called)
-        if (diagramElementDescription instanceof NodeDescription || diagramElementDescription instanceof EdgeDescription) {
             if (unsynchronizedMapping) {
                 SingleClickOnDiagramElementTool graphicalDeleteTool = SingleClickOnDiagramElementTool.newSingleClickOnDiagramElementTool("graphical-delete") //$NON-NLS-1$
                         .label("Delete from diagram") //$NON-NLS-1$


### PR DESCRIPTION
### Type of this PR 

- [x] Bug fix
- [ ] New feature or improvement
- [ ] Documentation
- [ ] Cleanup
- [ ] Test
- [ ] Build/Releng

### Issue(s)

Fixes: https://github.com/eclipse-sirius/sirius-components/issues/1096

### What does this PR do?

This PR adds the direct edit tool the representations edges.

### Screenshot/screencast of this PR

Before :
![image](https://user-images.githubusercontent.com/61457677/158197946-2e24f16c-4949-495c-bfef-38c0b3f535f9.png)


After : 
![image](https://user-images.githubusercontent.com/61457677/158197880-f8a5c2a9-c9d9-4cb5-b599-45128378bc6c.png)

 
### Potential side effects

The provider actually fixing this bug is the CompatibilityToolSectionsProvider. The same bug was present on the VewToolSectionsProvider so I fixed it as well, but I am not sure how to test this one. When is it supposed to be called?

### How to test this PR?

- [ ] Frontend Unit tests
- [ ] Backend Unit tests
- [ ] Cypress : please specify
- [x] Manual Test : try to open the direct edit tool from a topography representation

### Checklist

- [x] I have read CONTRIBUTING carefully.
- [x] I have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All my commits are signed-off (`-s`) with my mail address of my Eclipse Account.
- [ ] I have covered my changes by unit tests or integration tests or manual tests.
- [x] All tests pass.
- [ ] I have updated the documentation accordingly
- [ ] New React components are availables in storybook
