### PR TITLE
[doc] Add ADR for form descriptions in the view converter support

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -6,7 +6,8 @@
 
 - [ADR-50] Add support for multiple selection entries in the details view
 - [ADR-51] Add support for form descriptions in the View DSL
-- [ADR-52] Add Support for EditingContext actions
+- [ADR-52] Add support for EditingContext actions
+- [ADR-53] Add support for form descriptions in the view converter
 
 === Deprecation warning
 

--- a/doc/adrs/053_add_support_for_form_descriptions_in_the_view_converter.adoc
+++ b/doc/adrs/053_add_support_for_form_descriptions_in_the_view_converter.adoc
@@ -1,0 +1,44 @@
+= ADR-053 - Add support for form descriptions in the view converter
+
+== Context
+
+The RepresentationDescriptions in the View DSL needs to be converted in the supported type `org.eclipse.sirius.components.representations.IRepresentationDescription`.
+
+For now, only `DiagramDescription` are converted by the `ViewConverter`.
+
+== Decision
+
+We need to create and add a `FormDescriptionConverter` to the `ViewConverter`.
+The `ViewConverter.convert()` method statically converts DiagramDescription:
+
+```            
+result = view.getDescriptions().stream()
+    .filter(org.eclipse.sirius.components.view.DiagramDescription.class::isInstance)
+    .map(org.eclipse.sirius.components.view.DiagramDescription.class::cast)
+    .map(viewDiagramDescription -> this.convertDiagramDescription(viewDiagramDescription, interpreter))
+    .collect(Collectors.toList());
+                         
+```
+
+We need to modify this logic to dispatch to the correct converter according to the `IRepresentationDescription` concrete type.
+We will create a common interface `IRepresentationDescriptionConverter` for `FormDescriptionConverter` and `DiagramDescriptionConverter`. The `ViewConverter` will no longer reference a specific converter implementation.
+
+The `FormDescriptionConverter` will create a new `org.eclipse.sirius.components.forms.description.FormDescription`. The DSL does not yet handle Pages and Groups. The converter will create a default page and group.
+
+As a first step, we will only convert `TextfieldDescription`. The Textfield Widget will be read only for now.
+
+Since the View DSL does not yet allow defining behavior on the Textfield Widget, the following fields from `TextfieldDescription` will be provided with default values:
+
+* `textfieldDescription.newValueHandler`: Will do nothing for now.
+* `textfieldDescription.diagnosticsProvider`: Will return an empty list.
+* `textfieldDescription.kindProvider`: Will return an empty String.
+* `textfieldDescription.messageProvider`: Will return an empty String.
+
+
+== Status
+
+WIP
+
+== Consequences
+
+We will be able to create a new Form Representation based on a defined FormDescription. This representation will just allow to display Textfield with a computed value but without editing capabilities in a first step.


### PR DESCRIPTION
Bug: https://github.com/eclipse-sirius/sirius-components/issues/1152
Signed-off-by: Florian Barbin <florian.barbin@obeo.fr>

### Type of this PR 

- [ ] Bug fix
- [x] New feature or improvement
- [x] Documentation
- [ ] Cleanup
- [ ] Test
- [ ] Build/Releng

### Issue(s)
#1152 
...

### What does this PR do?
Add the ADR for the support for form descriptions in the view converter
...

### Screenshot/screencast of this PR

...
 

### Potential side effects

...

### How to test this PR?

- [ ] Frontend Unit tests
- [ ] Backend Unit tests
- [ ] Cypress : please specify
- [ ] Manual Test : please specify

### Checklist

- [ ] I have read CONTRIBUTING carefully.
- [x] I have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All my commits are signed-off (`-s`) with my mail address of my Eclipse Account.
- [ ] I have covered my changes by unit tests or integration tests or manual tests.
- [ ] All tests pass.
- [ ] I have updated the documentation accordingly
- [ ] New React components are availables in storybook
