### PR TITLE
[689] Improve the performances of the unsynchronized nodes

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -48,6 +48,7 @@ See ADR-54 for the details.
 - [releng] Detect the presence of classes without a public visibility or with a package or protected constructor in order to speed up the code reviews.
 - https://github.com/eclipse-sirius/sirius-components/issues/1138[#1138] [workbench] The left and right panels can be closed by clicking on the current view's icon or by resizing them to the minimum widht (showing only the icons).
 When closed, clicking on any of the views' icon will re-open the panel to make the selected view visible.
+- https://github.com/eclipse-sirius/sirius-components/issues/689[#689] [diagram] Add a variable containing objects ids to render for unsynchronized nodes rendering
 
 === New features
 

--- a/backend/sirius-components-diagrams/src/main/java/org/eclipse/sirius/components/diagrams/components/DiagramComponent.java
+++ b/backend/sirius-components-diagrams/src/main/java/org/eclipse/sirius/components/diagrams/components/DiagramComponent.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 Obeo and others.
+ * Copyright (c) 2019, 2022 Obeo and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -59,6 +59,7 @@ public class DiagramComponent implements IComponent {
                 .map(nodeDescription -> {
                     var previousNodes = optionalPreviousDiagram.map(previousDiagram -> diagramElementRequestor.getRootNodes(previousDiagram, nodeDescription))
                             .orElse(List.of());
+                    var previousNodesTargetIds = previousNodes.stream().map(node -> node.getTargetObjectId()).collect(Collectors.toList());
                     INodesRequestor nodesRequestor = new NodesRequestor(previousNodes);
                     var nodeComponentProps = NodeComponentProps.newNodeComponentProps()
                             .variableManager(variableManager)
@@ -69,6 +70,7 @@ public class DiagramComponent implements IComponent {
                             .viewCreationRequests(this.props.getViewCreationRequests())
                             .viewDeletionRequests(this.props.getViewDeletionRequests())
                             .parentElementId(diagramId)
+                            .previousTargetObjectIds(previousNodesTargetIds)
                             .build();
                     return new Element(NodeComponent.class, nodeComponentProps);
                 }).collect(Collectors.toList());

--- a/backend/sirius-components-diagrams/src/main/java/org/eclipse/sirius/components/diagrams/components/NodeComponentProps.java
+++ b/backend/sirius-components-diagrams/src/main/java/org/eclipse/sirius/components/diagrams/components/NodeComponentProps.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 Obeo and others.
+ * Copyright (c) 2019, 2022 Obeo and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -47,6 +47,8 @@ public final class NodeComponentProps implements IProps {
 
     private String parentElementId;
 
+    private List<String> previousTargetObjectIds;
+
     private NodeComponentProps() {
         // Prevent instantiation
     }
@@ -83,6 +85,10 @@ public final class NodeComponentProps implements IProps {
         return this.parentElementId;
     }
 
+    public List<String> getPreviousTargetObjectIds() {
+        return this.previousTargetObjectIds;
+    }
+
     public static Builder newNodeComponentProps() {
         return new Builder();
     }
@@ -109,6 +115,8 @@ public final class NodeComponentProps implements IProps {
         private List<ViewDeletionRequest> viewDeletionRequests;
 
         private String parentElementId;
+
+        private List<String> previousTargetObjectIds;
 
         public Builder variableManager(VariableManager variableManager) {
             this.variableManager = Objects.requireNonNull(variableManager);
@@ -150,6 +158,11 @@ public final class NodeComponentProps implements IProps {
             return this;
         }
 
+        public Builder previousTargetObjectIds(List<String> previousTargetObjectIds) {
+            this.previousTargetObjectIds = Objects.requireNonNull(previousTargetObjectIds);
+            return this;
+        }
+
         public NodeComponentProps build() {
             NodeComponentProps nodeComponentProps = new NodeComponentProps();
             nodeComponentProps.variableManager = Objects.requireNonNull(this.variableManager);
@@ -160,6 +173,7 @@ public final class NodeComponentProps implements IProps {
             nodeComponentProps.viewCreationRequests = Objects.requireNonNull(this.viewCreationRequests);
             nodeComponentProps.viewDeletionRequests = Objects.requireNonNull(this.viewDeletionRequests);
             nodeComponentProps.parentElementId = Objects.requireNonNull(this.parentElementId);
+            nodeComponentProps.previousTargetObjectIds = Objects.requireNonNull(this.previousTargetObjectIds);
             return nodeComponentProps;
         }
     }

--- a/backend/sirius-components-diagrams/src/test/java/org/eclipse/sirius/components/diagrams/renderer/UnsynchronizedDiagramTests.java
+++ b/backend/sirius-components-diagrams/src/test/java/org/eclipse/sirius/components/diagrams/renderer/UnsynchronizedDiagramTests.java
@@ -64,7 +64,7 @@ public class UnsynchronizedDiagramTests {
      */
     @Test
     public void testRenderingOnRoot() {
-        DiagramDescription diagramDescription = this.getDiagramDescription();
+        DiagramDescription diagramDescription = this.getDiagramDescription(variableManager -> List.of(new Object()));
 
         Diagram initialDiagram = this.render(diagramDescription, List.of(), List.of(), Optional.empty());
         assertThat(initialDiagram.getNodes()).hasSize(1);
@@ -86,7 +86,7 @@ public class UnsynchronizedDiagramTests {
      */
     @Test
     public void testUnsynchronizedRenderingOnRoot() {
-        DiagramDescription diagramDescription = this.getDiagramDescription();
+        DiagramDescription diagramDescription = this.getDiagramDescription(variableManager -> List.of(new Object()));
 
         Diagram initialDiagram = this.render(diagramDescription, List.of(), List.of(), Optional.empty());
 
@@ -116,7 +116,7 @@ public class UnsynchronizedDiagramTests {
      */
     @Test
     public void testUnsynchronizedRenderingOnRootAfterDeletion() {
-        DiagramDescription diagramDescription = this.getDiagramDescription();
+        DiagramDescription diagramDescription = this.getDiagramDescription(variableManager -> List.of(new Object()));
 
         Diagram initialDiagram = this.render(diagramDescription, List.of(), List.of(), Optional.empty());
 
@@ -154,7 +154,14 @@ public class UnsynchronizedDiagramTests {
      */
     @Test
     public void testUnsynchronizedRenderingOnNodeContainer() {
-        DiagramDescription diagramDescription = this.getDiagramDescription();
+        Function<VariableManager, List<?>> semanticElementsProvider = new Function<>() {
+            @Override
+            public List<?> apply(VariableManager variableManager) {
+                return List.of(new Object());
+            }
+        };
+
+        DiagramDescription diagramDescription = this.getDiagramDescription(semanticElementsProvider);
 
         Diagram initialDiagram = this.render(diagramDescription, List.of(), List.of(), Optional.empty());
         // @formatter:off
@@ -199,7 +206,7 @@ public class UnsynchronizedDiagramTests {
      */
     @Test
     public void testUnsynchronizedRenderingOnNodeContainerAfterDeletion() {
-        DiagramDescription diagramDescription = this.getDiagramDescription();
+        DiagramDescription diagramDescription = this.getDiagramDescription(variableManager -> List.of(new Object()));
 
         Diagram initialDiagram = this.render(diagramDescription, List.of(), List.of(), Optional.empty());
         // @formatter:off
@@ -255,7 +262,7 @@ public class UnsynchronizedDiagramTests {
         return diagram;
     }
 
-    private DiagramDescription getDiagramDescription() {
+    private DiagramDescription getDiagramDescription(Function<VariableManager, List<?>> semanticElementsProvider) {
         // @formatter:off
         LabelStyleDescription labelStyleDescription = LabelStyleDescription.newLabelStyleDescription()
                 .italicProvider(VariableManager -> true)
@@ -285,7 +292,7 @@ public class UnsynchronizedDiagramTests {
         NodeDescription subUnsynchronizedNodeDescription = NodeDescription.newNodeDescription(UUID.nameUUIDFromBytes("subUnsynchronized".getBytes())) //$NON-NLS-1$
                 .synchronizationPolicy(SynchronizationPolicy.UNSYNCHRONIZED)
                 .typeProvider(variableManager -> NODE_TYPE)
-                .semanticElementsProvider(variableManager -> List.of(new Object()))
+                .semanticElementsProvider(semanticElementsProvider)
                 .targetObjectIdProvider(variableManager -> TARGET_OBJECT_ID)
                 .targetObjectKindProvider(variableManager -> "") //$NON-NLS-1$
                 .targetObjectLabelProvider(variableManager -> "")//$NON-NLS-1$
@@ -300,7 +307,7 @@ public class UnsynchronizedDiagramTests {
         NodeDescription unsynchronizedNodeDescription = NodeDescription.newNodeDescription(UUID.nameUUIDFromBytes("unsynchronized".getBytes())) //$NON-NLS-1$
                 .synchronizationPolicy(SynchronizationPolicy.UNSYNCHRONIZED)
                 .typeProvider(variableManager -> NODE_TYPE)
-                .semanticElementsProvider(variableManager -> List.of(new Object()))
+                .semanticElementsProvider(semanticElementsProvider)
                 .targetObjectIdProvider(variableManager -> TARGET_OBJECT_ID)
                 .targetObjectKindProvider(variableManager -> "") //$NON-NLS-1$
                 .targetObjectLabelProvider(variableManager -> "")//$NON-NLS-1$


### PR DESCRIPTION
Bug: #689
Signed-off-by: Nicolas Vannier <nicolas.vannier@obeo.fr>

### Type of this PR 

- [ ] Bug fix
- [X] New feature or improvement
- [ ] Documentation
- [ ] Cleanup
- [ ] Test
- [ ] Build/Releng

### Issue(s)

#689 

### What does this PR do?

- Implementations of `IObjectService` must now implement `getObjects` in addition of current `getObject`
- Added variable containing objects ids to render for unsynchronized nodes rendering, improving performance
- Added specific semantic elements provider for unsynchronized nodes for converted diagram descriptions

### Screenshot/screencast of this PR

### Potential side effects

### How to test this PR?

- [ ] Frontend Unit tests
- [ ] Backend Unit tests
- [ ] Cypress : please specify
- [ ] Manual Test : please specify

### Checklist

- [] I have read CONTRIBUTING carefully.
- [] I have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [] All my commits are signed-off (`-s`) with my mail address of my Eclipse Account.
- [] I have covered my changes by unit tests or integration tests or manual tests.
- [] All tests pass.
- [] I have updated the documentation accordingly
- [ ] New React components are availables in storybook
