### PR TITLE
[457] Fix rename Form representation from the project explorer

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -48,6 +48,7 @@ The `label` value is displayed before the widget to be consistent with other pro
 - https://github.com/eclipse-sirius/sirius-components/issues/1347[#1347] [form] Fix Conditional Style menu items (two menu items available instead of one)
 - https://github.com/eclipse-sirius/sirius-components/issues/1349[#1349] [form] Fix Form Representation scrolling on Y axis
 - https://github.com/eclipse-sirius/sirius-components/issues/1351[#1351] [form] Fix Style/ConditionalStyle not applied to List Widget
+- https://github.com/eclipse-sirius/sirius-components/issues/457[#457] [form] Fix rename Form representation from the project explorer
 
 === Improvements
 

--- a/packages/forms/backend/sirius-components-collaborative-forms/src/main/java/org/eclipse/sirius/components/collaborative/forms/FormEventProcessorFactory.java
+++ b/packages/forms/backend/sirius-components-collaborative-forms/src/main/java/org/eclipse/sirius/components/collaborative/forms/FormEventProcessorFactory.java
@@ -101,7 +101,7 @@ public class FormEventProcessorFactory implements IRepresentationEventProcessorF
                             .build();
                     // @formatter:on
 
-                    IRepresentationEventProcessor formEventProcessor = new FormEventProcessor(formCreationParameters, this.formEventHandlers, this.subscriptionManagerFactory.create(),
+                    IRepresentationEventProcessor formEventProcessor = new FormEventProcessor(editingContext, formCreationParameters, this.formEventHandlers, this.subscriptionManagerFactory.create(),
                             this.widgetSubscriptionManagerFactory.create(), this.representationRefreshPolicyRegistry);
 
                     // @formatter:off

--- a/packages/forms/backend/sirius-components-collaborative-forms/src/main/java/org/eclipse/sirius/components/collaborative/forms/PropertiesEventProcessorFactory.java
+++ b/packages/forms/backend/sirius-components-collaborative-forms/src/main/java/org/eclipse/sirius/components/collaborative/forms/PropertiesEventProcessorFactory.java
@@ -101,7 +101,7 @@ public class PropertiesEventProcessorFactory implements IRepresentationEventProc
                         .build();
                 // @formatter:on
 
-                IRepresentationEventProcessor formEventProcessor = new FormEventProcessor(formCreationParameters, this.formEventHandlers, this.subscriptionManagerFactory.create(),
+                IRepresentationEventProcessor formEventProcessor = new FormEventProcessor(editingContext, formCreationParameters, this.formEventHandlers, this.subscriptionManagerFactory.create(),
                         this.widgetSubscriptionManagerFactory.create(), this.representationRefreshPolicyRegistry);
 
                 // @formatter:off

--- a/packages/forms/backend/sirius-components-collaborative-forms/src/main/java/org/eclipse/sirius/components/collaborative/forms/RelatedElementsEventProcessorFactory.java
+++ b/packages/forms/backend/sirius-components-collaborative-forms/src/main/java/org/eclipse/sirius/components/collaborative/forms/RelatedElementsEventProcessorFactory.java
@@ -91,7 +91,7 @@ public class RelatedElementsEventProcessorFactory implements IRepresentationEven
                         .build();
                 // @formatter:on
 
-                IRepresentationEventProcessor formEventProcessor = new FormEventProcessor(formCreationParameters, this.formEventHandlers, this.subscriptionManagerFactory.create(),
+                IRepresentationEventProcessor formEventProcessor = new FormEventProcessor(editingContext, formCreationParameters, this.formEventHandlers, this.subscriptionManagerFactory.create(),
                         this.widgetSubscriptionManagerFactory.create(), this.representationRefreshPolicyRegistry);
 
                 // @formatter:off

--- a/packages/forms/backend/sirius-components-collaborative-forms/src/main/java/org/eclipse/sirius/components/collaborative/forms/RepresentationsEventProcessorFactory.java
+++ b/packages/forms/backend/sirius-components-collaborative-forms/src/main/java/org/eclipse/sirius/components/collaborative/forms/RepresentationsEventProcessorFactory.java
@@ -86,7 +86,7 @@ public class RepresentationsEventProcessorFactory implements IRepresentationEven
                         .build();
                 // @formatter:on
 
-                FormEventProcessor formEventProcessor = new FormEventProcessor(formCreationParameters, this.formEventHandlers, this.subscriptionManagerFactory.create(),
+                FormEventProcessor formEventProcessor = new FormEventProcessor(editingContext, formCreationParameters, this.formEventHandlers, this.subscriptionManagerFactory.create(),
                         this.widgetSubscriptionManagerFactory.create(), this.representationRefreshPolicyRegistry);
 
                 // @formatter:off

--- a/packages/forms/backend/sirius-components-collaborative-forms/src/main/java/org/eclipse/sirius/components/collaborative/forms/api/IFormEventHandler.java
+++ b/packages/forms/backend/sirius-components-collaborative-forms/src/main/java/org/eclipse/sirius/components/collaborative/forms/api/IFormEventHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Obeo.
+ * Copyright (c) 2019, 2022 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -13,6 +13,7 @@
 package org.eclipse.sirius.components.collaborative.forms.api;
 
 import org.eclipse.sirius.components.collaborative.api.ChangeDescription;
+import org.eclipse.sirius.components.core.api.IEditingContext;
 import org.eclipse.sirius.components.core.api.IPayload;
 import org.eclipse.sirius.components.forms.Form;
 
@@ -27,5 +28,5 @@ import reactor.core.publisher.Sinks.One;
 public interface IFormEventHandler {
     boolean canHandle(IFormInput formInput);
 
-    void handle(One<IPayload> payloadSink, Many<ChangeDescription> changeDescriptionSink, Form form, IFormInput formInput);
+    void handle(One<IPayload> payloadSink, Many<ChangeDescription> changeDescriptionSink, IEditingContext editingContext, Form form, IFormInput formInput);
 }

--- a/packages/forms/backend/sirius-components-collaborative-forms/src/main/java/org/eclipse/sirius/components/collaborative/forms/dto/RenameFormInput.java
+++ b/packages/forms/backend/sirius-components-collaborative-forms/src/main/java/org/eclipse/sirius/components/collaborative/forms/dto/RenameFormInput.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.collaborative.forms.dto;
+
+import java.text.MessageFormat;
+import java.util.Objects;
+import java.util.UUID;
+
+import org.eclipse.sirius.components.collaborative.forms.api.IFormInput;
+
+/**
+ * The input of the rename diagram mutation.
+ *
+ * @author arichard
+ */
+public final class RenameFormInput implements IFormInput {
+
+    private UUID id;
+
+    private String editingContextId;
+
+    private String formId;
+
+    private String newLabel;
+
+    public RenameFormInput() {
+        // Used by Jackson
+    }
+
+    public RenameFormInput(UUID id, String editingContextId, String formId, String newLabel) {
+        this.id = Objects.requireNonNull(id);
+        this.editingContextId = Objects.requireNonNull(editingContextId);
+        this.formId = Objects.requireNonNull(formId);
+        this.newLabel = Objects.requireNonNull(newLabel);
+    }
+
+    @Override
+    public UUID getId() {
+        return this.id;
+    }
+
+    public String getEditingContextId() {
+        return this.editingContextId;
+    }
+
+    @Override
+    public String getRepresentationId() {
+        return this.formId;
+    }
+
+    public String getNewLabel() {
+        return this.newLabel;
+    }
+
+    @Override
+    public String toString() {
+        String pattern = "{0} '{'id: {1}, editingContextId: {2}, formId: {3}, newLabel: {4}'}'"; //$NON-NLS-1$
+        return MessageFormat.format(pattern, this.getClass().getSimpleName(), this.id, this.editingContextId, this.formId, this.newLabel);
+    }
+}

--- a/packages/forms/backend/sirius-components-collaborative-forms/src/main/java/org/eclipse/sirius/components/collaborative/forms/handlers/DeleteListItemEventHandler.java
+++ b/packages/forms/backend/sirius-components-collaborative-forms/src/main/java/org/eclipse/sirius/components/collaborative/forms/handlers/DeleteListItemEventHandler.java
@@ -25,6 +25,7 @@ import org.eclipse.sirius.components.collaborative.forms.dto.DeleteListItemInput
 import org.eclipse.sirius.components.collaborative.forms.dto.DeleteListItemSuccessPayload;
 import org.eclipse.sirius.components.collaborative.forms.messages.ICollaborativeFormMessageService;
 import org.eclipse.sirius.components.core.api.ErrorPayload;
+import org.eclipse.sirius.components.core.api.IEditingContext;
 import org.eclipse.sirius.components.core.api.IPayload;
 import org.eclipse.sirius.components.forms.Form;
 import org.eclipse.sirius.components.forms.List;
@@ -69,7 +70,7 @@ public class DeleteListItemEventHandler implements IFormEventHandler {
     }
 
     @Override
-    public void handle(One<IPayload> payloadSink, Many<ChangeDescription> changeDescriptionSink, Form form, IFormInput formInput) {
+    public void handle(One<IPayload> payloadSink, Many<ChangeDescription> changeDescriptionSink, IEditingContext editingContext, Form form, IFormInput formInput) {
         this.counter.increment();
 
         String message = this.messageService.invalidInput(formInput.getClass().getSimpleName(), DeleteListItemInput.class.getSimpleName());

--- a/packages/forms/backend/sirius-components-collaborative-forms/src/main/java/org/eclipse/sirius/components/collaborative/forms/handlers/EditCheckboxEventHandler.java
+++ b/packages/forms/backend/sirius-components-collaborative-forms/src/main/java/org/eclipse/sirius/components/collaborative/forms/handlers/EditCheckboxEventHandler.java
@@ -24,6 +24,7 @@ import org.eclipse.sirius.components.collaborative.forms.dto.EditCheckboxInput;
 import org.eclipse.sirius.components.collaborative.forms.dto.EditCheckboxSuccessPayload;
 import org.eclipse.sirius.components.collaborative.forms.messages.ICollaborativeFormMessageService;
 import org.eclipse.sirius.components.core.api.ErrorPayload;
+import org.eclipse.sirius.components.core.api.IEditingContext;
 import org.eclipse.sirius.components.core.api.IPayload;
 import org.eclipse.sirius.components.forms.Checkbox;
 import org.eclipse.sirius.components.forms.Form;
@@ -68,7 +69,7 @@ public class EditCheckboxEventHandler implements IFormEventHandler {
     }
 
     @Override
-    public void handle(One<IPayload> payloadSink, Many<ChangeDescription> changeDescriptionSink, Form form, IFormInput formInput) {
+    public void handle(One<IPayload> payloadSink, Many<ChangeDescription> changeDescriptionSink, IEditingContext editingContext, Form form, IFormInput formInput) {
         this.counter.increment();
         String message = this.messageService.invalidInput(formInput.getClass().getSimpleName(), EditCheckboxInput.class.getSimpleName());
         IPayload payload = new ErrorPayload(formInput.getId(), message);

--- a/packages/forms/backend/sirius-components-collaborative-forms/src/main/java/org/eclipse/sirius/components/collaborative/forms/handlers/EditMultiSelectEventHandler.java
+++ b/packages/forms/backend/sirius-components-collaborative-forms/src/main/java/org/eclipse/sirius/components/collaborative/forms/handlers/EditMultiSelectEventHandler.java
@@ -25,6 +25,7 @@ import org.eclipse.sirius.components.collaborative.forms.dto.EditMultiSelectInpu
 import org.eclipse.sirius.components.collaborative.forms.dto.EditMultiSelectSuccessPayload;
 import org.eclipse.sirius.components.collaborative.forms.messages.ICollaborativeFormMessageService;
 import org.eclipse.sirius.components.core.api.ErrorPayload;
+import org.eclipse.sirius.components.core.api.IEditingContext;
 import org.eclipse.sirius.components.core.api.IPayload;
 import org.eclipse.sirius.components.forms.Form;
 import org.eclipse.sirius.components.forms.MultiSelect;
@@ -69,7 +70,7 @@ public class EditMultiSelectEventHandler implements IFormEventHandler {
     }
 
     @Override
-    public void handle(One<IPayload> payloadSink, Many<ChangeDescription> changeDescriptionSink, Form form, IFormInput formInput) {
+    public void handle(One<IPayload> payloadSink, Many<ChangeDescription> changeDescriptionSink, IEditingContext editingContext, Form form, IFormInput formInput) {
         this.counter.increment();
         String message = this.messageService.invalidInput(formInput.getClass().getSimpleName(), EditMultiSelectInput.class.getSimpleName());
         IPayload payload = new ErrorPayload(formInput.getId(), message);

--- a/packages/forms/backend/sirius-components-collaborative-forms/src/main/java/org/eclipse/sirius/components/collaborative/forms/handlers/EditRadioEventHandler.java
+++ b/packages/forms/backend/sirius-components-collaborative-forms/src/main/java/org/eclipse/sirius/components/collaborative/forms/handlers/EditRadioEventHandler.java
@@ -24,6 +24,7 @@ import org.eclipse.sirius.components.collaborative.forms.dto.EditRadioInput;
 import org.eclipse.sirius.components.collaborative.forms.dto.EditRadioSuccessPayload;
 import org.eclipse.sirius.components.collaborative.forms.messages.ICollaborativeFormMessageService;
 import org.eclipse.sirius.components.core.api.ErrorPayload;
+import org.eclipse.sirius.components.core.api.IEditingContext;
 import org.eclipse.sirius.components.core.api.IPayload;
 import org.eclipse.sirius.components.forms.Form;
 import org.eclipse.sirius.components.forms.Radio;
@@ -68,7 +69,7 @@ public class EditRadioEventHandler implements IFormEventHandler {
     }
 
     @Override
-    public void handle(One<IPayload> payloadSink, Many<ChangeDescription> changeDescriptionSink, Form form, IFormInput formInput) {
+    public void handle(One<IPayload> payloadSink, Many<ChangeDescription> changeDescriptionSink, IEditingContext editingContext, Form form, IFormInput formInput) {
         this.counter.increment();
         String message = this.messageService.invalidInput(formInput.getClass().getSimpleName(), EditRadioInput.class.getSimpleName());
         IPayload payload = new ErrorPayload(formInput.getId(), message);

--- a/packages/forms/backend/sirius-components-collaborative-forms/src/main/java/org/eclipse/sirius/components/collaborative/forms/handlers/EditSelectEventHandler.java
+++ b/packages/forms/backend/sirius-components-collaborative-forms/src/main/java/org/eclipse/sirius/components/collaborative/forms/handlers/EditSelectEventHandler.java
@@ -25,6 +25,7 @@ import org.eclipse.sirius.components.collaborative.forms.dto.EditSelectInput;
 import org.eclipse.sirius.components.collaborative.forms.dto.EditSelectSuccessPayload;
 import org.eclipse.sirius.components.collaborative.forms.messages.ICollaborativeFormMessageService;
 import org.eclipse.sirius.components.core.api.ErrorPayload;
+import org.eclipse.sirius.components.core.api.IEditingContext;
 import org.eclipse.sirius.components.core.api.IPayload;
 import org.eclipse.sirius.components.forms.Form;
 import org.eclipse.sirius.components.forms.Select;
@@ -69,7 +70,7 @@ public class EditSelectEventHandler implements IFormEventHandler {
     }
 
     @Override
-    public void handle(One<IPayload> payloadSink, Many<ChangeDescription> changeDescriptionSink, Form form, IFormInput formInput) {
+    public void handle(One<IPayload> payloadSink, Many<ChangeDescription> changeDescriptionSink, IEditingContext editingContext, Form form, IFormInput formInput) {
         this.counter.increment();
         String message = this.messageService.invalidInput(formInput.getClass().getSimpleName(), EditSelectInput.class.getSimpleName());
         IPayload payload = new ErrorPayload(formInput.getId(), message);

--- a/packages/forms/backend/sirius-components-collaborative-forms/src/main/java/org/eclipse/sirius/components/collaborative/forms/handlers/EditTextfieldEventHandler.java
+++ b/packages/forms/backend/sirius-components-collaborative-forms/src/main/java/org/eclipse/sirius/components/collaborative/forms/handlers/EditTextfieldEventHandler.java
@@ -25,6 +25,7 @@ import org.eclipse.sirius.components.collaborative.forms.dto.EditTextfieldInput;
 import org.eclipse.sirius.components.collaborative.forms.dto.EditTextfieldSuccessPayload;
 import org.eclipse.sirius.components.collaborative.forms.messages.ICollaborativeFormMessageService;
 import org.eclipse.sirius.components.core.api.ErrorPayload;
+import org.eclipse.sirius.components.core.api.IEditingContext;
 import org.eclipse.sirius.components.core.api.IPayload;
 import org.eclipse.sirius.components.forms.Form;
 import org.eclipse.sirius.components.forms.Textarea;
@@ -70,7 +71,7 @@ public class EditTextfieldEventHandler implements IFormEventHandler {
     }
 
     @Override
-    public void handle(One<IPayload> payloadSink, Many<ChangeDescription> changeDescriptionSink, Form form, IFormInput formInput) {
+    public void handle(One<IPayload> payloadSink, Many<ChangeDescription> changeDescriptionSink, IEditingContext editingContext, Form form, IFormInput formInput) {
         this.counter.increment();
         String message = this.messageService.invalidInput(formInput.getClass().getSimpleName(), EditTextfieldInput.class.getSimpleName());
         IPayload payload = new ErrorPayload(formInput.getId(), message);

--- a/packages/forms/backend/sirius-components-collaborative-forms/src/main/java/org/eclipse/sirius/components/collaborative/forms/handlers/PushButtonEventHandler.java
+++ b/packages/forms/backend/sirius-components-collaborative-forms/src/main/java/org/eclipse/sirius/components/collaborative/forms/handlers/PushButtonEventHandler.java
@@ -25,6 +25,7 @@ import org.eclipse.sirius.components.collaborative.forms.dto.PushButtonInput;
 import org.eclipse.sirius.components.collaborative.forms.dto.PushButtonSuccessPayload;
 import org.eclipse.sirius.components.collaborative.forms.messages.ICollaborativeFormMessageService;
 import org.eclipse.sirius.components.core.api.ErrorPayload;
+import org.eclipse.sirius.components.core.api.IEditingContext;
 import org.eclipse.sirius.components.core.api.IPayload;
 import org.eclipse.sirius.components.forms.Button;
 import org.eclipse.sirius.components.forms.Form;
@@ -69,7 +70,7 @@ public class PushButtonEventHandler implements IFormEventHandler {
     }
 
     @Override
-    public void handle(One<IPayload> payloadSink, Many<ChangeDescription> changeDescriptionSink, Form form, IFormInput formInput) {
+    public void handle(One<IPayload> payloadSink, Many<ChangeDescription> changeDescriptionSink, IEditingContext editingContext, Form form, IFormInput formInput) {
         this.counter.increment();
         String message = this.messageService.invalidInput(formInput.getClass().getSimpleName(), PushButtonInput.class.getSimpleName());
         IPayload payload = new ErrorPayload(formInput.getId(), message);

--- a/packages/forms/backend/sirius-components-collaborative-forms/src/test/java/org/eclipse/sirius/components/collaborative/forms/FormEventProcessorTests.java
+++ b/packages/forms/backend/sirius-components-collaborative-forms/src/test/java/org/eclipse/sirius/components/collaborative/forms/FormEventProcessorTests.java
@@ -67,16 +67,17 @@ public class FormEventProcessorTests {
     @Test
     public void testEmitFormOnSubscription() {
         IInput input = new FormEventInput(UUID.randomUUID(), UUID.randomUUID().toString(), UUID.randomUUID().toString());
+        IEditingContext.NoOp editingContext = new IEditingContext.NoOp();
 
         // @formatter:off
         FormCreationParameters formCreationParameters = FormCreationParameters.newFormCreationParameters(FORM_ID)
                 .formDescription(this.getFormDescription())
-                .editingContext(new IEditingContext.NoOp())
+                .editingContext(editingContext)
                 .objects(List.of(new Object()))
                 .build();
         // @formatter:on
 
-        FormEventProcessor formEventProcessor = new FormEventProcessor(formCreationParameters, List.of(), new SubscriptionManager(), new WidgetSubscriptionManager(),
+        FormEventProcessor formEventProcessor = new FormEventProcessor(editingContext, formCreationParameters, List.of(), new SubscriptionManager(), new WidgetSubscriptionManager(),
                 new RepresentationRefreshPolicyRegistry());
 
         // @formatter:off
@@ -90,16 +91,17 @@ public class FormEventProcessorTests {
     @Test
     public void testEmitFormOnRefresh() {
         FormEventInput input = new FormEventInput(UUID.randomUUID(), UUID.randomUUID().toString(), UUID.randomUUID().toString());
+        IEditingContext.NoOp editingContext = new IEditingContext.NoOp();
 
         // @formatter:off
         FormCreationParameters formCreationParameters = FormCreationParameters.newFormCreationParameters(FORM_ID)
                 .formDescription(this.getFormDescription())
-                .editingContext(new IEditingContext.NoOp())
+                .editingContext(editingContext)
                 .objects(List.of(new Object()))
                 .build();
         // @formatter:on
 
-        FormEventProcessor formEventProcessor = new FormEventProcessor(formCreationParameters, List.of(), new SubscriptionManager(), new WidgetSubscriptionManager(),
+        FormEventProcessor formEventProcessor = new FormEventProcessor(editingContext, formCreationParameters, List.of(), new SubscriptionManager(), new WidgetSubscriptionManager(),
                 new RepresentationRefreshPolicyRegistry());
 
         Runnable performRefresh = () -> formEventProcessor.refresh(new ChangeDescription(ChangeKind.SEMANTIC_CHANGE, input.getFormId(), input));
@@ -117,16 +119,17 @@ public class FormEventProcessorTests {
     @Test
     public void testCompleteOnDispose() {
         FormEventInput input = new FormEventInput(UUID.randomUUID(), UUID.randomUUID().toString(), UUID.randomUUID().toString());
+        IEditingContext.NoOp editingContext = new IEditingContext.NoOp();
 
         // @formatter:off
         FormCreationParameters formCreationParameters = FormCreationParameters.newFormCreationParameters(FORM_ID)
                 .formDescription(this.getFormDescription())
-                .editingContext(new IEditingContext.NoOp())
+                .editingContext(editingContext)
                 .objects(List.of(new Object()))
                 .build();
         // @formatter:on
 
-        FormEventProcessor formEventProcessor = new FormEventProcessor(formCreationParameters, List.of(), new SubscriptionManager(), new WidgetSubscriptionManager(),
+        FormEventProcessor formEventProcessor = new FormEventProcessor(editingContext, formCreationParameters, List.of(), new SubscriptionManager(), new WidgetSubscriptionManager(),
                 new RepresentationRefreshPolicyRegistry());
 
         Runnable disposeFormEventProcessor = () -> formEventProcessor.dispose();

--- a/packages/forms/backend/sirius-components-collaborative-forms/src/test/java/org/eclipse/sirius/components/collaborative/forms/handlers/EditCheckboxEventHandlerTests.java
+++ b/packages/forms/backend/sirius-components-collaborative-forms/src/test/java/org/eclipse/sirius/components/collaborative/forms/handlers/EditCheckboxEventHandlerTests.java
@@ -26,6 +26,7 @@ import org.eclipse.sirius.components.collaborative.forms.api.IFormQueryService;
 import org.eclipse.sirius.components.collaborative.forms.dto.EditCheckboxInput;
 import org.eclipse.sirius.components.collaborative.forms.dto.EditCheckboxSuccessPayload;
 import org.eclipse.sirius.components.collaborative.forms.messages.ICollaborativeFormMessageService;
+import org.eclipse.sirius.components.core.api.IEditingContext;
 import org.eclipse.sirius.components.core.api.IPayload;
 import org.eclipse.sirius.components.forms.AbstractWidget;
 import org.eclipse.sirius.components.forms.Checkbox;
@@ -98,7 +99,7 @@ public class EditCheckboxEventHandlerTests {
         Many<ChangeDescription> changeDescriptionSink = Sinks.many().unicast().onBackpressureBuffer();
         One<IPayload> payloadSink = Sinks.one();
 
-        handler.handle(payloadSink, changeDescriptionSink, form, input);
+        handler.handle(payloadSink, changeDescriptionSink, new IEditingContext.NoOp(), form, input);
 
         ChangeDescription changeDescription = changeDescriptionSink.asFlux().blockFirst();
         assertThat(changeDescription.getKind()).isEqualTo(ChangeKind.SEMANTIC_CHANGE);

--- a/packages/forms/backend/sirius-components-collaborative-forms/src/test/java/org/eclipse/sirius/components/collaborative/forms/handlers/EditMultiSelectEventHandlerTests.java
+++ b/packages/forms/backend/sirius-components-collaborative-forms/src/test/java/org/eclipse/sirius/components/collaborative/forms/handlers/EditMultiSelectEventHandlerTests.java
@@ -26,6 +26,7 @@ import org.eclipse.sirius.components.collaborative.forms.api.IFormQueryService;
 import org.eclipse.sirius.components.collaborative.forms.dto.EditMultiSelectInput;
 import org.eclipse.sirius.components.collaborative.forms.dto.EditMultiSelectSuccessPayload;
 import org.eclipse.sirius.components.collaborative.forms.messages.ICollaborativeFormMessageService;
+import org.eclipse.sirius.components.core.api.IEditingContext;
 import org.eclipse.sirius.components.core.api.IPayload;
 import org.eclipse.sirius.components.forms.AbstractWidget;
 import org.eclipse.sirius.components.forms.Form;
@@ -107,7 +108,7 @@ public class EditMultiSelectEventHandlerTests {
         Many<ChangeDescription> changeDescriptionSink = Sinks.many().unicast().onBackpressureBuffer();
         One<IPayload> payloadSink = Sinks.one();
 
-        handler.handle(payloadSink, changeDescriptionSink, form, input);
+        handler.handle(payloadSink, changeDescriptionSink, new IEditingContext.NoOp(), form, input);
 
         ChangeDescription changeDescription = changeDescriptionSink.asFlux().blockFirst();
         assertThat(changeDescription.getKind()).isEqualTo(ChangeKind.SEMANTIC_CHANGE);

--- a/packages/forms/backend/sirius-components-collaborative-forms/src/test/java/org/eclipse/sirius/components/collaborative/forms/handlers/EditRadioEventHandlerTests.java
+++ b/packages/forms/backend/sirius-components-collaborative-forms/src/test/java/org/eclipse/sirius/components/collaborative/forms/handlers/EditRadioEventHandlerTests.java
@@ -26,6 +26,7 @@ import org.eclipse.sirius.components.collaborative.forms.api.IFormQueryService;
 import org.eclipse.sirius.components.collaborative.forms.dto.EditRadioInput;
 import org.eclipse.sirius.components.collaborative.forms.dto.EditRadioSuccessPayload;
 import org.eclipse.sirius.components.collaborative.forms.messages.ICollaborativeFormMessageService;
+import org.eclipse.sirius.components.core.api.IEditingContext;
 import org.eclipse.sirius.components.core.api.IPayload;
 import org.eclipse.sirius.components.forms.AbstractWidget;
 import org.eclipse.sirius.components.forms.Form;
@@ -105,7 +106,7 @@ public class EditRadioEventHandlerTests {
         Many<ChangeDescription> changeDescriptionSink = Sinks.many().unicast().onBackpressureBuffer();
         One<IPayload> payloadSink = Sinks.one();
 
-        handler.handle(payloadSink, changeDescriptionSink, form, input);
+        handler.handle(payloadSink, changeDescriptionSink, new IEditingContext.NoOp(), form, input);
 
         ChangeDescription changeDescription = changeDescriptionSink.asFlux().blockFirst();
         assertThat(changeDescription.getKind()).isEqualTo(ChangeKind.SEMANTIC_CHANGE);

--- a/packages/forms/backend/sirius-components-collaborative-forms/src/test/java/org/eclipse/sirius/components/collaborative/forms/handlers/EditSelectEventHandlerTests.java
+++ b/packages/forms/backend/sirius-components-collaborative-forms/src/test/java/org/eclipse/sirius/components/collaborative/forms/handlers/EditSelectEventHandlerTests.java
@@ -26,6 +26,7 @@ import org.eclipse.sirius.components.collaborative.forms.api.IFormQueryService;
 import org.eclipse.sirius.components.collaborative.forms.dto.EditSelectInput;
 import org.eclipse.sirius.components.collaborative.forms.dto.EditSelectSuccessPayload;
 import org.eclipse.sirius.components.collaborative.forms.messages.ICollaborativeFormMessageService;
+import org.eclipse.sirius.components.core.api.IEditingContext;
 import org.eclipse.sirius.components.core.api.IPayload;
 import org.eclipse.sirius.components.forms.AbstractWidget;
 import org.eclipse.sirius.components.forms.Form;
@@ -107,7 +108,7 @@ public class EditSelectEventHandlerTests {
         Many<ChangeDescription> changeDescriptionSink = Sinks.many().unicast().onBackpressureBuffer();
         One<IPayload> payloadSink = Sinks.one();
 
-        handler.handle(payloadSink, changeDescriptionSink, form, input);
+        handler.handle(payloadSink, changeDescriptionSink, new IEditingContext.NoOp(), form, input);
 
         ChangeDescription changeDescription = changeDescriptionSink.asFlux().blockFirst();
         assertThat(changeDescription.getKind()).isEqualTo(ChangeKind.SEMANTIC_CHANGE);

--- a/packages/forms/backend/sirius-components-collaborative-forms/src/test/java/org/eclipse/sirius/components/collaborative/forms/handlers/EditTextfieldEventHandlerTests.java
+++ b/packages/forms/backend/sirius-components-collaborative-forms/src/test/java/org/eclipse/sirius/components/collaborative/forms/handlers/EditTextfieldEventHandlerTests.java
@@ -26,6 +26,7 @@ import org.eclipse.sirius.components.collaborative.forms.api.IFormQueryService;
 import org.eclipse.sirius.components.collaborative.forms.dto.EditTextfieldInput;
 import org.eclipse.sirius.components.collaborative.forms.dto.EditTextfieldSuccessPayload;
 import org.eclipse.sirius.components.collaborative.forms.messages.ICollaborativeFormMessageService;
+import org.eclipse.sirius.components.core.api.IEditingContext;
 import org.eclipse.sirius.components.core.api.IPayload;
 import org.eclipse.sirius.components.forms.AbstractWidget;
 import org.eclipse.sirius.components.forms.Form;
@@ -99,7 +100,7 @@ public class EditTextfieldEventHandlerTests {
         Many<ChangeDescription> changeDescriptionSink = Sinks.many().unicast().onBackpressureBuffer();
         One<IPayload> payloadSink = Sinks.one();
 
-        handler.handle(payloadSink, changeDescriptionSink, form, input);
+        handler.handle(payloadSink, changeDescriptionSink, new IEditingContext.NoOp(), form, input);
 
         ChangeDescription changeDescription = changeDescriptionSink.asFlux().blockFirst();
         assertThat(changeDescription.getKind()).isEqualTo(ChangeKind.SEMANTIC_CHANGE);

--- a/packages/forms/backend/sirius-components-collaborative-forms/src/test/java/org/eclipse/sirius/components/collaborative/forms/handlers/ListItemEventHandlersTests.java
+++ b/packages/forms/backend/sirius-components-collaborative-forms/src/test/java/org/eclipse/sirius/components/collaborative/forms/handlers/ListItemEventHandlersTests.java
@@ -26,11 +26,12 @@ import java.util.function.Supplier;
 import org.eclipse.sirius.components.collaborative.api.ChangeDescription;
 import org.eclipse.sirius.components.collaborative.api.ChangeKind;
 import org.eclipse.sirius.components.collaborative.forms.api.IFormQueryService;
-import org.eclipse.sirius.components.collaborative.forms.dto.DeleteListItemInput;
-import org.eclipse.sirius.components.collaborative.forms.dto.DeleteListItemSuccessPayload;
 import org.eclipse.sirius.components.collaborative.forms.dto.ClickListItemInput;
 import org.eclipse.sirius.components.collaborative.forms.dto.ClickListItemSuccessPayload;
+import org.eclipse.sirius.components.collaborative.forms.dto.DeleteListItemInput;
+import org.eclipse.sirius.components.collaborative.forms.dto.DeleteListItemSuccessPayload;
 import org.eclipse.sirius.components.collaborative.forms.messages.ICollaborativeFormMessageService;
+import org.eclipse.sirius.components.core.api.IEditingContext;
 import org.eclipse.sirius.components.core.api.IPayload;
 import org.eclipse.sirius.components.forms.AbstractWidget;
 import org.eclipse.sirius.components.forms.ClickEventKind;
@@ -120,7 +121,7 @@ public class ListItemEventHandlersTests {
         Many<ChangeDescription> changeDescriptionSink = Sinks.many().unicast().onBackpressureBuffer();
         One<IPayload> payloadSink = Sinks.one();
 
-        handler.handle(payloadSink, changeDescriptionSink, form, input);
+        handler.handle(payloadSink, changeDescriptionSink, new IEditingContext.NoOp(), form, input);
 
         ChangeDescription changeDescription = changeDescriptionSink.asFlux().blockFirst();
         assertThat(changeDescription.getKind()).isEqualTo(changeKind);
@@ -197,7 +198,7 @@ public class ListItemEventHandlersTests {
         Many<ChangeDescription> changeDescriptionSink = Sinks.many().unicast().onBackpressureBuffer();
         One<IPayload> payloadSink = Sinks.one();
 
-        handler.handle(payloadSink, changeDescriptionSink, form, input);
+        handler.handle(payloadSink, changeDescriptionSink, new IEditingContext.NoOp(), form, input);
 
         ChangeDescription changeDescription = changeDescriptionSink.asFlux().blockFirst();
         assertThat(changeDescription.getKind()).isEqualTo(changeKind);

--- a/packages/forms/backend/sirius-components-collaborative-forms/src/test/java/org/eclipse/sirius/components/collaborative/forms/handlers/PushButtonEventHandlerTests.java
+++ b/packages/forms/backend/sirius-components-collaborative-forms/src/test/java/org/eclipse/sirius/components/collaborative/forms/handlers/PushButtonEventHandlerTests.java
@@ -26,6 +26,7 @@ import org.eclipse.sirius.components.collaborative.forms.api.IFormQueryService;
 import org.eclipse.sirius.components.collaborative.forms.dto.PushButtonInput;
 import org.eclipse.sirius.components.collaborative.forms.dto.PushButtonSuccessPayload;
 import org.eclipse.sirius.components.collaborative.forms.messages.ICollaborativeFormMessageService;
+import org.eclipse.sirius.components.core.api.IEditingContext;
 import org.eclipse.sirius.components.core.api.IPayload;
 import org.eclipse.sirius.components.forms.AbstractWidget;
 import org.eclipse.sirius.components.forms.Button;
@@ -98,7 +99,7 @@ public class PushButtonEventHandlerTests {
         Many<ChangeDescription> changeDescriptionSink = Sinks.many().unicast().onBackpressureBuffer();
         One<IPayload> payloadSink = Sinks.one();
 
-        handler.handle(payloadSink, changeDescriptionSink, form, input);
+        handler.handle(payloadSink, changeDescriptionSink, new IEditingContext.NoOp(), form, input);
 
         ChangeDescription changeDescription = changeDescriptionSink.asFlux().blockFirst();
         assertThat(changeDescription.getKind()).isEqualTo(ChangeKind.SEMANTIC_CHANGE);

--- a/packages/forms/backend/sirius-components-collaborative-forms/src/test/java/org/eclipse/sirius/components/collaborative/forms/handlers/RenameFormEventHandlerTests.java
+++ b/packages/forms/backend/sirius-components-collaborative-forms/src/test/java/org/eclipse/sirius/components/collaborative/forms/handlers/RenameFormEventHandlerTests.java
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.collaborative.forms.handlers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.eclipse.sirius.components.collaborative.api.ChangeDescription;
+import org.eclipse.sirius.components.collaborative.api.ChangeKind;
+import org.eclipse.sirius.components.collaborative.api.IRepresentationPersistenceService;
+import org.eclipse.sirius.components.collaborative.dto.RenameRepresentationSuccessPayload;
+import org.eclipse.sirius.components.collaborative.forms.dto.RenameFormInput;
+import org.eclipse.sirius.components.collaborative.forms.messages.ICollaborativeFormMessageService;
+import org.eclipse.sirius.components.core.api.IEditingContext;
+import org.eclipse.sirius.components.core.api.IPayload;
+import org.eclipse.sirius.components.forms.Form;
+import org.junit.jupiter.api.Test;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import reactor.core.publisher.Sinks;
+import reactor.core.publisher.Sinks.Many;
+import reactor.core.publisher.Sinks.One;
+
+/**
+ * Unit tests of the rename representation event handler.
+ *
+ * @author arichard
+ */
+public class RenameFormEventHandlerTests {
+    private static final String OLD_LABEL = "oldLabel"; //$NON-NLS-1$
+
+    private static final String NEW_LABEL = "newLabel"; //$NON-NLS-1$
+
+    @Test
+    public void testRenameRepresentation() {
+        String projectId = UUID.randomUUID().toString();
+        String formDescriptionId = UUID.randomUUID().toString();
+        String representationId = UUID.randomUUID().toString();
+        UUID targetObjectId = UUID.randomUUID();
+
+        // @formatter:off
+        Form form = Form.newForm(representationId)
+                .label(OLD_LABEL)
+                .descriptionId(formDescriptionId)
+                .targetObjectId(targetObjectId.toString())
+                .pages(List.of())
+                .build();
+        // @formatter:on
+
+        RenameFormEventHandler handler = new RenameFormEventHandler(new IRepresentationPersistenceService.NoOp(), new ICollaborativeFormMessageService.NoOp(), new SimpleMeterRegistry());
+
+        var input = new RenameFormInput(UUID.randomUUID(), projectId, representationId, NEW_LABEL);
+        assertThat(handler.canHandle(input)).isTrue();
+
+        Many<ChangeDescription> changeDescriptionSink = Sinks.many().unicast().onBackpressureBuffer();
+        One<IPayload> payloadSink = Sinks.one();
+
+        handler.handle(payloadSink, changeDescriptionSink, new IEditingContext.NoOp(), form, input);
+
+        ChangeDescription changeDescription = changeDescriptionSink.asFlux().blockFirst();
+        assertThat(changeDescription.getKind()).isEqualTo(ChangeKind.REPRESENTATION_RENAMING);
+
+        IPayload payload = payloadSink.asMono().block();
+        assertThat(payload).isInstanceOf(RenameRepresentationSuccessPayload.class);
+        assertThat(((RenameRepresentationSuccessPayload) payload).getRepresentation().getLabel()).isEqualTo(NEW_LABEL);
+    }
+}

--- a/packages/forms/backend/sirius-components-forms/src/main/java/org/eclipse/sirius/components/forms/Form.java
+++ b/packages/forms/backend/sirius-components-forms/src/main/java/org/eclipse/sirius/components/forms/Form.java
@@ -13,6 +13,7 @@
 package org.eclipse.sirius.components.forms;
 
 import java.text.MessageFormat;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -80,6 +81,10 @@ public final class Form implements IRepresentation, ISemanticRepresentation {
         return new Builder(id);
     }
 
+    public static Builder newForm(Form form) {
+        return new Builder(form);
+    }
+
     @Override
     public String toString() {
         String pattern = "{0} '{'id: {1}, label: {2}, targetObjectId: {3}, descriptionId: {4} pageCount: {5}'}'"; //$NON-NLS-1$
@@ -107,6 +112,14 @@ public final class Form implements IRepresentation, ISemanticRepresentation {
 
         private Builder(String id) {
             this.id = Objects.requireNonNull(id);
+        }
+
+        private Builder(Form form) {
+            this.id = form.getId();
+            this.targetObjectId = form.getTargetObjectId();
+            this.descriptionId = form.getDescriptionId();
+            this.label = form.getLabel();
+            this.pages = new ArrayList<>(form.getPages());
         }
 
         public Builder label(String label) {


### PR DESCRIPTION
Bug: https://github.com/eclipse-sirius/sirius-components/issues/457
Signed-off-by: Axel RICHARD <axel.richard@obeo.fr>

# Pull request template

## General purpose
What is the main goal of this pull request?
- [x] Bug fixes
- [ ] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [x] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [x] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [x] Have the relevant issues been added to the pull request?
- [x] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [x] Have the relevant issues been added to the same project and milestone as the pull request?
- [x] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [x] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [x] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?