### PR TITLE
[1118] Upgrade our backend dependencies for Sirius Components 2022.5.0

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -1,6 +1,24 @@
 = Changelog
 
-== v2022.03.0
+== v2022.5.0 (unreleased)
+
+=== Architectural decision records
+
+=== Deprecation warning
+
+=== Breaking changes
+
+=== Dependency update
+
+- https://github.com/eclipse-sirius/sirius-components/issues/1118[#1118] [core] Switch to Spring Boot 2.6.6
+
+=== Bug fixes
+
+=== Improvements
+
+=== New features
+
+== v2022.3.0
 
 === Architectural decision records
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -12,6 +12,7 @@
 
 - https://github.com/eclipse-sirius/sirius-components/issues/1118[#1118] [core] Switch to Spring Boot 2.6.6
 - https://github.com/eclipse-sirius/sirius-components/issues/1118[#1118] [core] Switch to GraphQL Java 18.0
+- https://github.com/eclipse-sirius/sirius-components/issues/1118[#1118] [core] Switch to Sirius Desktop 7.0.0
 
 === Bug fixes
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -11,6 +11,7 @@
 === Dependency update
 
 - https://github.com/eclipse-sirius/sirius-components/issues/1118[#1118] [core] Switch to Spring Boot 2.6.6
+- https://github.com/eclipse-sirius/sirius-components/issues/1118[#1118] [core] Switch to GraphQL Java 18.0
 
 === Bug fixes
 

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -15,7 +15,7 @@
 
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components</artifactId>
-	<version>2022.3.0</version>
+	<version>2022.3.1</version>
 
 	<name>sirius-components</name>
 	<description>Sirius Components</description>

--- a/backend/sirius-components-annotations-spring/pom.xml
+++ b/backend/sirius-components-annotations-spring/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.6.4</version>
+		<version>2.6.6</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>

--- a/backend/sirius-components-annotations-spring/pom.xml
+++ b/backend/sirius-components-annotations-spring/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-annotations-spring</artifactId>
-	<version>2022.3.0</version>
+	<version>2022.3.1</version>
 	<name>sirius-components-annotations-spring</name>
 	<description>Sirius Components Annotations Spring</description>
 

--- a/backend/sirius-components-annotations/pom.xml
+++ b/backend/sirius-components-annotations/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-annotations</artifactId>
-	<version>2022.3.0</version>
+	<version>2022.3.1</version>
 	<name>sirius-components-annotations</name>
 	<description>Sirius Components Annotations</description>
 

--- a/backend/sirius-components-annotations/pom.xml
+++ b/backend/sirius-components-annotations/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.6.4</version>
+		<version>2.6.6</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>

--- a/backend/sirius-components-collaborative-diagrams/pom.xml
+++ b/backend/sirius-components-collaborative-diagrams/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-collaborative-diagrams</artifactId>
-	<version>2022.3.0</version>
+	<version>2022.3.1</version>
 	<name>sirius-components-collaborative-diagrams</name>
 	<description>Sirius Components Collaborative Diagrams</description>
 
@@ -50,34 +50,34 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-layout-api</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-tests</artifactId>
-    		<version>2022.3.0</version>
+    		<version>2022.3.1</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-spring-tests</artifactId>
-    		<version>2022.3.0</version>
+    		<version>2022.3.1</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-tests</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/backend/sirius-components-collaborative-diagrams/pom.xml
+++ b/backend/sirius-components-collaborative-diagrams/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.6.4</version>
+		<version>2.6.6</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>

--- a/backend/sirius-components-collaborative-forms/pom.xml
+++ b/backend/sirius-components-collaborative-forms/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-collaborative-forms</artifactId>
-	<version>2022.3.0</version>
+	<version>2022.3.1</version>
 	<name>sirius-components-collaborative-forms</name>
 	<description>Sirius Components Collaborative Forms</description>
 
@@ -50,23 +50,23 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-forms</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-tests</artifactId>
-    		<version>2022.3.0</version>
+    		<version>2022.3.1</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-spring-tests</artifactId>
-    		<version>2022.3.0</version>
+    		<version>2022.3.1</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>

--- a/backend/sirius-components-collaborative-forms/pom.xml
+++ b/backend/sirius-components-collaborative-forms/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.6.4</version>
+		<version>2.6.6</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>

--- a/backend/sirius-components-collaborative-selection/pom.xml
+++ b/backend/sirius-components-collaborative-selection/pom.xml
@@ -18,7 +18,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.6.4</version>
+		<version>2.6.6</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>

--- a/backend/sirius-components-collaborative-selection/pom.xml
+++ b/backend/sirius-components-collaborative-selection/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-collaborative-selection</artifactId>
-	<version>2022.3.0</version>
+	<version>2022.3.1</version>
 	<name>sirius-components-collaborative-selection</name>
 	<description>Sirius Components Collaborative Selection</description>
 
@@ -43,7 +43,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-selection</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>
@@ -56,18 +56,18 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/backend/sirius-components-collaborative-trees/pom.xml
+++ b/backend/sirius-components-collaborative-trees/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.6.4</version>
+		<version>2.6.6</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>

--- a/backend/sirius-components-collaborative-trees/pom.xml
+++ b/backend/sirius-components-collaborative-trees/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-collaborative-trees</artifactId>
-	<version>2022.3.0</version>
+	<version>2022.3.1</version>
 	<name>sirius-components-collaborative-trees</name>
 	<description>Sirius Components Collaborative Trees</description>
 
@@ -42,12 +42,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-trees</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>
@@ -64,13 +64,13 @@
 		<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-tests</artifactId>
-    		<version>2022.3.0</version>
+    		<version>2022.3.1</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-spring-tests</artifactId>
-    		<version>2022.3.0</version>
+    		<version>2022.3.1</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>

--- a/backend/sirius-components-collaborative-validation/pom.xml
+++ b/backend/sirius-components-collaborative-validation/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.6.4</version>
+		<version>2.6.6</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>

--- a/backend/sirius-components-collaborative-validation/pom.xml
+++ b/backend/sirius-components-collaborative-validation/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-collaborative-validation</artifactId>
-	<version>2022.3.0</version>
+	<version>2022.3.1</version>
 	<name>sirius-components-collaborative-validation</name>
 	<description>Sirius Components Collaborative Validation</description>
 	
@@ -46,12 +46,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-validation</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -61,13 +61,13 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 			<scope>test</scope>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-spring-tests</artifactId>
-    		<version>2022.3.0</version>
+    		<version>2022.3.1</version>
     		<scope>test</scope>
     	</dependency>
 	</dependencies>

--- a/backend/sirius-components-collaborative/pom.xml
+++ b/backend/sirius-components-collaborative/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.6.4</version>
+		<version>2.6.6</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>

--- a/backend/sirius-components-collaborative/pom.xml
+++ b/backend/sirius-components-collaborative/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-collaborative</artifactId>
-	<version>2022.3.0</version>
+	<version>2022.3.1</version>
 	<name>sirius-components-collaborative</name>
 	<description>Sirius Components Collaborative</description>
 
@@ -66,12 +66,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-core</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -80,13 +80,13 @@
 		<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-tests</artifactId>
-    		<version>2022.3.0</version>
+    		<version>2022.3.1</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-spring-tests</artifactId>
-    		<version>2022.3.0</version>
+    		<version>2022.3.1</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>

--- a/backend/sirius-components-compatibility/pom.xml
+++ b/backend/sirius-components-compatibility/pom.xml
@@ -28,7 +28,7 @@
 
 	<properties>
 		<java.version>11</java.version>
-		<sirius.version>6.6.0-SNAPSHOT</sirius.version>
+		<sirius.version>7.0.0-SNAPSHOT</sirius.version>
 	</properties>
 	
 	<distributionManagement>
@@ -138,6 +138,11 @@
 		</dependency>
 		<dependency>
 			 <groupId>org.eclipse.sirius</groupId>
+			<artifactId>org.eclipse.sirius.model</artifactId>
+			<version>${sirius.version}</version>
+		</dependency>
+		<dependency>
+			 <groupId>org.eclipse.sirius</groupId>
 			<artifactId>org.eclipse.sirius.common</artifactId>
 			<version>${sirius.version}</version>
 		</dependency>
@@ -148,7 +153,12 @@
 		</dependency>
 		<dependency>
 			 <groupId>org.eclipse.sirius</groupId>
-			<artifactId>org.eclipse.sirius.diagram.sequence</artifactId>
+			<artifactId>org.eclipse.sirius.diagram.model</artifactId>
+			<version>${sirius.version}</version>
+		</dependency>
+		<dependency>
+			 <groupId>org.eclipse.sirius</groupId>
+			<artifactId>org.eclipse.sirius.diagram.sequence.model</artifactId>
 			<version>${sirius.version}</version>
 		</dependency>
 		<dependency>
@@ -173,12 +183,12 @@
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
-			<artifactId>org.eclipse.sirius.table</artifactId>
+			<artifactId>org.eclipse.sirius.table.model</artifactId>
 			<version>${sirius.version}</version>
 		</dependency>
 		<dependency>
 			 <groupId>org.eclipse.sirius</groupId>
-			<artifactId>org.eclipse.sirius.tree</artifactId>
+			<artifactId>org.eclipse.sirius.tree.model</artifactId>
 			<version>${sirius.version}</version>
 		</dependency>
 		<dependency>

--- a/backend/sirius-components-compatibility/pom.xml
+++ b/backend/sirius-components-compatibility/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-compatibility</artifactId>
-	<version>2022.3.0</version>
+	<version>2022.3.1</version>
 	<name>sirius-components-compatibility</name>
 	<description>Sirius Components Compatibility</description>
 
@@ -63,7 +63,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -73,43 +73,43 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-core</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-diagrams</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-forms</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-forms</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-selection</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-trees</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-interpreter</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.emf</groupId>

--- a/backend/sirius-components-compatibility/pom.xml
+++ b/backend/sirius-components-compatibility/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.6.4</version>
+		<version>2.6.6</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>

--- a/backend/sirius-components-compatibility/src/main/java/org/eclipse/sirius/components/compatibility/services/diagrams/CompatibilityToolSectionsProvider.java
+++ b/backend/sirius-components-compatibility/src/main/java/org/eclipse/sirius/components/compatibility/services/diagrams/CompatibilityToolSectionsProvider.java
@@ -45,10 +45,10 @@ import org.eclipse.sirius.components.interpreter.Status;
 import org.eclipse.sirius.components.representations.IStatus;
 import org.eclipse.sirius.components.representations.Success;
 import org.eclipse.sirius.components.representations.VariableManager;
-import org.eclipse.sirius.diagram.business.internal.metamodel.description.spec.LayerSpec;
 import org.eclipse.sirius.diagram.description.ContainerMapping;
 import org.eclipse.sirius.diagram.description.DiagramElementMapping;
 import org.eclipse.sirius.diagram.description.EdgeMapping;
+import org.eclipse.sirius.diagram.description.Layer;
 import org.eclipse.sirius.diagram.description.NodeMapping;
 import org.eclipse.sirius.diagram.description.tool.ContainerCreationDescription;
 import org.eclipse.sirius.diagram.description.tool.DeleteElementDescription;
@@ -214,7 +214,7 @@ public class CompatibilityToolSectionsProvider implements IToolSectionsProvider 
         //@formatter:off
         return mappings.stream()
                 .map(DiagramElementMapping::eContainer)
-                .anyMatch(LayerSpec.class::isInstance);
+                .anyMatch(Layer.class::isInstance);
         //@formatter:on
     }
 

--- a/backend/sirius-components-compatibility/src/main/java/org/eclipse/sirius/components/compatibility/services/diagrams/DiagramDescriptionNodeAndEdgeDescriptionsPopulator.java
+++ b/backend/sirius-components-compatibility/src/main/java/org/eclipse/sirius/components/compatibility/services/diagrams/DiagramDescriptionNodeAndEdgeDescriptionsPopulator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 Obeo.
+ * Copyright (c) 2019, 2022 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -41,12 +41,13 @@ import org.eclipse.sirius.components.interpreter.AQLInterpreter;
 import org.eclipse.sirius.components.representations.Failure;
 import org.eclipse.sirius.components.representations.IStatus;
 import org.eclipse.sirius.components.representations.VariableManager;
-import org.eclipse.sirius.diagram.business.internal.metamodel.helper.LayerHelper;
+import org.eclipse.sirius.diagram.business.api.query.DiagramDescriptionQuery;
 import org.eclipse.sirius.diagram.description.AdditionalLayer;
 import org.eclipse.sirius.diagram.description.ContainerMappingImport;
 import org.eclipse.sirius.diagram.description.DiagramDescription;
 import org.eclipse.sirius.diagram.description.Layer;
 import org.eclipse.sirius.diagram.description.tool.ContainerDropDescription;
+import org.eclipse.sirius.diagram.model.business.internal.helper.LayerModelHelper;
 import org.springframework.stereotype.Service;
 
 /**
@@ -89,7 +90,7 @@ public class DiagramDescriptionNodeAndEdgeDescriptionsPopulator implements IDiag
         Map<UUID, NodeDescription> id2NodeDescriptions = new HashMap<>();
 
         // @formatter:off
-        List<Layer> layers = LayerHelper.getAllLayers(siriusDiagramDescription).stream()
+        List<Layer> layers = LayerModelHelper.getAllLayers(siriusDiagramDescription).stream()
                 .filter(this::isEnabledByDefault)
                 .collect(Collectors.toList());
 
@@ -134,7 +135,7 @@ public class DiagramDescriptionNodeAndEdgeDescriptionsPopulator implements IDiag
 
     private Function<VariableManager, IStatus> getDropHandler(DiagramDescription siriusDiagramDescription, AQLInterpreter interpreter) {
         // @formatter:off
-        List<ContainerDropDescription> diagramDropTools = siriusDiagramDescription.getAllTools().stream()
+        List<ContainerDropDescription> diagramDropTools = new DiagramDescriptionQuery(siriusDiagramDescription).getAllTools().stream()
                 .filter(ContainerDropDescription.class::isInstance)
                 .map(ContainerDropDescription.class::cast)
                 .collect(Collectors.toList());

--- a/backend/sirius-components-compatibility/src/main/java/org/eclipse/sirius/components/compatibility/services/diagrams/ToolProvider.java
+++ b/backend/sirius-components-compatibility/src/main/java/org/eclipse/sirius/components/compatibility/services/diagrams/ToolProvider.java
@@ -34,17 +34,16 @@ import org.eclipse.sirius.components.diagrams.Diagram;
 import org.eclipse.sirius.components.diagrams.Node;
 import org.eclipse.sirius.components.diagrams.description.EdgeDescription;
 import org.eclipse.sirius.components.diagrams.description.NodeDescription;
-import org.eclipse.sirius.components.diagrams.tools.SingleClickOnTwoDiagramElementsTool;
+import org.eclipse.sirius.components.diagrams.tools.ITool;
 import org.eclipse.sirius.components.diagrams.tools.SingleClickOnDiagramElementTool;
 import org.eclipse.sirius.components.diagrams.tools.SingleClickOnTwoDiagramElementsCandidate;
-import org.eclipse.sirius.components.diagrams.tools.ITool;
+import org.eclipse.sirius.components.diagrams.tools.SingleClickOnTwoDiagramElementsTool;
 import org.eclipse.sirius.components.diagrams.tools.ToolSection;
 import org.eclipse.sirius.components.interpreter.AQLInterpreter;
 import org.eclipse.sirius.components.representations.Failure;
 import org.eclipse.sirius.components.representations.IStatus;
 import org.eclipse.sirius.components.representations.Success;
 import org.eclipse.sirius.components.representations.VariableManager;
-import org.eclipse.sirius.diagram.business.internal.metamodel.description.spec.LayerSpec;
 import org.eclipse.sirius.diagram.description.AbstractNodeMapping;
 import org.eclipse.sirius.diagram.description.AdditionalLayer;
 import org.eclipse.sirius.diagram.description.ContainerMapping;
@@ -209,7 +208,7 @@ public class ToolProvider implements IToolProvider {
         //@formatter:off
         return nodeMappings.stream()
                 .map(AbstractNodeMapping::eContainer)
-                .anyMatch(LayerSpec.class::isInstance);
+                .anyMatch(Layer.class::isInstance);
         //@formatter:on
     }
 
@@ -261,7 +260,8 @@ public class ToolProvider implements IToolProvider {
         // @formatter:on
     }
 
-    private SingleClickOnDiagramElementTool convertContainerCreationDescription(Map<UUID, NodeDescription> id2NodeDescriptions, AQLInterpreter interpreter, ContainerCreationDescription containerCreationDescription) {
+    private SingleClickOnDiagramElementTool convertContainerCreationDescription(Map<UUID, NodeDescription> id2NodeDescriptions, AQLInterpreter interpreter,
+            ContainerCreationDescription containerCreationDescription) {
         String id = this.identifierProvider.getIdentifier(containerCreationDescription);
         String label = new IdentifiedElementQuery(containerCreationDescription).getLabel();
         String imagePath = this.toolImageProviderFactory.getToolImageProvider(containerCreationDescription).get();
@@ -358,7 +358,8 @@ public class ToolProvider implements IToolProvider {
         return result;
     }
 
-    private SingleClickOnTwoDiagramElementsTool convertEdgeCreationDescription(Map<UUID, NodeDescription> id2NodeDescriptions, AQLInterpreter interpreter, EdgeCreationDescription edgeCreationDescription) {
+    private SingleClickOnTwoDiagramElementsTool convertEdgeCreationDescription(Map<UUID, NodeDescription> id2NodeDescriptions, AQLInterpreter interpreter,
+            EdgeCreationDescription edgeCreationDescription) {
         String id = this.identifierProvider.getIdentifier(edgeCreationDescription);
         String label = new IdentifiedElementQuery(edgeCreationDescription).getLabel();
         String imagePath = this.toolImageProviderFactory.getToolImageProvider(edgeCreationDescription).get();
@@ -392,7 +393,8 @@ public class ToolProvider implements IToolProvider {
         // @formatter:on
     }
 
-    private SingleClickOnDiagramElementTool convertDeleteElementDescription(Map<UUID, NodeDescription> id2NodeDescriptions, AQLInterpreter interpreter, DeleteElementDescription deleteElementDescription) {
+    private SingleClickOnDiagramElementTool convertDeleteElementDescription(Map<UUID, NodeDescription> id2NodeDescriptions, AQLInterpreter interpreter,
+            DeleteElementDescription deleteElementDescription) {
         String id = this.identifierProvider.getIdentifier(deleteElementDescription);
         String label = new IdentifiedElementQuery(deleteElementDescription).getLabel();
         String imagePath = this.toolImageProviderFactory.getToolImageProvider(deleteElementDescription).get();

--- a/backend/sirius-components-compatibility/src/main/java/org/eclipse/sirius/components/compatibility/services/representations/SiriusRepresentationDescriptionProvider.java
+++ b/backend/sirius-components-compatibility/src/main/java/org/eclipse/sirius/components/compatibility/services/representations/SiriusRepresentationDescriptionProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 Obeo.
+ * Copyright (c) 2019, 2022 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -26,6 +26,7 @@ import org.eclipse.sirius.components.compatibility.services.selection.api.ISelec
 import org.eclipse.sirius.components.forms.description.FormDescription;
 import org.eclipse.sirius.components.representations.IRepresentationDescription;
 import org.eclipse.sirius.components.selection.description.SelectionDescription;
+import org.eclipse.sirius.diagram.business.api.query.DiagramDescriptionQuery;
 import org.eclipse.sirius.diagram.description.tool.ContainerCreationDescription;
 import org.eclipse.sirius.diagram.description.tool.NodeCreationDescription;
 import org.eclipse.sirius.properties.ViewExtensionDescription;
@@ -80,12 +81,12 @@ public class SiriusRepresentationDescriptionProvider {
 
     private List<SelectionDescription> getSelectionDescriptions(org.eclipse.sirius.diagram.description.DiagramDescription diagramDescription) {
         // @formatter:off
-        List<ContainerCreationDescription> containerCreationDescriptions = diagramDescription.getAllTools().stream()
+        List<ContainerCreationDescription> containerCreationDescriptions = new DiagramDescriptionQuery(diagramDescription).getAllTools().stream()
                 .filter(ContainerCreationDescription.class::isInstance)
                 .map(ContainerCreationDescription.class::cast)
                 .collect(Collectors.toList());
 
-        List<NodeCreationDescription> nodeCreationDescriptions = diagramDescription.getAllTools().stream()
+        List<NodeCreationDescription> nodeCreationDescriptions = new DiagramDescriptionQuery(diagramDescription).getAllTools().stream()
                 .filter(NodeCreationDescription.class::isInstance)
                 .map(NodeCreationDescription.class::cast)
                 .collect(Collectors.toList());

--- a/backend/sirius-components-core/pom.xml
+++ b/backend/sirius-components-core/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.6.4</version>
+		<version>2.6.6</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>

--- a/backend/sirius-components-core/pom.xml
+++ b/backend/sirius-components-core/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-core</artifactId>
-	<version>2022.3.0</version>
+	<version>2022.3.1</version>
 	<name>sirius-components-core</name>
 	<description>Sirius Components Core</description>
 
@@ -51,17 +51,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend/sirius-components-diagrams-layout-api/pom.xml
+++ b/backend/sirius-components-diagrams-layout-api/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-diagrams-layout-api</artifactId>
-	<version>2022.3.0</version>
+	<version>2022.3.1</version>
 	<name>sirius-components-diagrams-layout-api</name>
 	<description>Sirius Components Diagrams Layout API</description>
 
@@ -42,12 +42,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-core</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 	</dependencies>
 

--- a/backend/sirius-components-diagrams-layout-api/pom.xml
+++ b/backend/sirius-components-diagrams-layout-api/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.6.4</version>
+		<version>2.6.6</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>

--- a/backend/sirius-components-diagrams-layout/pom.xml
+++ b/backend/sirius-components-diagrams-layout/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.6.4</version>
+		<version>2.6.6</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>

--- a/backend/sirius-components-diagrams-layout/pom.xml
+++ b/backend/sirius-components-diagrams-layout/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-diagrams-layout</artifactId>
-	<version>2022.3.0</version>
+	<version>2022.3.1</version>
 	<name>sirius-components-diagrams-layout</name>
 	<description>Sirius Components Diagrams layout</description>
 
@@ -65,17 +65,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-core</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-layout-api</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.elk</groupId>
@@ -112,7 +112,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -127,18 +127,18 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-tests</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-diagrams</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/backend/sirius-components-diagrams-tests/pom.xml
+++ b/backend/sirius-components-diagrams-tests/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.6.4</version>
+		<version>2.6.6</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>

--- a/backend/sirius-components-diagrams-tests/pom.xml
+++ b/backend/sirius-components-diagrams-tests/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-diagrams-tests</artifactId>
-	<version>2022.3.0</version>
+	<version>2022.3.1</version>
 	<name>sirius-components-diagrams-tests</name>
 	<description>Sirius Components Diagrams Tests</description>
 
@@ -46,12 +46,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-core</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.assertj</groupId>

--- a/backend/sirius-components-diagrams/pom.xml
+++ b/backend/sirius-components-diagrams/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-diagrams</artifactId>
-	<version>2022.3.0</version>
+	<version>2022.3.1</version>
 	<name>sirius-components-diagrams</name>
 	<description>Sirius Components Diagrams</description>
 
@@ -42,7 +42,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -52,7 +52,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend/sirius-components-diagrams/pom.xml
+++ b/backend/sirius-components-diagrams/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.6.4</version>
+		<version>2.6.6</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>

--- a/backend/sirius-components-domain-design/pom.xml
+++ b/backend/sirius-components-domain-design/pom.xml
@@ -18,7 +18,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.6.4</version>
+		<version>2.6.6</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>

--- a/backend/sirius-components-domain-design/pom.xml
+++ b/backend/sirius-components-domain-design/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-domain-design</artifactId>
-	<version>2022.3.0</version>
+	<version>2022.3.1</version>
 	<name>sirius-components-domain-design</name>
 	<description>Sirius Components Domain Definition DSL - Graphical Modeler Definition</description>
 
@@ -64,7 +64,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-domain</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 	</dependencies>
 	

--- a/backend/sirius-components-domain-edit/pom.xml
+++ b/backend/sirius-components-domain-edit/pom.xml
@@ -18,7 +18,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.6.4</version>
+		<version>2.6.6</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>

--- a/backend/sirius-components-domain-edit/pom.xml
+++ b/backend/sirius-components-domain-edit/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-domain-edit</artifactId>
-	<version>2022.3.0</version>
+	<version>2022.3.1</version>
 	<name>sirius-components-domain-edit</name>
 	<description>Sirius Components Domain Definition DSL - Edit Support</description>
 
@@ -64,7 +64,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-domain</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 	</dependencies>
 	

--- a/backend/sirius-components-domain/pom.xml
+++ b/backend/sirius-components-domain/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-domain</artifactId>
-	<version>2022.3.0</version>
+	<version>2022.3.1</version>
 	<name>sirius-components-domain</name>
 	<description>Sirius Components Domain Definition DSL</description>
 

--- a/backend/sirius-components-domain/pom.xml
+++ b/backend/sirius-components-domain/pom.xml
@@ -18,7 +18,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.6.4</version>
+		<version>2.6.6</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>

--- a/backend/sirius-components-emf/pom.xml
+++ b/backend/sirius-components-emf/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-emf</artifactId>
-	<version>2022.3.0</version>
+	<version>2022.3.1</version>
 	<name>sirius-components-emf</name>
 	<description>Sirius Components EMF</description>
 
@@ -62,52 +62,52 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql-api</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-diagrams</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-forms</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-trees</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-validation</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-compatibility</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-interpreter</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-domain</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.emf</groupId>
@@ -156,19 +156,19 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-tests</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend/sirius-components-emf/pom.xml
+++ b/backend/sirius-components-emf/pom.xml
@@ -18,7 +18,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.6.4</version>
+		<version>2.6.6</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>

--- a/backend/sirius-components-forms-tests/pom.xml
+++ b/backend/sirius-components-forms-tests/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-forms-tests</artifactId>
-	<version>2022.3.0</version>
+	<version>2022.3.1</version>
 	<name>sirius-components-forms-tests</name>
 	<description>Sirius Components Forms Tests</description>
 
@@ -42,7 +42,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-forms</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.assertj</groupId>

--- a/backend/sirius-components-forms-tests/pom.xml
+++ b/backend/sirius-components-forms-tests/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.6.4</version>
+		<version>2.6.6</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>

--- a/backend/sirius-components-forms/pom.xml
+++ b/backend/sirius-components-forms/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.6.4</version>
+		<version>2.6.6</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>

--- a/backend/sirius-components-forms/pom.xml
+++ b/backend/sirius-components-forms/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-forms</artifactId>
-	<version>2022.3.0</version>
+	<version>2022.3.1</version>
 	<name>sirius-components-forms</name>
 	<description>Sirius Components Forms</description>
 
@@ -46,12 +46,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -61,7 +61,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/backend/sirius-components-graphiql/pom.xml
+++ b/backend/sirius-components-graphiql/pom.xml
@@ -18,7 +18,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.6.4</version>
+		<version>2.6.6</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>

--- a/backend/sirius-components-graphiql/pom.xml
+++ b/backend/sirius-components-graphiql/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-graphiql</artifactId>
-	<version>2022.3.0</version>
+	<version>2022.3.1</version>
 	<name>sirius-components-graphiql</name>
 	<description>Sirius Components Graphiql support. This project contribute a GraphQL query tool on the /graphiql/index.html URI.</description>
 

--- a/backend/sirius-components-graphql-api/pom.xml
+++ b/backend/sirius-components-graphql-api/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.6.4</version>
+		<version>2.6.6</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>

--- a/backend/sirius-components-graphql-api/pom.xml
+++ b/backend/sirius-components-graphql-api/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-graphql-api</artifactId>
-	<version>2022.3.0</version>
+	<version>2022.3.1</version>
 	<name>sirius-components-graphql-api</name>
 	<description>Sirius Components GraphQL API</description>
 
@@ -48,7 +48,7 @@
     	<dependency>
         	<groupId>org.eclipse.sirius</groupId>
         	<artifactId>sirius-components-annotations-spring</artifactId>
-        	<version>2022.3.0</version>
+        	<version>2022.3.1</version>
     	</dependency>
 	</dependencies>
 

--- a/backend/sirius-components-graphql-api/pom.xml
+++ b/backend/sirius-components-graphql-api/pom.xml
@@ -28,7 +28,7 @@
 
 	<properties>
 		<java.version>11</java.version>
-		<graphql-java.version>17.3</graphql-java.version>
+		<graphql-java.version>18.0</graphql-java.version>
 	</properties>
 
 	<distributionManagement>

--- a/backend/sirius-components-graphql-utils/pom.xml
+++ b/backend/sirius-components-graphql-utils/pom.xml
@@ -28,7 +28,7 @@
 
 	<properties>
 		<java.version>11</java.version>
-		<graphql-java.version>17.3</graphql-java.version>
+		<graphql-java.version>18.0</graphql-java.version>
 	</properties>
 	
 	<distributionManagement>

--- a/backend/sirius-components-graphql-utils/pom.xml
+++ b/backend/sirius-components-graphql-utils/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-graphql-utils</artifactId>
-	<version>2022.3.0</version>
+	<version>2022.3.1</version>
 	<name>sirius-components-graphql-utils</name>
 	<description>Sirius Components GraphQL Utils</description>
 
@@ -43,7 +43,7 @@
 		<dependency>
         	<groupId>org.eclipse.sirius</groupId>
         	<artifactId>sirius-components-annotations</artifactId>
-        	<version>2022.3.0</version>
+        	<version>2022.3.1</version>
     	</dependency>
 		<dependency>
         	<groupId>com.graphql-java</groupId>
@@ -53,7 +53,7 @@
     	<dependency>
    			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 			<scope>test</scope>
     	</dependency>
     	<dependency>

--- a/backend/sirius-components-graphql-utils/pom.xml
+++ b/backend/sirius-components-graphql-utils/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.6.4</version>
+		<version>2.6.6</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>

--- a/backend/sirius-components-graphql-voyager/pom.xml
+++ b/backend/sirius-components-graphql-voyager/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-graphql-voyager</artifactId>
-	<version>2022.3.0</version>
+	<version>2022.3.1</version>
 	<name>sirius-components-graphql-voyager</name>
 	<description>Sirius Components Graph Voyager. This project contribute a GraphQL API UX thanks to the https://github.com/APIs-guru/graphql-voyager project.</description>
 

--- a/backend/sirius-components-graphql-voyager/pom.xml
+++ b/backend/sirius-components-graphql-voyager/pom.xml
@@ -18,7 +18,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.6.4</version>
+		<version>2.6.6</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>

--- a/backend/sirius-components-graphql/pom.xml
+++ b/backend/sirius-components-graphql/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-graphql</artifactId>
-	<version>2022.3.0</version>
+	<version>2022.3.1</version>
 	<name>sirius-components-graphql</name>
 	<description>Sirius Components GraphQL</description>
 
@@ -64,28 +64,28 @@
     	<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-annotations</artifactId>
-    		<version>2022.3.0</version>
+    		<version>2022.3.1</version>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-graphql-utils</artifactId>
-    		<version>2022.3.0</version>
+    		<version>2022.3.1</version>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-graphql-api</artifactId>
-    		<version>2022.3.0</version>
+    		<version>2022.3.1</version>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-tests</artifactId>
-    		<version>2022.3.0</version>
+    		<version>2022.3.1</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-spring-tests</artifactId>
-    		<version>2022.3.0</version>
+    		<version>2022.3.1</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>

--- a/backend/sirius-components-graphql/pom.xml
+++ b/backend/sirius-components-graphql/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.6.4</version>
+		<version>2.6.6</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>

--- a/backend/sirius-components-graphql/pom.xml
+++ b/backend/sirius-components-graphql/pom.xml
@@ -28,7 +28,7 @@
 
 	<properties>
 		<java.version>11</java.version>
-		<graphql-java.version>17.3</graphql-java.version>
+		<graphql-java.version>18.0</graphql-java.version>
 	</properties>
 
 	<distributionManagement>

--- a/backend/sirius-components-interpreter/pom.xml
+++ b/backend/sirius-components-interpreter/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.6.4</version>
+		<version>2.6.6</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>

--- a/backend/sirius-components-interpreter/pom.xml
+++ b/backend/sirius-components-interpreter/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-interpreter</artifactId>
-	<version>2022.3.0</version>
+	<version>2022.3.1</version>
 	<name>sirius-components-interpreter</name>
 	<description>Sirius Components Intepreter</description>
 

--- a/backend/sirius-components-representations/pom.xml
+++ b/backend/sirius-components-representations/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.6.4</version>
+		<version>2.6.6</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>

--- a/backend/sirius-components-representations/pom.xml
+++ b/backend/sirius-components-representations/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-representations</artifactId>
-	<version>2022.3.0</version>
+	<version>2022.3.1</version>
 	<name>sirius-components-representations</name>
 	<description>Sirius Components Representations</description>
 
@@ -46,7 +46,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 	</dependencies>
 

--- a/backend/sirius-components-selection/pom.xml
+++ b/backend/sirius-components-selection/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-selection</artifactId>
-	<version>2022.3.0</version>
+	<version>2022.3.1</version>
 	<name>sirius-components-selection</name>
 	<description>Sirius Components Selection</description>
 
@@ -42,17 +42,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend/sirius-components-selection/pom.xml
+++ b/backend/sirius-components-selection/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.6.4</version>
+		<version>2.6.6</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>

--- a/backend/sirius-components-spring-tests/pom.xml
+++ b/backend/sirius-components-spring-tests/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-spring-tests</artifactId>
-	<version>2022.3.0</version>
+	<version>2022.3.1</version>
 	<name>sirius-components-spring-tests</name>
 	<description>Sirius Components Spring Tests</description>
 
@@ -46,7 +46,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>

--- a/backend/sirius-components-spring-tests/pom.xml
+++ b/backend/sirius-components-spring-tests/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.6.4</version>
+		<version>2.6.6</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>

--- a/backend/sirius-components-starter/pom.xml
+++ b/backend/sirius-components-starter/pom.xml
@@ -15,7 +15,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-starter</artifactId>
-	<version>2022.3.0</version>
+	<version>2022.3.1</version>
 	<name>sirius-components-starter</name>
 	<description>Sirius Components Starter</description>
 
@@ -55,52 +55,52 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-layout</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-diagrams</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-forms</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-selection</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-trees</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-validation</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-emf</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-compatibility</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 	</dependencies>
 

--- a/backend/sirius-components-starter/pom.xml
+++ b/backend/sirius-components-starter/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.6.4</version>
+		<version>2.6.6</version>
 		<relativePath />
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>

--- a/backend/sirius-components-test-coverage/pom.xml
+++ b/backend/sirius-components-test-coverage/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.6.4</version>
+		<version>2.6.6</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>

--- a/backend/sirius-components-test-coverage/pom.xml
+++ b/backend/sirius-components-test-coverage/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-test-coverage</artifactId>
-	<version>2022.3.0</version>
+	<version>2022.3.1</version>
 	<name>sirius-components-test-coverage-aggregation</name>
 	<description>Sirius Web Test Coverage Aggregation</description>
 
@@ -42,142 +42,142 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations-spring</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-compatibility</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-core</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-layout</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-layout-api</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-domain</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-domain-design</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-domain-edit</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-emf</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-forms</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql-utils</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-interpreter</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-selection</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-diagrams</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-forms</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-selection</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-trees</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-validation</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql-api</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-trees</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-validation</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-edit</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 	</dependencies>
 

--- a/backend/sirius-components-tests/pom.xml
+++ b/backend/sirius-components-tests/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.6.4</version>
+		<version>2.6.6</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>

--- a/backend/sirius-components-tests/pom.xml
+++ b/backend/sirius-components-tests/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-tests</artifactId>
-	<version>2022.3.0</version>
+	<version>2022.3.1</version>
 	<name>sirius-components-tests</name>
 	<description>Sirius Components Tests</description>
 
@@ -51,7 +51,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 	</dependencies>
 

--- a/backend/sirius-components-trees/pom.xml
+++ b/backend/sirius-components-trees/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.6.4</version>
+		<version>2.6.6</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>

--- a/backend/sirius-components-trees/pom.xml
+++ b/backend/sirius-components-trees/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-trees</artifactId>
-	<version>2022.3.0</version>
+	<version>2022.3.1</version>
 	<name>sirius-components-trees</name>
 	<description>Sirius Components Trees</description>
 
@@ -42,17 +42,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/backend/sirius-components-validation/pom.xml
+++ b/backend/sirius-components-validation/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-validation</artifactId>
-	<version>2022.3.0</version>
+	<version>2022.3.1</version>
 	<name>sirius-components-validation</name>
 	<description>Sirius Components Validation</description>
 	
@@ -47,12 +47,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend/sirius-components-validation/pom.xml
+++ b/backend/sirius-components-validation/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.6.4</version>
+		<version>2.6.6</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>

--- a/backend/sirius-components-view-edit/pom.xml
+++ b/backend/sirius-components-view-edit/pom.xml
@@ -18,7 +18,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.6.4</version>
+		<version>2.6.6</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>

--- a/backend/sirius-components-view-edit/pom.xml
+++ b/backend/sirius-components-view-edit/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-view-edit</artifactId>
-	<version>2022.3.0</version>
+	<version>2022.3.1</version>
 	<name>sirius-components-view-edit</name>
 	<description>Sirius Components View Definition DSL - Edit Support</description>
 
@@ -64,7 +64,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view</artifactId>
-			<version>2022.3.0</version>
+			<version>2022.3.1</version>
 		</dependency>
 	</dependencies>
 	

--- a/backend/sirius-components-view/pom.xml
+++ b/backend/sirius-components-view/pom.xml
@@ -18,7 +18,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.6.4</version>
+		<version>2.6.6</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>

--- a/backend/sirius-components-view/pom.xml
+++ b/backend/sirius-components-view/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-view</artifactId>
-	<version>2022.3.0</version>
+	<version>2022.3.1</version>
 	<name>sirius-components-view</name>
 	<description>Sirius Components View Definition DSL</description>
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@eclipse-sirius/sirius-components",
-  "version": "2022.3.0",
+  "version": "2022.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@eclipse-sirius/sirius-components",
-      "version": "2022.3.0",
+      "version": "2022.3.1",
       "license": "EPL-2.0",
       "dependencies": {
         "uuid": "8.3.2"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-sirius/sirius-components",
-  "version": "2022.3.0",
+  "version": "2022.3.1",
   "author": "Eclipse Sirius",
   "license": "EPL-2.0",
   "description": "Reusable components used to build the Sirius Web frontend",


### PR DESCRIPTION
See: https://github.com/spring-projects/spring-boot/releases/tag/v2.6.6

Signed-off-by: Stéphane Bégaudeau <stephane.begaudeau@obeo.fr>
