### PR TITLE
[1067] Hide hamburger menu on tree items with no operations

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -74,6 +74,7 @@
 - https://github.com/eclipse-sirius/sirius-components/issues/783[#783] [diagram] Nodes which use images can now also have a border with all the relevant properties: color, size, radius, and line style. This applies to modelers using the compatibility layer and the web-based diagram definitions
 - https://github.com/eclipse-sirius/sirius-components/issues/1033[#1033] [view] It is now possible to configure all properties of node's border in web-based diagrams, including the border line style
 - https://github.com/eclipse-sirius/sirius-components/issues/837[#837] [layout] Improve the position of the dropped elements
+- https://github.com/eclipse-sirius/sirius-components/issues/1067[#1067] [workbench] Hide hamburger menu on tree items with no operations
 
 === New features
 

--- a/frontend/src/tree/TreeItem.tsx
+++ b/frontend/src/tree/TreeItem.tsx
@@ -18,11 +18,11 @@ import { Text } from 'core/text/Text';
 import { Textfield } from 'core/textfield/Textfield';
 import gql from 'graphql-tag';
 import { ArrowCollapsed, ArrowExpanded, More, NoIcon } from 'icons';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useContext, useEffect, useRef, useState } from 'react';
 import { v4 as uuid } from 'uuid';
 import styles from './TreeItem.module.css';
 import { TreeItemProps } from './TreeItem.types';
-import { TreeItemContextMenu } from './TreeItemContextMenu';
+import { TreeItemContextMenu, TreeItemContextMenuContext } from './TreeItemContextMenu';
 
 const renameTreeItemMutation = gql`
   mutation renameTreeItem($input: RenameTreeItemInput!) {
@@ -78,6 +78,10 @@ export const TreeItem = ({
   setSelection,
   readOnly,
 }: TreeItemProps) => {
+  const treeItemMenuContributionComponents = useContext(TreeItemContextMenuContext)
+    .filter((contribution) => contribution.props.canHandle(item))
+    .map((contribution) => contribution.props.component);
+
   const initialState = {
     showContextMenu: false,
     menuAnchor: null,
@@ -168,6 +172,7 @@ export const TreeItem = ({
         treeId={treeId}
         item={item}
         readOnly={readOnly}
+        treeItemMenuContributionComponents={treeItemMenuContributionComponents}
         depth={depth}
         onExpand={onExpand}
         selection={selection}
@@ -337,6 +342,8 @@ export const TreeItem = ({
     }
   }
 
+  const shouldDisplayMoreButton = item.deletable || item.editable || treeItemMenuContributionComponents.length > 0;
+
   /* ref, tabindex and onFocus are used to set the React component focusabled and to set the focus to the corresponding DOM part */
   return (
     <>
@@ -367,9 +374,11 @@ export const TreeItem = ({
               {image}
               {text}
             </div>
-            <IconButton className={styles.more} onClick={openContextMenu} data-testid={`${item.label}-more`}>
-              <More title="More" />
-            </IconButton>
+            {shouldDisplayMoreButton ? (
+              <IconButton className={styles.more} onClick={openContextMenu} data-testid={`${item.label}-more`}>
+                <More title="More" />
+              </IconButton>
+            ) : null}
           </div>
         </div>
       </div>

--- a/frontend/src/tree/TreeItemContextMenu.tsx
+++ b/frontend/src/tree/TreeItemContextMenu.tsx
@@ -21,7 +21,7 @@ import CloseIcon from '@material-ui/icons/Close';
 import DeleteIcon from '@material-ui/icons/Delete';
 import EditIcon from '@material-ui/icons/Edit';
 import gql from 'graphql-tag';
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { v4 as uuid } from 'uuid';
 import {
   GQLDeleteTreeItemData,
@@ -56,6 +56,7 @@ export const TreeItemContextMenu = ({
   treeId,
   item,
   readOnly,
+  treeItemMenuContributionComponents,
   depth,
   onExpand,
   selection,
@@ -65,7 +66,6 @@ export const TreeItemContextMenu = ({
 }: TreeItemContextMenuProps) => {
   const [state, setState] = useState<TreeItemContextMenuState>({ message: null });
   const closeToast = () => setState({ message: null });
-  const treeItemContextMenuContributions = useContext(TreeItemContextMenuContext);
 
   const expandItem = () => {
     if (!item.expanded && item.hasChildren) {
@@ -120,23 +120,22 @@ export const TreeItemContextMenu = ({
           horizontal: 'right',
         }}
       >
-        {treeItemContextMenuContributions
-          .filter((contribution) => contribution.props.canHandle(item))
-          .map((contribution, index) => {
-            const props: TreeItemContextMenuComponentProps = {
-              editingContextId,
-              item,
-              readOnly,
-              onClose,
-              selection,
-              setSelection,
-              expandItem,
-              key: index.toString(),
-              treeId: treeId,
-            };
-            const element = React.createElement(contribution.props.component, props);
-            return element;
-          })}
+        {treeItemMenuContributionComponents.map((component, index) => {
+          const props: TreeItemContextMenuComponentProps = {
+            editingContextId,
+            item,
+            readOnly,
+            onClose,
+            selection,
+            setSelection,
+            expandItem,
+            key: index.toString(),
+            treeId: treeId,
+          };
+          const element = React.createElement(component, props);
+          return element;
+        })}
+
         {item.editable ? (
           <MenuItem
             key="rename"

--- a/frontend/src/tree/TreeItemContextMenu.types.ts
+++ b/frontend/src/tree/TreeItemContextMenu.types.ts
@@ -12,6 +12,7 @@
  *******************************************************************************/
 import { Selection } from 'workbench/Workbench.types';
 import { TreeItemType } from './TreeItem.types';
+import { TreeItemContextMenuComponentProps } from './TreeItemContextMenuContribution.types';
 
 export interface TreeItemContextMenuProps {
   menuAnchor: Element;
@@ -19,6 +20,7 @@ export interface TreeItemContextMenuProps {
   editingContextId: string;
   treeId: string;
   readOnly: boolean;
+  treeItemMenuContributionComponents: ((props: TreeItemContextMenuComponentProps) => JSX.Element)[];
   depth: number;
   onExpand: (id: string, depth: number) => void;
   selection: Selection;


### PR DESCRIPTION
### Type of this PR 

- [x] New feature or improvement

### Issue(s)

Fix: https://github.com/eclipse-sirius/sirius-components/issues/1067

### What does this PR do?

This PR should hide the hamburger item on menu items who do not have any associated operations. I could not really test it since I do not think that I can reproduce this situation on either OCP or Sirius web.

I am not entirely sure that the condition describing this situation is enough : 
`  const shouldDisplayMoreButton = (item.deletable || item.editable) && treeItemMenuContributionComponents.length > 0;
` 
For example, if an item have different operations but all of them are disabled for some reason, should we still display the hamburger?

### How to test this PR?

- [x] Manual Test : Find a situation where a menu item do not have any operation 

### Checklist

- [x] I have read CONTRIBUTING carefully.
- [x] I have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All my commits are signed-off (`-s`) with my mail address of my Eclipse Account.
- [ ] I have covered my changes by unit tests or integration tests or manual tests.
- [x] All tests pass.
