### PR TITLE
[1104] Fix image base path during svg export

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -56,6 +56,7 @@
 - https://github.com/eclipse-sirius/sirius-components/issues/1073[#1073] [core] Add missing ErrorCallback on the canBeDisposed subscriber of the EditingContextEventProcessor
 - [diagram] Fix an issue preventing the resizing of a node if the cursor had not moved after a previous resizing
 - https://github.com/eclipse-sirius/sirius-components/issues/1075[#1075] [compatibility] Use the proper icon feature for OperationAction
+- https://github.com/eclipse-sirius/sirius-components/issues/1104[#1104] [diagram] Fix the image base path during the SVG export
 
 === Improvements
 

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -15,7 +15,7 @@
 
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components</artifactId>
-	<version>2022.01.18</version>
+	<version>2022.01.19</version>
 
 	<name>sirius-components</name>
 	<description>Sirius Components</description>

--- a/backend/sirius-components-annotations-spring/pom.xml
+++ b/backend/sirius-components-annotations-spring/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-annotations-spring</artifactId>
-	<version>2022.01.18</version>
+	<version>2022.01.19</version>
 	<name>sirius-components-annotations-spring</name>
 	<description>Sirius Components Annotations Spring</description>
 

--- a/backend/sirius-components-annotations/pom.xml
+++ b/backend/sirius-components-annotations/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-annotations</artifactId>
-	<version>2022.01.18</version>
+	<version>2022.01.19</version>
 	<name>sirius-components-annotations</name>
 	<description>Sirius Components Annotations</description>
 

--- a/backend/sirius-components-collaborative-diagrams/pom.xml
+++ b/backend/sirius-components-collaborative-diagrams/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-collaborative-diagrams</artifactId>
-	<version>2022.01.18</version>
+	<version>2022.01.19</version>
 	<name>sirius-components-collaborative-diagrams</name>
 	<description>Sirius Components Collaborative Diagrams</description>
 
@@ -50,34 +50,34 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-layout</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-tests</artifactId>
-    		<version>2022.01.18</version>
+    		<version>2022.01.19</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-spring-tests</artifactId>
-    		<version>2022.01.18</version>
+    		<version>2022.01.19</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-tests</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/backend/sirius-components-collaborative-forms/pom.xml
+++ b/backend/sirius-components-collaborative-forms/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-collaborative-forms</artifactId>
-	<version>2022.01.18</version>
+	<version>2022.01.19</version>
 	<name>sirius-components-collaborative-forms</name>
 	<description>Sirius Components Collaborative Forms</description>
 
@@ -50,23 +50,23 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-forms</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-tests</artifactId>
-    		<version>2022.01.18</version>
+    		<version>2022.01.19</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-spring-tests</artifactId>
-    		<version>2022.01.18</version>
+    		<version>2022.01.19</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>

--- a/backend/sirius-components-collaborative-selection/pom.xml
+++ b/backend/sirius-components-collaborative-selection/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-collaborative-selection</artifactId>
-	<version>2022.01.18</version>
+	<version>2022.01.19</version>
 	<name>sirius-components-collaborative-selection</name>
 	<description>Sirius Components Collaborative Selection</description>
 
@@ -43,7 +43,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-selection</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>
@@ -56,18 +56,18 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/backend/sirius-components-collaborative-trees/pom.xml
+++ b/backend/sirius-components-collaborative-trees/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-collaborative-trees</artifactId>
-	<version>2022.01.18</version>
+	<version>2022.01.19</version>
 	<name>sirius-components-collaborative-trees</name>
 	<description>Sirius Components Collaborative Trees</description>
 
@@ -42,12 +42,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-trees</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>
@@ -64,13 +64,13 @@
 		<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-tests</artifactId>
-    		<version>2022.01.18</version>
+    		<version>2022.01.19</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-spring-tests</artifactId>
-    		<version>2022.01.18</version>
+    		<version>2022.01.19</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>

--- a/backend/sirius-components-collaborative-validation/pom.xml
+++ b/backend/sirius-components-collaborative-validation/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-collaborative-validation</artifactId>
-	<version>2022.01.18</version>
+	<version>2022.01.19</version>
 	<name>sirius-components-collaborative-validation</name>
 	<description>Sirius Components Collaborative Validation</description>
 	
@@ -46,12 +46,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-validation</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -61,13 +61,13 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 			<scope>test</scope>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-spring-tests</artifactId>
-    		<version>2022.01.18</version>
+    		<version>2022.01.19</version>
     		<scope>test</scope>
     	</dependency>
 	</dependencies>

--- a/backend/sirius-components-collaborative/pom.xml
+++ b/backend/sirius-components-collaborative/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-collaborative</artifactId>
-	<version>2022.01.18</version>
+	<version>2022.01.19</version>
 	<name>sirius-components-collaborative</name>
 	<description>Sirius Components Collaborative</description>
 
@@ -66,12 +66,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-core</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -80,13 +80,13 @@
 		<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-tests</artifactId>
-    		<version>2022.01.18</version>
+    		<version>2022.01.19</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-spring-tests</artifactId>
-    		<version>2022.01.18</version>
+    		<version>2022.01.19</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>

--- a/backend/sirius-components-compatibility/pom.xml
+++ b/backend/sirius-components-compatibility/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-compatibility</artifactId>
-	<version>2022.01.18</version>
+	<version>2022.01.19</version>
 	<name>sirius-components-compatibility</name>
 	<description>Sirius Components Compatibility</description>
 
@@ -63,7 +63,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -73,43 +73,43 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-core</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-diagrams</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-forms</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-forms</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-selection</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-trees</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-interpreter</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.emf</groupId>

--- a/backend/sirius-components-core/pom.xml
+++ b/backend/sirius-components-core/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-core</artifactId>
-	<version>2022.01.18</version>
+	<version>2022.01.19</version>
 	<name>sirius-components-core</name>
 	<description>Sirius Components Core</description>
 
@@ -51,17 +51,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend/sirius-components-diagrams-layout-api/pom.xml
+++ b/backend/sirius-components-diagrams-layout-api/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-diagrams-layout-api</artifactId>
-	<version>2022.01.18</version>
+	<version>2022.01.19</version>
 	<name>sirius-components-diagrams-layout-api</name>
 	<description>Sirius Components Diagrams Layout API</description>
 
@@ -42,12 +42,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-core</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 	</dependencies>
 

--- a/backend/sirius-components-diagrams-layout/pom.xml
+++ b/backend/sirius-components-diagrams-layout/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-diagrams-layout</artifactId>
-	<version>2022.01.18</version>
+	<version>2022.01.19</version>
 	<name>sirius-components-diagrams-layout</name>
 	<description>Sirius Components Diagrams layout</description>
 
@@ -65,17 +65,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-core</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-layout-api</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.elk</groupId>
@@ -112,7 +112,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -127,12 +127,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-tests</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/backend/sirius-components-diagrams-tests/pom.xml
+++ b/backend/sirius-components-diagrams-tests/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-diagrams-tests</artifactId>
-	<version>2022.01.18</version>
+	<version>2022.01.19</version>
 	<name>sirius-components-diagrams-tests</name>
 	<description>Sirius Components Diagrams Tests</description>
 
@@ -46,12 +46,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-core</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.assertj</groupId>

--- a/backend/sirius-components-diagrams/pom.xml
+++ b/backend/sirius-components-diagrams/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-diagrams</artifactId>
-	<version>2022.01.18</version>
+	<version>2022.01.19</version>
 	<name>sirius-components-diagrams</name>
 	<description>Sirius Components Diagrams</description>
 
@@ -42,7 +42,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -52,7 +52,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend/sirius-components-domain-design/pom.xml
+++ b/backend/sirius-components-domain-design/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-domain-design</artifactId>
-	<version>2022.01.18</version>
+	<version>2022.01.19</version>
 	<name>sirius-components-domain-design</name>
 	<description>Sirius Components Domain Definition DSL - Graphical Modeler Definition</description>
 
@@ -64,7 +64,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-domain</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 	</dependencies>
 	

--- a/backend/sirius-components-domain-edit/pom.xml
+++ b/backend/sirius-components-domain-edit/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-domain-edit</artifactId>
-	<version>2022.01.18</version>
+	<version>2022.01.19</version>
 	<name>sirius-components-domain-edit</name>
 	<description>Sirius Components Domain Definition DSL - Edit Support</description>
 
@@ -64,7 +64,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-domain</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 	</dependencies>
 	

--- a/backend/sirius-components-domain/pom.xml
+++ b/backend/sirius-components-domain/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-domain</artifactId>
-	<version>2022.01.18</version>
+	<version>2022.01.19</version>
 	<name>sirius-components-domain</name>
 	<description>Sirius Components Domain Definition DSL</description>
 

--- a/backend/sirius-components-emf/pom.xml
+++ b/backend/sirius-components-emf/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-emf</artifactId>
-	<version>2022.01.18</version>
+	<version>2022.01.19</version>
 	<name>sirius-components-emf</name>
 	<description>Sirius Components EMF</description>
 
@@ -62,52 +62,52 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql-api</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-diagrams</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-forms</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-trees</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-validation</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-compatibility</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-interpreter</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-domain</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.emf</groupId>
@@ -156,19 +156,19 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-tests</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend/sirius-components-forms-tests/pom.xml
+++ b/backend/sirius-components-forms-tests/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-forms-tests</artifactId>
-	<version>2022.01.18</version>
+	<version>2022.01.19</version>
 	<name>sirius-components-forms-tests</name>
 	<description>Sirius Components Forms Tests</description>
 
@@ -42,7 +42,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-forms</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.assertj</groupId>

--- a/backend/sirius-components-forms/pom.xml
+++ b/backend/sirius-components-forms/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-forms</artifactId>
-	<version>2022.01.18</version>
+	<version>2022.01.19</version>
 	<name>sirius-components-forms</name>
 	<description>Sirius Components Forms</description>
 
@@ -46,12 +46,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -61,7 +61,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/backend/sirius-components-graphiql/pom.xml
+++ b/backend/sirius-components-graphiql/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-graphiql</artifactId>
-	<version>2022.01.18</version>
+	<version>2022.01.19</version>
 	<name>sirius-components-graphiql</name>
 	<description>Sirius Components Graphiql support. This project contribute a GraphQL query tool on the /graphiql/index.html URI.</description>
 

--- a/backend/sirius-components-graphql-api/pom.xml
+++ b/backend/sirius-components-graphql-api/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-graphql-api</artifactId>
-	<version>2022.01.18</version>
+	<version>2022.01.19</version>
 	<name>sirius-components-graphql-api</name>
 	<description>Sirius Components GraphQL API</description>
 
@@ -48,7 +48,7 @@
     	<dependency>
         	<groupId>org.eclipse.sirius</groupId>
         	<artifactId>sirius-components-annotations-spring</artifactId>
-        	<version>2022.01.18</version>
+        	<version>2022.01.19</version>
     	</dependency>
 	</dependencies>
 

--- a/backend/sirius-components-graphql-utils/pom.xml
+++ b/backend/sirius-components-graphql-utils/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-graphql-utils</artifactId>
-	<version>2022.01.18</version>
+	<version>2022.01.19</version>
 	<name>sirius-components-graphql-utils</name>
 	<description>Sirius Components GraphQL Utils</description>
 
@@ -43,7 +43,7 @@
 		<dependency>
         	<groupId>org.eclipse.sirius</groupId>
         	<artifactId>sirius-components-annotations</artifactId>
-        	<version>2022.01.18</version>
+        	<version>2022.01.19</version>
     	</dependency>
 		<dependency>
         	<groupId>com.graphql-java</groupId>
@@ -53,7 +53,7 @@
     	<dependency>
    			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 			<scope>test</scope>
     	</dependency>
     	<dependency>

--- a/backend/sirius-components-graphql-voyager/pom.xml
+++ b/backend/sirius-components-graphql-voyager/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-graphql-voyager</artifactId>
-	<version>2022.01.18</version>
+	<version>2022.01.19</version>
 	<name>sirius-components-graphql-voyager</name>
 	<description>Sirius Components Graph Voyager. This project contribute a GraphQL API UX thanks to the https://github.com/APIs-guru/graphql-voyager project.</description>
 

--- a/backend/sirius-components-graphql/pom.xml
+++ b/backend/sirius-components-graphql/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-graphql</artifactId>
-	<version>2022.01.18</version>
+	<version>2022.01.19</version>
 	<name>sirius-components-graphql</name>
 	<description>Sirius Components GraphQL</description>
 
@@ -64,28 +64,28 @@
     	<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-annotations</artifactId>
-    		<version>2022.01.18</version>
+    		<version>2022.01.19</version>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-graphql-utils</artifactId>
-    		<version>2022.01.18</version>
+    		<version>2022.01.19</version>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-graphql-api</artifactId>
-    		<version>2022.01.18</version>
+    		<version>2022.01.19</version>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-tests</artifactId>
-    		<version>2022.01.18</version>
+    		<version>2022.01.19</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-spring-tests</artifactId>
-    		<version>2022.01.18</version>
+    		<version>2022.01.19</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>

--- a/backend/sirius-components-interpreter/pom.xml
+++ b/backend/sirius-components-interpreter/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-interpreter</artifactId>
-	<version>2022.01.18</version>
+	<version>2022.01.19</version>
 	<name>sirius-components-interpreter</name>
 	<description>Sirius Components Intepreter</description>
 

--- a/backend/sirius-components-representations/pom.xml
+++ b/backend/sirius-components-representations/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-representations</artifactId>
-	<version>2022.01.18</version>
+	<version>2022.01.19</version>
 	<name>sirius-components-representations</name>
 	<description>Sirius Components Representations</description>
 
@@ -46,7 +46,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 	</dependencies>
 

--- a/backend/sirius-components-selection/pom.xml
+++ b/backend/sirius-components-selection/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-selection</artifactId>
-	<version>2022.01.18</version>
+	<version>2022.01.19</version>
 	<name>sirius-components-selection</name>
 	<description>Sirius Components Selection</description>
 
@@ -42,17 +42,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend/sirius-components-spring-tests/pom.xml
+++ b/backend/sirius-components-spring-tests/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-spring-tests</artifactId>
-	<version>2022.01.18</version>
+	<version>2022.01.19</version>
 	<name>sirius-components-spring-tests</name>
 	<description>Sirius Components Spring Tests</description>
 
@@ -46,7 +46,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>

--- a/backend/sirius-components-starter/pom.xml
+++ b/backend/sirius-components-starter/pom.xml
@@ -15,7 +15,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-starter</artifactId>
-	<version>2022.01.18</version>
+	<version>2022.01.19</version>
 	<name>sirius-components-starter</name>
 	<description>Sirius Components Starter</description>
 
@@ -55,52 +55,52 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-layout</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-diagrams</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-forms</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-selection</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-trees</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-validation</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-emf</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-compatibility</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 	</dependencies>
 

--- a/backend/sirius-components-test-coverage/pom.xml
+++ b/backend/sirius-components-test-coverage/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-test-coverage</artifactId>
-	<version>2022.01.18</version>
+	<version>2022.01.19</version>
 	<name>sirius-components-test-coverage-aggregation</name>
 	<description>Sirius Web Test Coverage Aggregation</description>
 
@@ -42,142 +42,142 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations-spring</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-compatibility</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-core</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-layout</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-layout-api</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-domain</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-domain-design</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-domain-edit</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-emf</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-forms</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql-utils</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-interpreter</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-selection</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-diagrams</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-forms</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-selection</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-trees</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-validation</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql-api</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-trees</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-validation</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-edit</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 	</dependencies>
 

--- a/backend/sirius-components-tests/pom.xml
+++ b/backend/sirius-components-tests/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-tests</artifactId>
-	<version>2022.01.18</version>
+	<version>2022.01.19</version>
 	<name>sirius-components-tests</name>
 	<description>Sirius Components Tests</description>
 
@@ -51,7 +51,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 	</dependencies>
 

--- a/backend/sirius-components-trees/pom.xml
+++ b/backend/sirius-components-trees/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-trees</artifactId>
-	<version>2022.01.18</version>
+	<version>2022.01.19</version>
 	<name>sirius-components-trees</name>
 	<description>Sirius Components Trees</description>
 
@@ -42,17 +42,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/backend/sirius-components-validation/pom.xml
+++ b/backend/sirius-components-validation/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-validation</artifactId>
-	<version>2022.01.18</version>
+	<version>2022.01.19</version>
 	<name>sirius-components-validation</name>
 	<description>Sirius Components Validation</description>
 	
@@ -47,12 +47,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend/sirius-components-view-edit/pom.xml
+++ b/backend/sirius-components-view-edit/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-view-edit</artifactId>
-	<version>2022.01.18</version>
+	<version>2022.01.19</version>
 	<name>sirius-components-view-edit</name>
 	<description>Sirius Components View Definition DSL - Edit Support</description>
 
@@ -64,7 +64,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view</artifactId>
-			<version>2022.01.18</version>
+			<version>2022.01.19</version>
 		</dependency>
 	</dependencies>
 	

--- a/backend/sirius-components-view/pom.xml
+++ b/backend/sirius-components-view/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-view</artifactId>
-	<version>2022.01.18</version>
+	<version>2022.01.19</version>
 	<name>sirius-components-view</name>
 	<description>Sirius Components View Definition DSL</description>
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@eclipse-sirius/sirius-components",
-  "version": "2022.1.18",
+  "version": "2022.1.19",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@eclipse-sirius/sirius-components",
-      "version": "2022.1.18",
+      "version": "2022.1.19",
       "license": "EPL-2.0",
       "dependencies": {
         "uuid": "8.3.2"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-sirius/sirius-components",
-  "version": "2022.1.18",
+  "version": "2022.1.19",
   "author": "Eclipse Sirius",
   "license": "EPL-2.0",
   "description": "Reusable components used to build the Sirius Web frontend",


### PR DESCRIPTION
### Type of this PR 

- [x] Bug fix
- [ ] New feature or improvement
- [ ] Documentation
- [ ] Cleanup
- [ ] Test
- [ ] Build/Releng

### Issue(s)

Fix: https://github.com/eclipse-sirius/sirius-components/issues/1104

### What does this PR do?

It removes the port from the URI used to access the images during the SVG export.
