### PR TITLE
[1250] Fixed invoke tool effect hooks dependencies

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -39,6 +39,7 @@ This allows representation precondition expressions to be more precise as they k
 === Bug fixes
 
 - https://github.com/eclipse-sirius/sirius-components/issues/1287[#1287] [form] Fix wrong VariableManager scope usage in ViewFormDescriptionConverterSwitch.
+- https://github.com/eclipse-sirius/sirius-components/issues/1250[#1250] [diagram] Fix invoke tool effect hooks dependencies (to avoid evaluating the same tool result multiple times)
 
 === Improvements
 

--- a/packages/core/frontend/sirius-components-core/src/workbench/Workbench.tsx
+++ b/packages/core/frontend/sirius-components-core/src/workbench/Workbench.tsx
@@ -16,7 +16,7 @@ import Snackbar from '@material-ui/core/Snackbar';
 import { makeStyles } from '@material-ui/core/styles';
 import CloseIcon from '@material-ui/icons/Close';
 import { useMachine } from '@xstate/react';
-import React, { useContext, useEffect } from 'react';
+import React, { useCallback, useContext, useEffect } from 'react';
 import { Panels } from './Panels';
 import { RepresentationContext } from './RepresentationContext';
 import { RepresentationNavigation } from './RepresentationNavigation';
@@ -115,17 +115,20 @@ export const Workbench = ({
     }
   }, [error, dispatch]);
 
-  const setSelection = (selection: Selection) => {
-    const representations: Representation[] = selection.entries.filter((entry) =>
-      entry.kind.startsWith('siriusComponents://representation')
-    );
-    const updateSelectionEvent: UpdateSelectionEvent = {
-      type: 'UPDATE_SELECTION',
-      selection,
-      representations,
-    };
-    dispatch(updateSelectionEvent);
-  };
+  const setSelection = useCallback(
+    (selection: Selection) => {
+      const representations: Representation[] = selection.entries.filter((entry) =>
+        entry.kind.startsWith('siriusComponents://representation')
+      );
+      const updateSelectionEvent: UpdateSelectionEvent = {
+        type: 'UPDATE_SELECTION',
+        selection,
+        representations,
+      };
+      dispatch(updateSelectionEvent);
+    },
+    [dispatch]
+  );
 
   const onRepresentationClick = (representation: Representation) => {
     setSelection({ entries: [{ id: representation.id, label: representation.label, kind: representation.kind }] });

--- a/packages/diagrams/frontend/sirius-components-diagrams/src/representation/DiagramRepresentation.tsx
+++ b/packages/diagrams/frontend/sirius-components-diagrams/src/representation/DiagramRepresentation.tsx
@@ -877,7 +877,6 @@ export const DiagramRepresentation = ({
     handleError,
     resetTools,
     setSelection,
-    selection,
   ]);
   useEffect(() => {
     handleError(
@@ -900,7 +899,6 @@ export const DiagramRepresentation = ({
     invokeSingleClickOnTwoDiagramElementsToolError,
     handleError,
     setSelection,
-    selection,
   ]);
   useEffect(() => {
     handleError(arrangeAllLoading, arrangeAllData, arrangeAllError);


### PR DESCRIPTION
Bug: https://github.com/eclipse-sirius/sirius-components/issues/1250
Signed-off-by: Nicolas Vannier <nicolas.vannier@obeo.fr>

# Pull request template

## General purpose
What is the main goal of this pull request?
- [x] Bug fixes
- [ ] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [ ] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [x] Have the relevant issues been added to the pull request?
- [x] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [x] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [x] Variables have a proper type
- [x] Functions’ arguments have a proper type
- [x] Functions’ return type are specified
- Hooks are properly typed:
	- [x] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [x] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [x] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [x] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [x] `useState<STATE_TYPE>(…)`
- [x] All components have a proper typing for their props
- [x] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [x] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
the useEffect hooks evaluating invokeSingleClickOnTwoDiagramElementsToolData and invokeSingleClickOnDiagramElementToolData were executed each time a new selection was done in the diagram, now they are only executed when the corresponding mutations are executed.

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?