### PR TITLE
[1260] Fix download fails when model contains a FormDescriptionEditor

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -17,6 +17,7 @@
 - https://github.com/eclipse-sirius/sirius-components/issues/1245[#1245] [form] Fix Dropping widget from FormDescriptionEditor opens new tab on Firefox
 - https://github.com/eclipse-sirius/sirius-components/issues/1253[#1253] [studio] Fix the computation of unsynchronized semantic elements in studios (which broke the use of the Create View operation)
 - https://github.com/eclipse-sirius/sirius-components/issues/1193[#1193] [layout] Fix edge layout on diagrams with node lists.
+- https://github.com/eclipse-sirius/sirius-components/issues/1260[#1260] [workbench] Fix download project fails when model contains a Form Description Editor
 
 === Improvements
 

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -15,7 +15,7 @@
 
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components</artifactId>
-	<version>2022.5.3</version>
+	<version>2022.5.4</version>
 
 	<name>sirius-components</name>
 	<description>Sirius Components</description>

--- a/backend/sirius-components-annotations-spring/pom.xml
+++ b/backend/sirius-components-annotations-spring/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-annotations-spring</artifactId>
-	<version>2022.5.3</version>
+	<version>2022.5.4</version>
 	<name>sirius-components-annotations-spring</name>
 	<description>Sirius Components Annotations Spring</description>
 

--- a/backend/sirius-components-annotations/pom.xml
+++ b/backend/sirius-components-annotations/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-annotations</artifactId>
-	<version>2022.5.3</version>
+	<version>2022.5.4</version>
 	<name>sirius-components-annotations</name>
 	<description>Sirius Components Annotations</description>
 

--- a/backend/sirius-components-charts/pom.xml
+++ b/backend/sirius-components-charts/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-charts</artifactId>
-	<version>2022.5.3</version>
+	<version>2022.5.4</version>
 	<name>sirius-components-charts</name>
 	<description>Sirius Components Charts</description>
 
@@ -53,7 +53,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -63,7 +63,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/backend/sirius-components-collaborative-charts/pom.xml
+++ b/backend/sirius-components-collaborative-charts/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-collaborative-charts</artifactId>
-	<version>2022.5.3</version>
+	<version>2022.5.4</version>
 	<name>sirius-components-collaborative-charts</name>
 	<description>Sirius Components Collaborative Charts</description>
 
@@ -50,23 +50,23 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-charts</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-tests</artifactId>
-    		<version>2022.5.3</version>
+    		<version>2022.5.4</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-spring-tests</artifactId>
-    		<version>2022.5.3</version>
+    		<version>2022.5.4</version>
     		<scope>test</scope>
     	</dependency>
 	</dependencies>

--- a/backend/sirius-components-collaborative-diagrams/pom.xml
+++ b/backend/sirius-components-collaborative-diagrams/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-collaborative-diagrams</artifactId>
-	<version>2022.5.3</version>
+	<version>2022.5.4</version>
 	<name>sirius-components-collaborative-diagrams</name>
 	<description>Sirius Components Collaborative Diagrams</description>
 
@@ -50,34 +50,34 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-layout-api</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-tests</artifactId>
-    		<version>2022.5.3</version>
+    		<version>2022.5.4</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-spring-tests</artifactId>
-    		<version>2022.5.3</version>
+    		<version>2022.5.4</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-tests</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/backend/sirius-components-collaborative-formdescriptioneditors/pom.xml
+++ b/backend/sirius-components-collaborative-formdescriptioneditors/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-collaborative-formdescriptioneditors</artifactId>
-	<version>2022.5.3</version>
+	<version>2022.5.4</version>
 	<name>sirius-components-collaborative-formdescriptioneditors</name>
 	<description>Sirius Components Collaborative FormDescriptionEditors</description>
 
@@ -50,23 +50,23 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-formdescriptioneditors</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-tests</artifactId>
-    		<version>2022.5.3</version>
+    		<version>2022.5.4</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-spring-tests</artifactId>
-    		<version>2022.5.3</version>
+    		<version>2022.5.4</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>

--- a/backend/sirius-components-collaborative-formdescriptioneditors/src/main/java/org/eclipse/sirius/components/collaborative/formdescriptioneditors/services/FormDescriptionEditorDeserializer.java
+++ b/backend/sirius-components-collaborative-formdescriptioneditors/src/main/java/org/eclipse/sirius/components/collaborative/formdescriptioneditors/services/FormDescriptionEditorDeserializer.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.collaborative.formdescriptioneditors.services;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import java.util.Optional;
+
+import org.eclipse.sirius.components.collaborative.api.IRepresentationDeserializer;
+import org.eclipse.sirius.components.formdescriptioneditors.FormDescriptionEditor;
+import org.eclipse.sirius.components.representations.IRepresentation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+/**
+ * Used to deserialize a form description editor.
+ *
+ * @author arichard
+ */
+@Service
+public class FormDescriptionEditorDeserializer implements IRepresentationDeserializer {
+
+    private final Logger logger = LoggerFactory.getLogger(FormDescriptionEditorDeserializer.class);
+
+    @Override
+    public boolean canHandle(ObjectNode root) {
+        // @formatter:off
+        return Optional.ofNullable(root.get("kind")) //$NON-NLS-1$
+                .map(JsonNode::asText)
+                .filter(FormDescriptionEditor.KIND::equals)
+                .isPresent();
+        // @formatter:on
+    }
+
+    @Override
+    public Optional<IRepresentation> handle(ObjectMapper mapper, ObjectNode root) {
+        try {
+            return Optional.of(mapper.readValue(root.toString(), FormDescriptionEditor.class));
+        } catch (JsonProcessingException exception) {
+            this.logger.warn(exception.getMessage(), exception);
+        }
+
+        return Optional.empty();
+    }
+
+}

--- a/backend/sirius-components-collaborative-forms/pom.xml
+++ b/backend/sirius-components-collaborative-forms/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-collaborative-forms</artifactId>
-	<version>2022.5.3</version>
+	<version>2022.5.4</version>
 	<name>sirius-components-collaborative-forms</name>
 	<description>Sirius Components Collaborative Forms</description>
 
@@ -50,23 +50,23 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-forms</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-tests</artifactId>
-    		<version>2022.5.3</version>
+    		<version>2022.5.4</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-spring-tests</artifactId>
-    		<version>2022.5.3</version>
+    		<version>2022.5.4</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>

--- a/backend/sirius-components-collaborative-selection/pom.xml
+++ b/backend/sirius-components-collaborative-selection/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-collaborative-selection</artifactId>
-	<version>2022.5.3</version>
+	<version>2022.5.4</version>
 	<name>sirius-components-collaborative-selection</name>
 	<description>Sirius Components Collaborative Selection</description>
 
@@ -43,7 +43,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-selection</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>
@@ -56,18 +56,18 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/backend/sirius-components-collaborative-trees/pom.xml
+++ b/backend/sirius-components-collaborative-trees/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-collaborative-trees</artifactId>
-	<version>2022.5.3</version>
+	<version>2022.5.4</version>
 	<name>sirius-components-collaborative-trees</name>
 	<description>Sirius Components Collaborative Trees</description>
 
@@ -42,12 +42,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-trees</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>
@@ -64,13 +64,13 @@
 		<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-tests</artifactId>
-    		<version>2022.5.3</version>
+    		<version>2022.5.4</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-spring-tests</artifactId>
-    		<version>2022.5.3</version>
+    		<version>2022.5.4</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>

--- a/backend/sirius-components-collaborative-validation/pom.xml
+++ b/backend/sirius-components-collaborative-validation/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-collaborative-validation</artifactId>
-	<version>2022.5.3</version>
+	<version>2022.5.4</version>
 	<name>sirius-components-collaborative-validation</name>
 	<description>Sirius Components Collaborative Validation</description>
 	
@@ -46,12 +46,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-validation</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -61,13 +61,13 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 			<scope>test</scope>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-spring-tests</artifactId>
-    		<version>2022.5.3</version>
+    		<version>2022.5.4</version>
     		<scope>test</scope>
     	</dependency>
 	</dependencies>

--- a/backend/sirius-components-collaborative/pom.xml
+++ b/backend/sirius-components-collaborative/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-collaborative</artifactId>
-	<version>2022.5.3</version>
+	<version>2022.5.4</version>
 	<name>sirius-components-collaborative</name>
 	<description>Sirius Components Collaborative</description>
 
@@ -66,12 +66,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-core</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -80,13 +80,13 @@
 		<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-tests</artifactId>
-    		<version>2022.5.3</version>
+    		<version>2022.5.4</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-spring-tests</artifactId>
-    		<version>2022.5.3</version>
+    		<version>2022.5.4</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>

--- a/backend/sirius-components-compatibility/pom.xml
+++ b/backend/sirius-components-compatibility/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-compatibility</artifactId>
-	<version>2022.5.3</version>
+	<version>2022.5.4</version>
 	<name>sirius-components-compatibility</name>
 	<description>Sirius Components Compatibility</description>
 
@@ -63,7 +63,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -73,43 +73,43 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-core</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-diagrams</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-forms</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-forms</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-selection</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-trees</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-interpreter</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.emf</groupId>

--- a/backend/sirius-components-core/pom.xml
+++ b/backend/sirius-components-core/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-core</artifactId>
-	<version>2022.5.3</version>
+	<version>2022.5.4</version>
 	<name>sirius-components-core</name>
 	<description>Sirius Components Core</description>
 
@@ -51,17 +51,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend/sirius-components-diagrams-layout-api/pom.xml
+++ b/backend/sirius-components-diagrams-layout-api/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-diagrams-layout-api</artifactId>
-	<version>2022.5.3</version>
+	<version>2022.5.4</version>
 	<name>sirius-components-diagrams-layout-api</name>
 	<description>Sirius Components Diagrams Layout API</description>
 
@@ -42,12 +42,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-core</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 	</dependencies>
 

--- a/backend/sirius-components-diagrams-layout/pom.xml
+++ b/backend/sirius-components-diagrams-layout/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-diagrams-layout</artifactId>
-	<version>2022.5.3</version>
+	<version>2022.5.4</version>
 	<name>sirius-components-diagrams-layout</name>
 	<description>Sirius Components Diagrams layout</description>
 
@@ -65,17 +65,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-core</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-layout-api</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.elk</groupId>
@@ -112,7 +112,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -127,18 +127,18 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-tests</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-diagrams</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/backend/sirius-components-diagrams-tests/pom.xml
+++ b/backend/sirius-components-diagrams-tests/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-diagrams-tests</artifactId>
-	<version>2022.5.3</version>
+	<version>2022.5.4</version>
 	<name>sirius-components-diagrams-tests</name>
 	<description>Sirius Components Diagrams Tests</description>
 
@@ -46,12 +46,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-core</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.assertj</groupId>

--- a/backend/sirius-components-diagrams/pom.xml
+++ b/backend/sirius-components-diagrams/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-diagrams</artifactId>
-	<version>2022.5.3</version>
+	<version>2022.5.4</version>
 	<name>sirius-components-diagrams</name>
 	<description>Sirius Components Diagrams</description>
 
@@ -42,7 +42,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -52,7 +52,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend/sirius-components-domain-design/pom.xml
+++ b/backend/sirius-components-domain-design/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-domain-design</artifactId>
-	<version>2022.5.3</version>
+	<version>2022.5.4</version>
 	<name>sirius-components-domain-design</name>
 	<description>Sirius Components Domain Definition DSL - Graphical Modeler Definition</description>
 
@@ -64,7 +64,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-domain</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 	</dependencies>
 	

--- a/backend/sirius-components-domain-edit/pom.xml
+++ b/backend/sirius-components-domain-edit/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-domain-edit</artifactId>
-	<version>2022.5.3</version>
+	<version>2022.5.4</version>
 	<name>sirius-components-domain-edit</name>
 	<description>Sirius Components Domain Definition DSL - Edit Support</description>
 
@@ -64,7 +64,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-domain</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 	</dependencies>
 	

--- a/backend/sirius-components-domain/pom.xml
+++ b/backend/sirius-components-domain/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-domain</artifactId>
-	<version>2022.5.3</version>
+	<version>2022.5.4</version>
 	<name>sirius-components-domain</name>
 	<description>Sirius Components Domain Definition DSL</description>
 

--- a/backend/sirius-components-emf/pom.xml
+++ b/backend/sirius-components-emf/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-emf</artifactId>
-	<version>2022.5.3</version>
+	<version>2022.5.4</version>
 	<name>sirius-components-emf</name>
 	<description>Sirius Components EMF</description>
 
@@ -62,52 +62,52 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql-api</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-diagrams</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-forms</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-trees</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-validation</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-compatibility</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-interpreter</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-domain</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.emf</groupId>
@@ -156,19 +156,19 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-tests</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-spring-tests</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend/sirius-components-formdescriptioneditors/pom.xml
+++ b/backend/sirius-components-formdescriptioneditors/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-formdescriptioneditors</artifactId>
-	<version>2022.5.3</version>
+	<version>2022.5.4</version>
 	<name>sirius-components-formdescriptioneditors</name>
 	<description>Sirius Components FormDescriptionEditors</description>
 
@@ -46,22 +46,22 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-core</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -71,7 +71,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/backend/sirius-components-forms-tests/pom.xml
+++ b/backend/sirius-components-forms-tests/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-forms-tests</artifactId>
-	<version>2022.5.3</version>
+	<version>2022.5.4</version>
 	<name>sirius-components-forms-tests</name>
 	<description>Sirius Components Forms Tests</description>
 
@@ -42,7 +42,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-forms</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.assertj</groupId>

--- a/backend/sirius-components-forms/pom.xml
+++ b/backend/sirius-components-forms/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-forms</artifactId>
-	<version>2022.5.3</version>
+	<version>2022.5.4</version>
 	<name>sirius-components-forms</name>
 	<description>Sirius Components Forms</description>
 
@@ -46,17 +46,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-charts</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -66,7 +66,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/backend/sirius-components-graphiql/pom.xml
+++ b/backend/sirius-components-graphiql/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-graphiql</artifactId>
-	<version>2022.5.3</version>
+	<version>2022.5.4</version>
 	<name>sirius-components-graphiql</name>
 	<description>Sirius Components Graphiql support. This project contribute a GraphQL query tool on the /graphiql/index.html URI.</description>
 

--- a/backend/sirius-components-graphql-api/pom.xml
+++ b/backend/sirius-components-graphql-api/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-graphql-api</artifactId>
-	<version>2022.5.3</version>
+	<version>2022.5.4</version>
 	<name>sirius-components-graphql-api</name>
 	<description>Sirius Components GraphQL API</description>
 
@@ -48,7 +48,7 @@
     	<dependency>
         	<groupId>org.eclipse.sirius</groupId>
         	<artifactId>sirius-components-annotations-spring</artifactId>
-        	<version>2022.5.3</version>
+        	<version>2022.5.4</version>
     	</dependency>
 	</dependencies>
 

--- a/backend/sirius-components-graphql-utils/pom.xml
+++ b/backend/sirius-components-graphql-utils/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-graphql-utils</artifactId>
-	<version>2022.5.3</version>
+	<version>2022.5.4</version>
 	<name>sirius-components-graphql-utils</name>
 	<description>Sirius Components GraphQL Utils</description>
 
@@ -43,7 +43,7 @@
 		<dependency>
         	<groupId>org.eclipse.sirius</groupId>
         	<artifactId>sirius-components-annotations</artifactId>
-        	<version>2022.5.3</version>
+        	<version>2022.5.4</version>
     	</dependency>
 		<dependency>
         	<groupId>com.graphql-java</groupId>
@@ -53,7 +53,7 @@
     	<dependency>
    			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 			<scope>test</scope>
     	</dependency>
     	<dependency>

--- a/backend/sirius-components-graphql-voyager/pom.xml
+++ b/backend/sirius-components-graphql-voyager/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-graphql-voyager</artifactId>
-	<version>2022.5.3</version>
+	<version>2022.5.4</version>
 	<name>sirius-components-graphql-voyager</name>
 	<description>Sirius Components Graph Voyager. This project contribute a GraphQL API UX thanks to the https://github.com/APIs-guru/graphql-voyager project.</description>
 

--- a/backend/sirius-components-graphql/pom.xml
+++ b/backend/sirius-components-graphql/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-graphql</artifactId>
-	<version>2022.5.3</version>
+	<version>2022.5.4</version>
 	<name>sirius-components-graphql</name>
 	<description>Sirius Components GraphQL</description>
 
@@ -64,28 +64,28 @@
     	<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-annotations</artifactId>
-    		<version>2022.5.3</version>
+    		<version>2022.5.4</version>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-graphql-utils</artifactId>
-    		<version>2022.5.3</version>
+    		<version>2022.5.4</version>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-graphql-api</artifactId>
-    		<version>2022.5.3</version>
+    		<version>2022.5.4</version>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-tests</artifactId>
-    		<version>2022.5.3</version>
+    		<version>2022.5.4</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>
     		<groupId>org.eclipse.sirius</groupId>
     		<artifactId>sirius-components-spring-tests</artifactId>
-    		<version>2022.5.3</version>
+    		<version>2022.5.4</version>
     		<scope>test</scope>
     	</dependency>
     	<dependency>

--- a/backend/sirius-components-interpreter/pom.xml
+++ b/backend/sirius-components-interpreter/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-interpreter</artifactId>
-	<version>2022.5.3</version>
+	<version>2022.5.4</version>
 	<name>sirius-components-interpreter</name>
 	<description>Sirius Components Intepreter</description>
 

--- a/backend/sirius-components-representations/pom.xml
+++ b/backend/sirius-components-representations/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-representations</artifactId>
-	<version>2022.5.3</version>
+	<version>2022.5.4</version>
 	<name>sirius-components-representations</name>
 	<description>Sirius Components Representations</description>
 
@@ -46,7 +46,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 	</dependencies>
 

--- a/backend/sirius-components-selection/pom.xml
+++ b/backend/sirius-components-selection/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-selection</artifactId>
-	<version>2022.5.3</version>
+	<version>2022.5.4</version>
 	<name>sirius-components-selection</name>
 	<description>Sirius Components Selection</description>
 
@@ -42,17 +42,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend/sirius-components-spring-tests/pom.xml
+++ b/backend/sirius-components-spring-tests/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-spring-tests</artifactId>
-	<version>2022.5.3</version>
+	<version>2022.5.4</version>
 	<name>sirius-components-spring-tests</name>
 	<description>Sirius Components Spring Tests</description>
 
@@ -46,7 +46,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>

--- a/backend/sirius-components-starter/pom.xml
+++ b/backend/sirius-components-starter/pom.xml
@@ -15,7 +15,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-starter</artifactId>
-	<version>2022.5.3</version>
+	<version>2022.5.4</version>
 	<name>sirius-components-starter</name>
 	<description>Sirius Components Starter</description>
 
@@ -55,62 +55,62 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-charts</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-layout</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-charts</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-diagrams</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-forms</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-selection</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-trees</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-validation</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-emf</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-compatibility</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 	</dependencies>
 

--- a/backend/sirius-components-test-coverage/pom.xml
+++ b/backend/sirius-components-test-coverage/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-test-coverage</artifactId>
-	<version>2022.5.3</version>
+	<version>2022.5.4</version>
 	<name>sirius-components-test-coverage-aggregation</name>
 	<description>Sirius Web Test Coverage Aggregation</description>
 
@@ -42,152 +42,152 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations-spring</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-compatibility</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-charts</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-core</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-layout</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-diagrams-layout-api</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-domain</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-domain-design</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-domain-edit</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-emf</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-forms</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql-utils</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-interpreter</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-selection</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-charts</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-diagrams</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-forms</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-selection</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-trees</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-collaborative-validation</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-graphql-api</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-trees</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-validation</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view-edit</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 	</dependencies>
 

--- a/backend/sirius-components-tests/pom.xml
+++ b/backend/sirius-components-tests/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-tests</artifactId>
-	<version>2022.5.3</version>
+	<version>2022.5.4</version>
 	<name>sirius-components-tests</name>
 	<description>Sirius Components Tests</description>
 
@@ -51,7 +51,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 	</dependencies>
 

--- a/backend/sirius-components-trees/pom.xml
+++ b/backend/sirius-components-trees/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-trees</artifactId>
-	<version>2022.5.3</version>
+	<version>2022.5.4</version>
 	<name>sirius-components-trees</name>
 	<description>Sirius Components Trees</description>
 
@@ -42,17 +42,17 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-annotations</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/backend/sirius-components-validation/pom.xml
+++ b/backend/sirius-components-validation/pom.xml
@@ -22,7 +22,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-validation</artifactId>
-	<version>2022.5.3</version>
+	<version>2022.5.4</version>
 	<name>sirius-components-validation</name>
 	<description>Sirius Components Validation</description>
 	
@@ -47,12 +47,12 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-representations</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-tests</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend/sirius-components-view-edit/pom.xml
+++ b/backend/sirius-components-view-edit/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-view-edit</artifactId>
-	<version>2022.5.3</version>
+	<version>2022.5.4</version>
 	<name>sirius-components-view-edit</name>
 	<description>Sirius Components View Definition DSL - Edit Support</description>
 
@@ -64,7 +64,7 @@
 		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-view</artifactId>
-			<version>2022.5.3</version>
+			<version>2022.5.4</version>
 		</dependency>
 	</dependencies>
 	

--- a/backend/sirius-components-view/pom.xml
+++ b/backend/sirius-components-view/pom.xml
@@ -23,7 +23,7 @@
 	</parent>
 	<groupId>org.eclipse.sirius</groupId>
 	<artifactId>sirius-components-view</artifactId>
-	<version>2022.5.3</version>
+	<version>2022.5.4</version>
 	<name>sirius-components-view</name>
 	<description>Sirius Components View Definition DSL</description>
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@eclipse-sirius/sirius-components",
-  "version": "2022.5.3",
+  "version": "2022.5.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@eclipse-sirius/sirius-components",
-      "version": "2022.5.3",
+      "version": "2022.5.4",
       "license": "EPL-2.0",
       "dependencies": {
         "uuid": "8.3.2"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-sirius/sirius-components",
-  "version": "2022.5.3",
+  "version": "2022.5.4",
   "author": "Eclipse Sirius",
   "license": "EPL-2.0",
   "description": "Reusable components used to build the Sirius Web frontend",


### PR DESCRIPTION
The download action on a Project fails when one of its model contains a
Form Description Editor.

Fix by implementing an o.e.s.c.collaborative.api.IRepresentationDeserializer for the FormDescriptionEditor.

Bug: https://github.com/eclipse-sirius/sirius-components/issues/1260
Signed-off-by: Axel RICHARD <axel.richard@obeo.fr>

# Pull request template

## General purpose
What is the main goal of this pull request?
- [x] Bug fixes
- [ ] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [x] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [x] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [x] Have the relevant issues been added to the pull request?
- [x] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [x] Have the relevant issues been added to the same project and milestone as the pull request?
- [x] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [x] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?