### PR TITLE
[1152] Add support for form in the view converter

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -39,8 +39,8 @@ This will allow us, when we will receive an operation to perform with a given re
 - https://github.com/eclipse-sirius/sirius-components/issues/1112[#1112] [explorer] Add support for Ctrl+click or ⌘+click to select multiple elements in the explorer
 - https://github.com/eclipse-sirius/sirius-components/issues/1116[#1116] [form] Add support for multiple selection entries in the details view
 - https://github.com/eclipse-sirius/sirius-components/issues/1117[#1117] [diagram] Add support for multiple selections in a diagram. This work only display the various selection entries in the diagram. It does not support Ctrl+click or ⌘+click in a diagram. Support for this feature would require additional work with major improvements in the lifecycle of the `DiagramServer``
-- https://github.com/eclipse-sirius/sirius-components/issues/1146[#1146] [core] Add support for EditingContext actions. 
-
+- https://github.com/eclipse-sirius/sirius-components/issues/1146[#1146] [core] Add support for EditingContext actions
+- https://github.com/eclipse-sirius/sirius-components/issues/1152[#1152] [form] Add support for form descriptions in the view converter 
 == v2022.3.0
 
 === Architectural decision records

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -15,7 +15,7 @@
 
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components</artifactId>
-	<version>2022.3.6</version>
+	<version>2022.3.7</version>
 
 	<name>sirius-components</name>
 	<description>Sirius Components</description>

--- a/backend/sirius-components-annotations-spring/pom.xml
+++ b/backend/sirius-components-annotations-spring/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-annotations-spring</artifactId>
-	<version>2022.3.6</version>
+	<version>2022.3.7</version>
 	<name>sirius-components-annotations-spring</name>
 	<description>Sirius Components Annotations Spring</description>
 

--- a/backend/sirius-components-annotations/pom.xml
+++ b/backend/sirius-components-annotations/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-annotations</artifactId>
-	<version>2022.3.6</version>
+	<version>2022.3.7</version>
 	<name>sirius-components-annotations</name>
 	<description>Sirius Components Annotations</description>
 

--- a/backend/sirius-components-collaborative-diagrams/pom.xml
+++ b/backend/sirius-components-collaborative-diagrams/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-collaborative-diagrams</artifactId>
-	<version>2022.3.6</version>
+	<version>2022.3.7</version>
 	<name>sirius-components-collaborative-diagrams</name>
 	<description>Sirius Components Collaborative Diagrams</description>
 
@@ -50,34 +50,34 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-layout-api</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-tests</artifactId>
-    		<version>2022.3.6</version>
+    		<version>2022.3.7</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-spring-tests</artifactId>
-    		<version>2022.3.6</version>
+    		<version>2022.3.7</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-tests</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/backend/sirius-components-collaborative-forms/pom.xml
+++ b/backend/sirius-components-collaborative-forms/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-collaborative-forms</artifactId>
-	<version>2022.3.6</version>
+	<version>2022.3.7</version>
 	<name>sirius-components-collaborative-forms</name>
 	<description>Sirius Components Collaborative Forms</description>
 
@@ -50,23 +50,23 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-forms</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-tests</artifactId>
-    		<version>2022.3.6</version>
+    		<version>2022.3.7</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-spring-tests</artifactId>
-    		<version>2022.3.6</version>
+    		<version>2022.3.7</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>

--- a/backend/sirius-components-collaborative-selection/pom.xml
+++ b/backend/sirius-components-collaborative-selection/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-collaborative-selection</artifactId>
-	<version>2022.3.6</version>
+	<version>2022.3.7</version>
 	<name>sirius-components-collaborative-selection</name>
 	<description>Sirius Components Collaborative Selection</description>
 
@@ -43,7 +43,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-selection</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>
@@ -56,18 +56,18 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/backend/sirius-components-collaborative-trees/pom.xml
+++ b/backend/sirius-components-collaborative-trees/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-collaborative-trees</artifactId>
-	<version>2022.3.6</version>
+	<version>2022.3.7</version>
 	<name>sirius-components-collaborative-trees</name>
 	<description>Sirius Components Collaborative Trees</description>
 
@@ -42,12 +42,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-trees</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>
@@ -64,13 +64,13 @@
 		<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-tests</artifactId>
-    		<version>2022.3.6</version>
+    		<version>2022.3.7</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-spring-tests</artifactId>
-    		<version>2022.3.6</version>
+    		<version>2022.3.7</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>

--- a/backend/sirius-components-collaborative-validation/pom.xml
+++ b/backend/sirius-components-collaborative-validation/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-collaborative-validation</artifactId>
-	<version>2022.3.6</version>
+	<version>2022.3.7</version>
 	<name>sirius-components-collaborative-validation</name>
 	<description>Sirius Components Collaborative Validation</description>
 	
@@ -46,12 +46,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-validation</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -61,13 +61,13 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 			<scope>test</scope>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-spring-tests</artifactId>
-    		<version>2022.3.6</version>
+    		<version>2022.3.7</version>
     		<scope>test</scope>
     	</dependency>
 	</dependencies>

--- a/backend/sirius-components-collaborative/pom.xml
+++ b/backend/sirius-components-collaborative/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-collaborative</artifactId>
-	<version>2022.3.6</version>
+	<version>2022.3.7</version>
 	<name>sirius-components-collaborative</name>
 	<description>Sirius Components Collaborative</description>
 
@@ -66,12 +66,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-core</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -80,13 +80,13 @@
 		<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-tests</artifactId>
-    		<version>2022.3.6</version>
+    		<version>2022.3.7</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-spring-tests</artifactId>
-    		<version>2022.3.6</version>
+    		<version>2022.3.7</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>

--- a/backend/sirius-components-compatibility/pom.xml
+++ b/backend/sirius-components-compatibility/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-compatibility</artifactId>
-	<version>2022.3.6</version>
+	<version>2022.3.7</version>
 	<name>sirius-components-compatibility</name>
 	<description>Sirius Components Compatibility</description>
 
@@ -63,7 +63,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -73,43 +73,43 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-core</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-diagrams</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-forms</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-forms</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-selection</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-trees</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-interpreter</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.emf</groupId>

--- a/backend/sirius-components-core/pom.xml
+++ b/backend/sirius-components-core/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-core</artifactId>
-	<version>2022.3.6</version>
+	<version>2022.3.7</version>
 	<name>sirius-components-core</name>
 	<description>Sirius Components Core</description>
 
@@ -51,17 +51,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend/sirius-components-diagrams-layout-api/pom.xml
+++ b/backend/sirius-components-diagrams-layout-api/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-diagrams-layout-api</artifactId>
-	<version>2022.3.6</version>
+	<version>2022.3.7</version>
 	<name>sirius-components-diagrams-layout-api</name>
 	<description>Sirius Components Diagrams Layout API</description>
 
@@ -42,12 +42,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-core</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 	</dependencies>
 

--- a/backend/sirius-components-diagrams-layout/pom.xml
+++ b/backend/sirius-components-diagrams-layout/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-diagrams-layout</artifactId>
-	<version>2022.3.6</version>
+	<version>2022.3.7</version>
 	<name>sirius-components-diagrams-layout</name>
 	<description>Sirius Components Diagrams layout</description>
 
@@ -65,17 +65,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-core</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-layout-api</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.elk</groupId>
@@ -112,7 +112,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -127,18 +127,18 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-tests</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-diagrams</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/backend/sirius-components-diagrams-tests/pom.xml
+++ b/backend/sirius-components-diagrams-tests/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-diagrams-tests</artifactId>
-	<version>2022.3.6</version>
+	<version>2022.3.7</version>
 	<name>sirius-components-diagrams-tests</name>
 	<description>Sirius Components Diagrams Tests</description>
 
@@ -46,12 +46,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-core</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.assertj</groupId>

--- a/backend/sirius-components-diagrams/pom.xml
+++ b/backend/sirius-components-diagrams/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-diagrams</artifactId>
-	<version>2022.3.6</version>
+	<version>2022.3.7</version>
 	<name>sirius-components-diagrams</name>
 	<description>Sirius Components Diagrams</description>
 
@@ -42,7 +42,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -52,7 +52,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend/sirius-components-domain-design/pom.xml
+++ b/backend/sirius-components-domain-design/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-domain-design</artifactId>
-	<version>2022.3.6</version>
+	<version>2022.3.7</version>
 	<name>sirius-components-domain-design</name>
 	<description>Sirius Components Domain Definition DSL - Graphical Modeler Definition</description>
 
@@ -64,7 +64,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-domain</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 	</dependencies>
 	

--- a/backend/sirius-components-domain-edit/pom.xml
+++ b/backend/sirius-components-domain-edit/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-domain-edit</artifactId>
-	<version>2022.3.6</version>
+	<version>2022.3.7</version>
 	<name>sirius-components-domain-edit</name>
 	<description>Sirius Components Domain Definition DSL - Edit Support</description>
 
@@ -64,7 +64,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-domain</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 	</dependencies>
 	

--- a/backend/sirius-components-domain/pom.xml
+++ b/backend/sirius-components-domain/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-domain</artifactId>
-	<version>2022.3.6</version>
+	<version>2022.3.7</version>
 	<name>sirius-components-domain</name>
 	<description>Sirius Components Domain Definition DSL</description>
 

--- a/backend/sirius-components-emf/pom.xml
+++ b/backend/sirius-components-emf/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-emf</artifactId>
-	<version>2022.3.6</version>
+	<version>2022.3.7</version>
 	<name>sirius-components-emf</name>
 	<description>Sirius Components EMF</description>
 
@@ -62,52 +62,52 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql-api</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-diagrams</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-forms</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-trees</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-validation</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-compatibility</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-interpreter</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-domain</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.emf</groupId>
@@ -156,19 +156,19 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-tests</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend/sirius-components-emf/src/main/java/org/eclipse/sirius/components/emf/view/IRepresentationDescriptionConverter.java
+++ b/backend/sirius-components-emf/src/main/java/org/eclipse/sirius/components/emf/view/IRepresentationDescriptionConverter.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.emf.view;
+
+import org.eclipse.sirius.components.interpreter.AQLInterpreter;
+import org.eclipse.sirius.components.representations.IRepresentationDescription;
+import org.eclipse.sirius.components.view.RepresentationDescription;
+
+/**
+ * Interface for {@link RepresentationDescription} converters.
+ *
+ * @author fbarbin
+ */
+public interface IRepresentationDescriptionConverter {
+
+    boolean canConvert(RepresentationDescription representationDescription);
+
+    IRepresentationDescription convert(RepresentationDescription representationDescription, AQLInterpreter interpreter);
+}

--- a/backend/sirius-components-emf/src/main/java/org/eclipse/sirius/components/emf/view/IViewConverter.java
+++ b/backend/sirius-components-emf/src/main/java/org/eclipse/sirius/components/emf/view/IViewConverter.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.emf.view;
+
+import java.util.List;
+
+import org.eclipse.emf.ecore.EPackage;
+import org.eclipse.sirius.components.representations.IRepresentationDescription;
+import org.eclipse.sirius.components.view.View;
+
+/**
+ * Interface for ViewConverter services.
+ *
+ * @author fbarbin
+ */
+public interface IViewConverter {
+
+    /**
+     * Extract and convert the {@link IRepresentationDescription} from a {@link View} model.
+     */
+    List<IRepresentationDescription> convert(View view, List<EPackage> visibleEPackages);
+}

--- a/backend/sirius-components-emf/src/main/java/org/eclipse/sirius/components/emf/view/diagram/ViewDiagramDescriptionConverter.java
+++ b/backend/sirius-components-emf/src/main/java/org/eclipse/sirius/components/emf/view/diagram/ViewDiagramDescriptionConverter.java
@@ -49,6 +49,7 @@ import org.eclipse.sirius.components.diagrams.tools.SingleClickOnTwoDiagramEleme
 import org.eclipse.sirius.components.diagrams.tools.ToolSection;
 import org.eclipse.sirius.components.emf.compatibility.DomainClassPredicate;
 import org.eclipse.sirius.components.emf.view.CanonicalBehaviors;
+import org.eclipse.sirius.components.emf.view.IRepresentationDescriptionConverter;
 import org.eclipse.sirius.components.emf.view.ToolInterpreter;
 import org.eclipse.sirius.components.interpreter.AQLInterpreter;
 import org.eclipse.sirius.components.interpreter.Result;
@@ -64,14 +65,17 @@ import org.eclipse.sirius.components.view.EdgeTool;
 import org.eclipse.sirius.components.view.LabelEditTool;
 import org.eclipse.sirius.components.view.NodeStyle;
 import org.eclipse.sirius.components.view.NodeTool;
+import org.eclipse.sirius.components.view.RepresentationDescription;
 import org.eclipse.sirius.components.view.ViewPackage;
+import org.springframework.stereotype.Service;
 
 /**
  * Converts a View-based diagram description into an equivalent {@link DiagramDescription}.
  *
  * @author pcdavid
  */
-public class DiagramDescriptionConverter {
+@Service
+public class ViewDiagramDescriptionConverter implements IRepresentationDescriptionConverter {
     private static final String DEFAULT_DIAGRAM_LABEL = "Diagram"; //$NON-NLS-1$
 
     private static final String NODE_CREATION_TOOL_SECTION = "Node Creation"; //$NON-NLS-1$
@@ -105,7 +109,7 @@ public class DiagramDescriptionConverter {
 
     private Map<org.eclipse.sirius.components.view.EdgeDescription, EdgeDescription> convertedEdges;
 
-    public DiagramDescriptionConverter(IObjectService objectService, IEditService editService) {
+    public ViewDiagramDescriptionConverter(IObjectService objectService, IEditService editService) {
         this.objectService = Objects.requireNonNull(objectService);
         this.editService = Objects.requireNonNull(editService);
         this.stylesFactory = new StylesFactory();
@@ -115,7 +119,14 @@ public class DiagramDescriptionConverter {
         this.canonicalBehaviors = new CanonicalBehaviors(objectService, editService);
     }
 
-    public DiagramDescription convert(org.eclipse.sirius.components.view.DiagramDescription viewDiagramDescription, AQLInterpreter interpreter) {
+    @Override
+    public boolean canConvert(RepresentationDescription representationDescription) {
+        return representationDescription instanceof org.eclipse.sirius.components.view.DiagramDescription;
+    }
+
+    @Override
+    public IRepresentationDescription convert(RepresentationDescription viewRepresentationDescription, AQLInterpreter interpreter) {
+        org.eclipse.sirius.components.view.DiagramDescription viewDiagramDescription = (org.eclipse.sirius.components.view.DiagramDescription) viewRepresentationDescription;
         this.convertedNodes = new HashMap<>();
         this.convertedEdges = new HashMap<>();
         try {
@@ -560,4 +571,5 @@ public class DiagramDescriptionConverter {
     private IDiagramContext getDiagramContext(VariableManager variableManager) {
         return variableManager.get(IDiagramContext.DIAGRAM_CONTEXT, IDiagramContext.class).orElse(null);
     }
+
 }

--- a/backend/sirius-components-emf/src/main/java/org/eclipse/sirius/components/emf/view/form/ViewFormDescriptionConverter.java
+++ b/backend/sirius-components-emf/src/main/java/org/eclipse/sirius/components/emf/view/form/ViewFormDescriptionConverter.java
@@ -1,0 +1,178 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.emf.view.form;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.eclipse.sirius.components.compatibility.forms.WidgetIdProvider;
+import org.eclipse.sirius.components.compatibility.utils.StringValueProvider;
+import org.eclipse.sirius.components.core.api.IObjectService;
+import org.eclipse.sirius.components.emf.compatibility.DomainClassPredicate;
+import org.eclipse.sirius.components.emf.view.IRepresentationDescriptionConverter;
+import org.eclipse.sirius.components.forms.description.AbstractControlDescription;
+import org.eclipse.sirius.components.forms.description.FormDescription;
+import org.eclipse.sirius.components.forms.description.GroupDescription;
+import org.eclipse.sirius.components.forms.description.PageDescription;
+import org.eclipse.sirius.components.forms.description.TextfieldDescription;
+import org.eclipse.sirius.components.interpreter.AQLInterpreter;
+import org.eclipse.sirius.components.representations.Failure;
+import org.eclipse.sirius.components.representations.GetOrCreateRandomIdProvider;
+import org.eclipse.sirius.components.representations.IRepresentationDescription;
+import org.eclipse.sirius.components.representations.VariableManager;
+import org.eclipse.sirius.components.view.RepresentationDescription;
+import org.springframework.stereotype.Service;
+
+/**
+ * Converts a View-based form description into an equivalent {@link FormDescription}.
+ *
+ * @author fbarbin
+ */
+@Service
+public class ViewFormDescriptionConverter implements IRepresentationDescriptionConverter {
+
+    private static final String DEFAULT_FORM_LABEL = "Form"; //$NON-NLS-1$
+
+    private final IObjectService objectService;
+
+    public ViewFormDescriptionConverter(IObjectService objectService) {
+        this.objectService = Objects.requireNonNull(objectService);
+    }
+
+    @Override
+    public boolean canConvert(RepresentationDescription representationDescription) {
+        return representationDescription instanceof org.eclipse.sirius.components.view.FormDescription;
+    }
+
+    @Override
+    public IRepresentationDescription convert(RepresentationDescription representationDescription, AQLInterpreter interpreter) {
+        org.eclipse.sirius.components.view.FormDescription viewFormDescription = (org.eclipse.sirius.components.view.FormDescription) representationDescription;
+        // @formatter:off
+        List<AbstractControlDescription> textfieldDescriptions = viewFormDescription.getWidgets().stream()
+                .filter(org.eclipse.sirius.components.view.TextfieldDescription.class::isInstance)
+                .map(org.eclipse.sirius.components.view.TextfieldDescription.class::cast)
+                .map(viewTextfieldDescription -> this.convertTextfieldDescriptionviewTextfieldDescription(viewTextfieldDescription, interpreter))
+                .collect(Collectors.toList());
+
+        Function<VariableManager, List<?>> semanticElementsProvider = variableManager -> variableManager.get(VariableManager.SELF, Object.class).stream()
+                .collect(Collectors.toList());
+
+        String descriptionId = this.getDescriptionId(viewFormDescription);
+        GroupDescription groupDescription = GroupDescription.newGroupDescription(descriptionId + "_group") //$NON-NLS-1$
+                .idProvider(new GetOrCreateRandomIdProvider())
+                .labelProvider(variableManager -> this.computeFormLabel(viewFormDescription, variableManager, interpreter))
+                .semanticElementsProvider(semanticElementsProvider)
+                .controlDescriptions(textfieldDescriptions)
+                .build();
+        PageDescription pageDescription = PageDescription.newPageDescription(descriptionId + "_page") //$NON-NLS-1$
+                .idProvider(new GetOrCreateRandomIdProvider())
+                .labelProvider(variableManager -> this.computeFormLabel(viewFormDescription, variableManager, interpreter))
+                .semanticElementsProvider(semanticElementsProvider)
+                .canCreatePredicate(variableManager -> true)
+                .groupDescriptions(List.of(groupDescription))
+                .build();
+
+
+        // @formatter:on
+        List<GroupDescription> groupDescriptions = List.of(groupDescription);
+        List<PageDescription> pageDescriptions = List.of(pageDescription);
+
+        // @formatter:off
+        Function<VariableManager, String> targetObjectIdProvider = variableManager -> {
+            return this.self(variableManager)
+                .filter(self -> self instanceof List<?>)
+                .map(self -> (List<?>) self)
+                .flatMap(self -> self.stream().findFirst())
+                .map(this.objectService::getId)
+                .orElse(null);
+        };
+
+        return FormDescription.newFormDescription(descriptionId)
+                .label(Optional.ofNullable(viewFormDescription.getName()).orElse(DEFAULT_FORM_LABEL))
+                .idProvider(new GetOrCreateRandomIdProvider())
+                .labelProvider(variableManager -> this.computeFormLabel(viewFormDescription, variableManager, interpreter))
+                .canCreatePredicate(variableManager -> this.canCreatForm(viewFormDescription, variableManager, interpreter))
+                .targetObjectIdProvider(targetObjectIdProvider)
+                .pageDescriptions(pageDescriptions)
+                .groupDescriptions(groupDescriptions)
+                .build();
+        // @formatter:on
+    }
+
+    private String getDescriptionId(EObject description) {
+        String descriptionURI = EcoreUtil.getURI(description).toString();
+        return UUID.nameUUIDFromBytes(descriptionURI.getBytes()).toString();
+    }
+
+    private String computeFormLabel(org.eclipse.sirius.components.view.FormDescription viewFormDescription, VariableManager variableManager, AQLInterpreter interpreter) {
+        String title = this.evaluateString(interpreter, variableManager, viewFormDescription.getTitleExpression());
+        if (title == null || title.isBlank()) {
+            return DEFAULT_FORM_LABEL;
+        } else {
+            return title;
+        }
+    }
+
+    private String evaluateString(AQLInterpreter interpreter, VariableManager variableManager, String expression) {
+        return interpreter.evaluateExpression(variableManager.getVariables(), expression).asString().orElse(""); //$NON-NLS-1$
+    }
+
+    private boolean canCreatForm(org.eclipse.sirius.components.view.FormDescription viewFormDescription, VariableManager variableManager, AQLInterpreter interpreter) {
+        boolean result = false;
+        // @formatter:off
+        Optional<EClass> optionalEClass = variableManager.get(IRepresentationDescription.CLASS, EClass.class)
+                .filter(new DomainClassPredicate(viewFormDescription.getDomainType()));
+        // @formatter:on
+        if (optionalEClass.isPresent()) {
+            String preconditionExpression = viewFormDescription.getPreconditionExpression();
+            if (preconditionExpression != null && !preconditionExpression.isBlank()) {
+                result = interpreter.evaluateExpression(variableManager.getVariables(), preconditionExpression).asBoolean().orElse(false);
+            } else {
+                result = true;
+            }
+        }
+        return result;
+    }
+
+    private Optional<Object> self(VariableManager variableManager) {
+        return variableManager.get(VariableManager.SELF, Object.class);
+    }
+
+    private TextfieldDescription convertTextfieldDescriptionviewTextfieldDescription(org.eclipse.sirius.components.view.TextfieldDescription viewTextfieldDescription, AQLInterpreter interpreter) {
+
+        String labelExpression = Optional.ofNullable(viewTextfieldDescription.getLabelExpression()).orElse(""); //$NON-NLS-1$
+        StringValueProvider labelProvider = new StringValueProvider(interpreter, labelExpression);
+
+        String valueExpression = Optional.ofNullable(viewTextfieldDescription.getValueExpression()).orElse(""); //$NON-NLS-1$
+        StringValueProvider valueProvider = new StringValueProvider(interpreter, valueExpression);
+
+        // @formatter:off
+        return TextfieldDescription.newTextfieldDescription(this.getDescriptionId(viewTextfieldDescription))
+                .idProvider(new WidgetIdProvider())
+                .labelProvider(labelProvider)
+                .valueProvider(valueProvider)
+                .newValueHandler((variableManager, newValue) -> new Failure("Value Handler not yet supported")) //$NON-NLS-1$
+                .diagnosticsProvider(variableManager -> List.of())
+                .kindProvider(diagnostic -> "") //$NON-NLS-1$
+                .messageProvider(diagnostic -> "") //$NON-NLS-1$
+                .build();
+        // @formatter:on
+    }
+}

--- a/backend/sirius-components-emf/src/test/java/org/eclipse/sirius/components/emf/view/DynamicDiagramsTests.java
+++ b/backend/sirius-components-emf/src/test/java/org/eclipse/sirius/components/emf/view/DynamicDiagramsTests.java
@@ -29,6 +29,7 @@ import org.eclipse.sirius.components.core.api.IObjectService;
 import org.eclipse.sirius.components.core.api.IRepresentationDescriptionSearchService;
 import org.eclipse.sirius.components.diagrams.Diagram;
 import org.eclipse.sirius.components.diagrams.layout.api.ILayoutService;
+import org.eclipse.sirius.components.emf.view.diagram.ViewDiagramDescriptionConverter;
 import org.eclipse.sirius.components.representations.IRepresentationDescription;
 import org.eclipse.sirius.components.view.DiagramDescription;
 import org.eclipse.sirius.components.view.NodeDescription;
@@ -127,7 +128,8 @@ public class DynamicDiagramsTests {
         View view = ViewFactory.eINSTANCE.createView();
         view.getDescriptions().add(diagramDescription);
 
-        var viewConverter = new ViewConverter(new IObjectService.NoOp(), new IEditService.NoOp(), List.of());
+        ViewDiagramDescriptionConverter diagramDescriptionConverter = new ViewDiagramDescriptionConverter(new IObjectService.NoOp(), new IEditService.NoOp());
+        var viewConverter = new ViewConverter(List.of(), List.of(diagramDescriptionConverter));
         List<IRepresentationDescription> conversionResult = viewConverter.convert(view, List.of(EcorePackage.eINSTANCE));
         assertThat(conversionResult).hasSize(1);
         assertThat(conversionResult.get(0)).isInstanceOf(org.eclipse.sirius.components.diagrams.description.DiagramDescription.class);

--- a/backend/sirius-components-emf/src/test/java/org/eclipse/sirius/components/emf/view/DynamicFormsTests.java
+++ b/backend/sirius-components-emf/src/test/java/org/eclipse/sirius/components/emf/view/DynamicFormsTests.java
@@ -1,0 +1,108 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.emf.view;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.EPackage;
+import org.eclipse.emf.ecore.EcoreFactory;
+import org.eclipse.emf.ecore.EcorePackage;
+import org.eclipse.sirius.components.core.api.IObjectService;
+import org.eclipse.sirius.components.emf.view.form.ViewFormDescriptionConverter;
+import org.eclipse.sirius.components.forms.AbstractWidget;
+import org.eclipse.sirius.components.forms.Form;
+import org.eclipse.sirius.components.forms.Page;
+import org.eclipse.sirius.components.forms.Textfield;
+import org.eclipse.sirius.components.forms.components.FormComponent;
+import org.eclipse.sirius.components.forms.components.FormComponentProps;
+import org.eclipse.sirius.components.forms.renderer.FormRenderer;
+import org.eclipse.sirius.components.representations.Element;
+import org.eclipse.sirius.components.representations.IRepresentationDescription;
+import org.eclipse.sirius.components.representations.VariableManager;
+import org.eclipse.sirius.components.view.FormDescription;
+import org.eclipse.sirius.components.view.TextfieldDescription;
+import org.eclipse.sirius.components.view.View;
+import org.eclipse.sirius.components.view.ViewFactory;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for dynamically defined forms.
+ *
+ * @author fbarbin
+ */
+public class DynamicFormsTests {
+
+    @Test
+    void testRenderEcoreForm() throws Exception {
+        FormDescription formDescription = ViewFactory.eINSTANCE.createFormDescription();
+        formDescription.setName("Simple Ecore Form"); //$NON-NLS-1$
+        formDescription.setTitleExpression("aql:self.name"); //$NON-NLS-1$
+        formDescription.setDomainType("ecore::EPackage"); //$NON-NLS-1$
+
+        TextfieldDescription textfieldDescription = ViewFactory.eINSTANCE.createTextfieldDescription();
+        textfieldDescription.setLabelExpression("aql:'EPackage name'"); //$NON-NLS-1$
+        textfieldDescription.setValueExpression("aql:self.name"); //$NON-NLS-1$
+        textfieldDescription.setName("Class Name"); //$NON-NLS-1$
+        formDescription.getWidgets().add(textfieldDescription);
+
+        Form result = this.render(formDescription, this.buildFixture());
+
+        assertThat(result).isNotNull();
+        assertThat(result.getPages()).hasSize(1);
+        assertThat(result.getPages()).extracting(Page::getGroups).hasSize(1);
+        result.getPages().stream().map(Page::getGroups).flatMap(List::stream).forEach(group -> {
+            assertThat(group.getWidgets()).hasSize(1);
+            AbstractWidget abstractWidget = group.getWidgets().stream().findFirst().get();
+            assertThat(abstractWidget).isInstanceOf(Textfield.class);
+            assertThat((Textfield) abstractWidget).extracting(Textfield::getValue).isEqualTo("fixture"); //$NON-NLS-1$
+            assertThat((Textfield) abstractWidget).extracting(Textfield::getLabel).isEqualTo("EPackage name"); //$NON-NLS-1$
+        });
+    }
+
+    private EPackage buildFixture() {
+        EPackage fixture = EcoreFactory.eINSTANCE.createEPackage();
+        fixture.setName("fixture"); //$NON-NLS-1$
+        EClass klass1 = EcoreFactory.eINSTANCE.createEClass();
+        klass1.setName("Class1"); //$NON-NLS-1$
+        fixture.getEClassifiers().add(klass1);
+        EClass klass2 = EcoreFactory.eINSTANCE.createEClass();
+        klass2.setName("Class2"); //$NON-NLS-1$
+        fixture.getEClassifiers().add(klass2);
+        return fixture;
+    }
+
+    private Form render(FormDescription formDescription, Object target) {
+        // Wrap into a View, as expected by ViewConverter
+        View view = ViewFactory.eINSTANCE.createView();
+        view.getDescriptions().add(formDescription);
+
+        ViewFormDescriptionConverter formDescriptionConverter = new ViewFormDescriptionConverter(new IObjectService.NoOp());
+        var viewConverter = new ViewConverter(List.of(), List.of(formDescriptionConverter));
+        List<IRepresentationDescription> conversionResult = viewConverter.convert(view, List.of(EcorePackage.eINSTANCE));
+        assertThat(conversionResult).hasSize(1);
+        assertThat(conversionResult.get(0)).isInstanceOf(org.eclipse.sirius.components.forms.description.FormDescription.class);
+        org.eclipse.sirius.components.forms.description.FormDescription convertedFormDescription = (org.eclipse.sirius.components.forms.description.FormDescription) conversionResult.get(0);
+
+        VariableManager variableManager = new VariableManager();
+        variableManager.put(VariableManager.SELF, List.of(target));
+
+        FormRenderer formRenderer = new FormRenderer();
+        FormComponentProps props = new FormComponentProps(variableManager, convertedFormDescription);
+        Element element = new Element(FormComponent.class, props);
+        return formRenderer.render(element);
+
+    }
+}

--- a/backend/sirius-components-forms-tests/pom.xml
+++ b/backend/sirius-components-forms-tests/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-forms-tests</artifactId>
-	<version>2022.3.6</version>
+	<version>2022.3.7</version>
 	<name>sirius-components-forms-tests</name>
 	<description>Sirius Components Forms Tests</description>
 
@@ -42,7 +42,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-forms</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.assertj</groupId>

--- a/backend/sirius-components-forms/pom.xml
+++ b/backend/sirius-components-forms/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-forms</artifactId>
-	<version>2022.3.6</version>
+	<version>2022.3.7</version>
 	<name>sirius-components-forms</name>
 	<description>Sirius Components Forms</description>
 
@@ -46,12 +46,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -61,7 +61,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/backend/sirius-components-graphiql/pom.xml
+++ b/backend/sirius-components-graphiql/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-graphiql</artifactId>
-	<version>2022.3.6</version>
+	<version>2022.3.7</version>
 	<name>sirius-components-graphiql</name>
 	<description>Sirius Components Graphiql support. This project contribute a GraphQL query tool on the /graphiql/index.html URI.</description>
 

--- a/backend/sirius-components-graphql-api/pom.xml
+++ b/backend/sirius-components-graphql-api/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-graphql-api</artifactId>
-	<version>2022.3.6</version>
+	<version>2022.3.7</version>
 	<name>sirius-components-graphql-api</name>
 	<description>Sirius Components GraphQL API</description>
 
@@ -48,7 +48,7 @@
     	<dependency>
         	<groupId>org.eclipse.sirius</groupId>
         	<artifactId>sirius-components-annotations-spring</artifactId>
-        	<version>2022.3.6</version>
+        	<version>2022.3.7</version>
     	</dependency>
 	</dependencies>
 

--- a/backend/sirius-components-graphql-utils/pom.xml
+++ b/backend/sirius-components-graphql-utils/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-graphql-utils</artifactId>
-	<version>2022.3.6</version>
+	<version>2022.3.7</version>
 	<name>sirius-components-graphql-utils</name>
 	<description>Sirius Components GraphQL Utils</description>
 
@@ -43,7 +43,7 @@
 		<dependency>
         	<groupId>org.eclipse.sirius</groupId>
         	<artifactId>sirius-components-annotations</artifactId>
-        	<version>2022.3.6</version>
+        	<version>2022.3.7</version>
     	</dependency>
 		<dependency>
         	<groupId>com.graphql-java</groupId>
@@ -53,7 +53,7 @@
     	<dependency>
    			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 			<scope>test</scope>
     	</dependency>
     	<dependency>

--- a/backend/sirius-components-graphql-voyager/pom.xml
+++ b/backend/sirius-components-graphql-voyager/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-graphql-voyager</artifactId>
-	<version>2022.3.6</version>
+	<version>2022.3.7</version>
 	<name>sirius-components-graphql-voyager</name>
 	<description>Sirius Components Graph Voyager. This project contribute a GraphQL API UX thanks to the https://github.com/APIs-guru/graphql-voyager project.</description>
 

--- a/backend/sirius-components-graphql/pom.xml
+++ b/backend/sirius-components-graphql/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-graphql</artifactId>
-	<version>2022.3.6</version>
+	<version>2022.3.7</version>
 	<name>sirius-components-graphql</name>
 	<description>Sirius Components GraphQL</description>
 
@@ -64,28 +64,28 @@
     	<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-annotations</artifactId>
-    		<version>2022.3.6</version>
+    		<version>2022.3.7</version>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-graphql-utils</artifactId>
-    		<version>2022.3.6</version>
+    		<version>2022.3.7</version>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-graphql-api</artifactId>
-    		<version>2022.3.6</version>
+    		<version>2022.3.7</version>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-tests</artifactId>
-    		<version>2022.3.6</version>
+    		<version>2022.3.7</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-spring-tests</artifactId>
-    		<version>2022.3.6</version>
+    		<version>2022.3.7</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>

--- a/backend/sirius-components-interpreter/pom.xml
+++ b/backend/sirius-components-interpreter/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-interpreter</artifactId>
-	<version>2022.3.6</version>
+	<version>2022.3.7</version>
 	<name>sirius-components-interpreter</name>
 	<description>Sirius Components Intepreter</description>
 

--- a/backend/sirius-components-representations/pom.xml
+++ b/backend/sirius-components-representations/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-representations</artifactId>
-	<version>2022.3.6</version>
+	<version>2022.3.7</version>
 	<name>sirius-components-representations</name>
 	<description>Sirius Components Representations</description>
 
@@ -46,7 +46,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 	</dependencies>
 

--- a/backend/sirius-components-selection/pom.xml
+++ b/backend/sirius-components-selection/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-selection</artifactId>
-	<version>2022.3.6</version>
+	<version>2022.3.7</version>
 	<name>sirius-components-selection</name>
 	<description>Sirius Components Selection</description>
 
@@ -42,17 +42,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend/sirius-components-spring-tests/pom.xml
+++ b/backend/sirius-components-spring-tests/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-spring-tests</artifactId>
-	<version>2022.3.6</version>
+	<version>2022.3.7</version>
 	<name>sirius-components-spring-tests</name>
 	<description>Sirius Components Spring Tests</description>
 
@@ -46,7 +46,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>

--- a/backend/sirius-components-starter/pom.xml
+++ b/backend/sirius-components-starter/pom.xml
@@ -15,7 +15,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-starter</artifactId>
-	<version>2022.3.6</version>
+	<version>2022.3.7</version>
 	<name>sirius-components-starter</name>
 	<description>Sirius Components Starter</description>
 
@@ -55,52 +55,52 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-layout</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-diagrams</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-forms</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-selection</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-trees</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-validation</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-emf</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-compatibility</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 	</dependencies>
 

--- a/backend/sirius-components-test-coverage/pom.xml
+++ b/backend/sirius-components-test-coverage/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-test-coverage</artifactId>
-	<version>2022.3.6</version>
+	<version>2022.3.7</version>
 	<name>sirius-components-test-coverage-aggregation</name>
 	<description>Sirius Web Test Coverage Aggregation</description>
 
@@ -42,142 +42,142 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations-spring</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-compatibility</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-core</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-layout</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-layout-api</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-domain</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-domain-design</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-domain-edit</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-emf</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-forms</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql-utils</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-interpreter</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-selection</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-diagrams</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-forms</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-selection</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-trees</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-validation</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql-api</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-trees</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-validation</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-edit</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 	</dependencies>
 

--- a/backend/sirius-components-tests/pom.xml
+++ b/backend/sirius-components-tests/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-tests</artifactId>
-	<version>2022.3.6</version>
+	<version>2022.3.7</version>
 	<name>sirius-components-tests</name>
 	<description>Sirius Components Tests</description>
 
@@ -51,7 +51,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 	</dependencies>
 

--- a/backend/sirius-components-trees/pom.xml
+++ b/backend/sirius-components-trees/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-trees</artifactId>
-	<version>2022.3.6</version>
+	<version>2022.3.7</version>
 	<name>sirius-components-trees</name>
 	<description>Sirius Components Trees</description>
 
@@ -42,17 +42,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/backend/sirius-components-validation/pom.xml
+++ b/backend/sirius-components-validation/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-validation</artifactId>
-	<version>2022.3.6</version>
+	<version>2022.3.7</version>
 	<name>sirius-components-validation</name>
 	<description>Sirius Components Validation</description>
 	
@@ -47,12 +47,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend/sirius-components-view-edit/pom.xml
+++ b/backend/sirius-components-view-edit/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-view-edit</artifactId>
-	<version>2022.3.6</version>
+	<version>2022.3.7</version>
 	<name>sirius-components-view-edit</name>
 	<description>Sirius Components View Definition DSL - Edit Support</description>
 
@@ -64,7 +64,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view</artifactId>
-			<version>2022.3.6</version>
+			<version>2022.3.7</version>
 		</dependency>
 	</dependencies>
 	

--- a/backend/sirius-components-view/pom.xml
+++ b/backend/sirius-components-view/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-view</artifactId>
-	<version>2022.3.6</version>
+	<version>2022.3.7</version>
 	<name>sirius-components-view</name>
 	<description>Sirius Components View Definition DSL</description>
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@eclipse-sirius/sirius-components",
-  "version": "2022.3.6",
+  "version": "2022.3.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@eclipse-sirius/sirius-components",
-      "version": "2022.3.6",
+      "version": "2022.3.7",
       "license": "EPL-2.0",
       "dependencies": {
         "uuid": "8.3.2"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-sirius/sirius-components",
-  "version": "2022.3.6",
+  "version": "2022.3.7",
   "author": "Eclipse Sirius",
   "license": "EPL-2.0",
   "description": "Reusable components used to build the Sirius Web frontend",


### PR DESCRIPTION
### Type of this PR 

- [ ] Bug fix
- [x] New feature or improvement
- [ ] Documentation
- [ ] Cleanup
- [ ] Test
- [ ] Build/Releng

### Issue(s)
#1152 
...

### What does this PR do?

Refactor the ViewConverter to handle each kind of RepresentationDescription.
Add support for form in the view converter. We only handle a simple form with a read only textfield in this first version.
...

### Screenshot/screencast of this PR

...
 

### Potential side effects

...

### How to test this PR?

- [ ] Frontend Unit tests
- [x] Backend Unit tests
- [ ] Cypress : please specify
- [ ] Manual Test : please specify

### Checklist

- [ ] I have read CONTRIBUTING carefully.
- [x] I have signed the [Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
- [x] All my commits are signed-off (`-s`) with my mail address of my Eclipse Account.
- [ ] I have covered my changes by unit tests or integration tests or manual tests.
- [ ] All tests pass.
- [ ] I have updated the documentation accordingly
- [ ] New React components are availables in storybook
