### PR TITLE
[1154] Display the palette where the click has been made

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -22,6 +22,8 @@
 
 === Bug fixes
 
+- https://github.com/eclipse-sirius/sirius-components/issues/1154[#1154] [diagram] Display the palette where the click has been made, not where the cursor is. With the edge animation it was possible for the palette to be displayed at a wrong position which was making possible to create a floating edge.
+
 === Improvements
 
 - https://github.com/eclipse-sirius/sirius-components/issues/1165[#1165] [doc] Improve the pull request template

--- a/frontend/src/diagram/sprotty/DiagramServer.types.ts
+++ b/frontend/src/diagram/sprotty/DiagramServer.types.ts
@@ -17,7 +17,7 @@ import {
   Tool,
 } from 'diagram/DiagramWebSocketContainer.types';
 import { SModelElement } from 'sprotty';
-import { Action } from 'sprotty-protocol';
+import { Action, Point } from 'sprotty-protocol';
 import { Selection } from 'workbench/Workbench.types';
 
 export interface SiriusUpdateModelAction extends Action {
@@ -67,4 +67,10 @@ export interface ShowContextualMenuAction extends Action {
   tools: Tool[];
   startPosition: Position | null;
   endPosition: Position | null;
+}
+
+export interface ShowContextualToolbarAction {
+  kind: 'showContextualToolbar';
+  element: SModelElement;
+  position: Point;
 }


### PR DESCRIPTION
### Type of this PR 

- [x] Bug fix
- [ ] New feature or improvement
- [ ] Documentation
- [ ] Cleanup
- [ ] Test
- [ ] Build/Releng

### Issue(s)

closes https://github.com/eclipse-sirius/sirius-components/issues/1154

### What does this PR do?

This PR takes the position of the mouse when the click is made, then this position is given to the action that will display the contextual palette.

### How to test this PR?

- [ ] Frontend Unit tests
- [ ] Backend Unit tests
- [ ] Cypress : please specify
- [x] Manual Test: See the "step to reproduce" described in the issue. The actual behavior should not happen.
