### PR TITLE
[1176] Fix Exception in ViewDiagramDescriptionConverter

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -32,6 +32,7 @@ This will allow us, when we will receive an operation to perform with a given re
 
 - https://github.com/eclipse-sirius/sirius-components/issues/1154[#1154] [diagram] Display the palette where the click has been made, not where the cursor is. With the edge animation it was possible for the palette to be displayed at a wrong position which was making possible to create a floating edge.
 - https://github.com/eclipse-sirius/sirius-components/issues/1148[#1148] [diagram] Fix a lot of cases where removing an edge will change the layout of some other edges. This behavior will still happen when it will exist two edges between the two same elements and one of the edge is removed, the other edge will probably take the layout of the removed edge.
+- https://github.com/eclipse-sirius/sirius-components/issues/1176[#1176] [diagram] Fix potential ConcurrentModificationException in ViewDiagramDescriptionConverter when manipulating diagrams. This bug was introduced by the https://github.com/eclipse-sirius/sirius-components/issues/1152[#1152].
 
 === Improvements
 
@@ -39,6 +40,7 @@ This will allow us, when we will receive an operation to perform with a given re
 - https://github.com/eclipse-sirius/sirius-components/issues/1155[#1155] [workbench] The left and right panels now use a vertical bar of icons (instead of accordions) to select which view to display
 - https://github.com/eclipse-sirius/sirius-components/issues/966[#966] [diagram] Add the support source and target edge position ratio on the frontend side. For further explanation see ADR-055.
 - https://github.com/eclipse-sirius/sirius-components/issues/1179[#1179] [core] Move `WorkbenchSelection` and `WorkbenchSelectionEntry` to `sirius-components-representations` in order to let any representation use those classes. We may rename the `Selection` representation in the future in order to rename them to `Selection` and `SelectionEntry` to align the frontend and backend API
+- [releng] Detect the presence of classes without a public visibility or with a package or protected constructor in order to speed up the code reviews.
 
 === New features
 

--- a/backend/sirius-components-diagrams-layout/src/main/java/org/eclipse/sirius/components/diagrams/layout/incremental/BorderNodesOnSide.java
+++ b/backend/sirius-components-diagrams-layout/src/main/java/org/eclipse/sirius/components/diagrams/layout/incremental/BorderNodesOnSide.java
@@ -29,7 +29,7 @@ public class BorderNodesOnSide {
 
     private final RectangleSide side;
 
-    BorderNodesOnSide(RectangleSide side, List<NodeLayoutData> borderNodes) {
+    public BorderNodesOnSide(RectangleSide side, List<NodeLayoutData> borderNodes) {
         this.side = Objects.requireNonNull(side);
         this.borderNodes = Objects.requireNonNull(borderNodes);
     }

--- a/backend/sirius-components-emf/src/main/java/org/eclipse/sirius/components/emf/view/diagram/ViewDiagramDescriptionConverterContext.java
+++ b/backend/sirius-components-emf/src/main/java/org/eclipse/sirius/components/emf/view/diagram/ViewDiagramDescriptionConverterContext.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.emf.view.diagram;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import org.eclipse.sirius.components.diagrams.description.EdgeDescription;
+import org.eclipse.sirius.components.diagrams.description.NodeDescription;
+import org.eclipse.sirius.components.interpreter.AQLInterpreter;
+
+/**
+ * Represents the context used while converting a View DiagramDescription.
+ *
+ * @author fbarbin
+ */
+public class ViewDiagramDescriptionConverterContext {
+
+    private final Map<org.eclipse.sirius.components.view.NodeDescription, NodeDescription> convertedNodes;
+
+    private final Map<org.eclipse.sirius.components.view.EdgeDescription, EdgeDescription> convertedEdges;
+
+    private final AQLInterpreter interpreter;
+
+    public ViewDiagramDescriptionConverterContext(AQLInterpreter interpreter) {
+        this.interpreter = Objects.requireNonNull(interpreter);
+        this.convertedNodes = new HashMap<>();
+        this.convertedEdges = new HashMap<>();
+    }
+
+    public Map<org.eclipse.sirius.components.view.EdgeDescription, EdgeDescription> getConvertedEdges() {
+        return this.convertedEdges;
+    }
+
+    public Map<org.eclipse.sirius.components.view.NodeDescription, NodeDescription> getConvertedNodes() {
+        return this.convertedNodes;
+    }
+
+    public AQLInterpreter getInterpreter() {
+        return this.interpreter;
+    }
+
+}


### PR DESCRIPTION
ViewDiagramDescriptionConverter is now a service but two attributes
convertedNodes and convertedEdges were mutable and used during the
conversion.

# Pull request template

## General purpose
What is the main goal of this pull request?
- [x] Bug fixes
- [ ] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [x] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [x] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [x] Have the relevant issues been added to the pull request?
- [x] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [x] Have the relevant issues been added to the same project and milestone as the pull request?
- [ ] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?

This issue has been detected from this attached 
[Company DSL.zip](https://github.com/eclipse-sirius/sirius-components/files/8563334/Company.DSL.zip).
* Import the DSL
* Create a new project
* Create a new "Company" model
* Create a new 'Employee" diag
* Create several employees diagrams

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution
?