### PR TITLE
Select representation opened from a tab

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -76,6 +76,7 @@
 - https://github.com/eclipse-sirius/sirius-components/issues/1033[#1033] [view] It is now possible to configure all properties of node's border in web-based diagrams, including the border line style
 - https://github.com/eclipse-sirius/sirius-components/issues/837[#837] [layout] Improve the position of the dropped elements
 - https://github.com/eclipse-sirius/sirius-components/issues/1067[#1067] [workbench] Hide hamburger menu on tree items with no operations
+- https://github.com/eclipse-sirius/sirius-components/issues/1128[#1128] [workbench] Select representation opened from a tab
 
 === New features
 

--- a/frontend/src/workbench/Workbench.tsx
+++ b/frontend/src/workbench/Workbench.tsx
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Obeo.
+ * Copyright (c) 2021, 2022 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -40,7 +40,6 @@ import {
   HideRepresentationEvent,
   HideToastEvent,
   SchemaValue,
-  ShowRepresentationEvent,
   ShowToastEvent,
   UpdateSelectionEvent,
   WorkbenchContext,
@@ -136,8 +135,7 @@ export const Workbench = ({
   };
 
   const onRepresentationClick = (representation: Representation) => {
-    const showRepresentationEvent: ShowRepresentationEvent = { type: 'SHOW_REPRESENTATION', representation };
-    dispatch(showRepresentationEvent);
+    setSelection({ entries: [{ id: representation.id, label: representation.label, kind: representation.kind }] });
   };
 
   const onClose = (representation: Representation) => {

--- a/frontend/src/workbench/WorkbenchMachine.ts
+++ b/frontend/src/workbench/WorkbenchMachine.ts
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Obeo.
+ * Copyright (c) 2021, 2022 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -51,7 +51,6 @@ export interface WorkbenchContext {
   message: string | null;
 }
 
-export type ShowRepresentationEvent = { type: 'SHOW_REPRESENTATION'; representation: Representation };
 export type HideRepresentationEvent = { type: 'HIDE_REPRESENTATION'; representation: Representation };
 export type UpdateSelectionEvent = {
   type: 'UPDATE_SELECTION';
@@ -68,7 +67,6 @@ export type HandleSubscriptionResultEvent = {
 export type HandleCompleteEvent = { type: 'HANDLE_COMPLETE' };
 export type WorkbenchEvent =
   | UpdateSelectionEvent
-  | ShowRepresentationEvent
   | HideRepresentationEvent
   | HandleSubscriptionResultEvent
   | HandleCompleteEvent
@@ -120,10 +118,6 @@ export const workbenchMachine = Machine<WorkbenchContext, WorkbenchStateSchema, 
                 target: 'initial',
                 actions: 'updateSelection',
               },
-              SHOW_REPRESENTATION: {
-                target: 'initial',
-                actions: 'showRepresentation',
-              },
               HIDE_REPRESENTATION: {
                 target: 'initial',
                 actions: 'hideRepresentation',
@@ -162,10 +156,6 @@ export const workbenchMachine = Machine<WorkbenchContext, WorkbenchStateSchema, 
           return { selection, displayedRepresentation, representations: newSelectedRepresentations };
         }
         return { selection };
-      }),
-      showRepresentation: assign((_, event) => {
-        const { representation } = event as ShowRepresentationEvent;
-        return { displayedRepresentation: representation };
       }),
       hideRepresentation: assign((context, event) => {
         const { representation: representationToHide } = event as HideRepresentationEvent;


### PR DESCRIPTION
- [1128] Select the representation opened from a tab
- [1128] Remove dead code in the workbench's state machine

There might be more "aggressive" cleanups/refactoring possible, but given that we approach the release I prefered limiting the impacts.