### PR TITLE
[1284] Remove tab when Form representation contains only one page

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -50,6 +50,7 @@ This allows representation precondition expressions to be more precise as they k
 - https://github.com/eclipse-sirius/sirius-components/issues/1318[#1318] [studio] Java service classes used by studios (via `IJavaServiceProvider`) can now ask to be injected with any Spring bean available in the application context (for example `IObjectService` or other Sirius Components services they need for their implementation).
 - https://github.com/eclipse-sirius/sirius-components/issues/1288[#1288] [core] Improve support for precondition expression from representation description
 - https://github.com/eclipse-sirius/sirius-components/issues/1269[#1269] [diagram] Prevent dropping elements in a read only diagram
+- https://github.com/eclipse-sirius/sirius-components/issues/1284[#1284] [form] Remove tab when Form representation contains only one page
 
 === New features
 

--- a/packages/forms/frontend/sirius-components-forms/src/representations/FormRepresentation.tsx
+++ b/packages/forms/frontend/sirius-components-forms/src/representations/FormRepresentation.tsx
@@ -26,6 +26,7 @@ import {
   widgetSubscriptionsUpdatedEventPayloadFragment,
 } from '../form/FormEventFragments';
 import { GQLFormEventSubscription } from '../form/FormEventFragments.types';
+import { Page } from '../pages/Page';
 import {
   FormRepresentationContext,
   FormRepresentationEvent,
@@ -58,7 +59,11 @@ const formEventSubscription = gql(`
   ${formRefreshedEventPayloadFragment}
 `);
 
-const useFormRepresentationStyles = makeStyles(() => ({
+const useFormRepresentationStyles = makeStyles((theme) => ({
+  page: {
+    paddingLeft: theme.spacing(1),
+    paddingRight: theme.spacing(1),
+  },
   complete: {
     display: 'flex',
     alignItems: 'center',
@@ -129,15 +134,30 @@ export const FormRepresentation = ({
 
   let content = null;
   if (formRepresentation === 'ready') {
-    content = (
-      <Form
-        editingContextId={editingContextId}
-        form={form}
-        widgetSubscriptions={widgetSubscriptions}
-        setSelection={setSelection}
-        readOnly={readOnly}
-      />
-    );
+    if (form.pages.length > 1) {
+      content = (
+        <Form
+          editingContextId={editingContextId}
+          form={form}
+          widgetSubscriptions={widgetSubscriptions}
+          setSelection={setSelection}
+          readOnly={readOnly}
+        />
+      );
+    } else {
+      content = (
+        <div data-testid="page" className={classes.page}>
+          <Page
+            editingContextId={editingContextId}
+            formId={form.id}
+            page={form.pages[0]}
+            widgetSubscriptions={widgetSubscriptions}
+            setSelection={setSelection}
+            readOnly={readOnly}
+          />
+        </div>
+      );
+    }
   } else if (formRepresentation === 'complete') {
     content = (
       <div className={classes.complete}>


### PR DESCRIPTION
Bug: https://github.com/eclipse-sirius/sirius-components/issues/1284
Signed-off-by: Axel RICHARD <axel.richard@obeo.fr>

# Pull request template

## General purpose
What is the main goal of this pull request?
- [ ] Bug fixes
- [x] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [x] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [x] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [x] Have the relevant issues been added to the pull request?
- [x] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [x] Have the relevant issues been added to the same project and milestone as the pull request?
- [x] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?