### PR TITLE
[1354] Fix rename FormDescriptionEditor from the project explorer

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -49,6 +49,7 @@ The `label` value is displayed before the widget to be consistent with other pro
 - https://github.com/eclipse-sirius/sirius-components/issues/1349[#1349] [form] Fix Form Representation scrolling on Y axis
 - https://github.com/eclipse-sirius/sirius-components/issues/1351[#1351] [form] Fix Style/ConditionalStyle not applied to List Widget
 - https://github.com/eclipse-sirius/sirius-components/issues/457[#457] [form] Fix rename Form representation from the project explorer
+- https://github.com/eclipse-sirius/sirius-components/issues/1354[#1354] [form] Fix rename FormDescriptionEditor representation from the project explorer
 
 === Improvements
 

--- a/packages/formdescriptioneditors/backend/sirius-components-collaborative-formdescriptioneditors/src/main/java/org/eclipse/sirius/components/collaborative/formdescriptioneditors/FormDescriptionEditorEventProcessor.java
+++ b/packages/formdescriptioneditors/backend/sirius-components-collaborative-formdescriptioneditors/src/main/java/org/eclipse/sirius/components/collaborative/formdescriptioneditors/FormDescriptionEditorEventProcessor.java
@@ -21,11 +21,13 @@ import org.eclipse.sirius.components.collaborative.api.ChangeKind;
 import org.eclipse.sirius.components.collaborative.api.IRepresentationRefreshPolicy;
 import org.eclipse.sirius.components.collaborative.api.IRepresentationRefreshPolicyRegistry;
 import org.eclipse.sirius.components.collaborative.api.ISubscriptionManager;
+import org.eclipse.sirius.components.collaborative.dto.RenameRepresentationInput;
 import org.eclipse.sirius.components.collaborative.formdescriptioneditors.api.IFormDescriptionEditorContext;
 import org.eclipse.sirius.components.collaborative.formdescriptioneditors.api.IFormDescriptionEditorCreationService;
 import org.eclipse.sirius.components.collaborative.formdescriptioneditors.api.IFormDescriptionEditorEventHandler;
 import org.eclipse.sirius.components.collaborative.formdescriptioneditors.api.IFormDescriptionEditorEventProcessor;
 import org.eclipse.sirius.components.collaborative.formdescriptioneditors.api.IFormDescriptionEditorInput;
+import org.eclipse.sirius.components.collaborative.formdescriptioneditors.dto.RenameFormDescriptionEditorInput;
 import org.eclipse.sirius.components.core.api.IEditingContext;
 import org.eclipse.sirius.components.core.api.IInput;
 import org.eclipse.sirius.components.core.api.IPayload;
@@ -97,8 +99,14 @@ public class FormDescriptionEditorEventProcessor implements IFormDescriptionEdit
 
     @Override
     public void handle(One<IPayload> payloadSink, Many<ChangeDescription> changeDescriptionSink, IRepresentationInput representationInput) {
-        if (representationInput instanceof IFormDescriptionEditorInput) {
-            IFormDescriptionEditorInput formDescriptionEditorInput = (IFormDescriptionEditorInput) representationInput;
+        IRepresentationInput effectiveInput = representationInput;
+        if (representationInput instanceof RenameRepresentationInput) {
+            RenameRepresentationInput renameRepresentationInput = (RenameRepresentationInput) representationInput;
+            effectiveInput = new RenameFormDescriptionEditorInput(renameRepresentationInput.getId(), renameRepresentationInput.getEditingContextId(), renameRepresentationInput.getRepresentationId(),
+                    renameRepresentationInput.getNewLabel());
+        }
+        if (effectiveInput instanceof IFormDescriptionEditorInput) {
+            IFormDescriptionEditorInput formDescriptionEditorInput = (IFormDescriptionEditorInput) effectiveInput;
 
             Optional<IFormDescriptionEditorEventHandler> optionalFormEventHandler = this.formDescriptionEditorEventHandlers.stream().filter(handler -> handler.canHandle(formDescriptionEditorInput))
                     .findFirst();

--- a/packages/formdescriptioneditors/backend/sirius-components-collaborative-formdescriptioneditors/src/main/java/org/eclipse/sirius/components/collaborative/formdescriptioneditors/dto/RenameFormDescriptionEditorInput.java
+++ b/packages/formdescriptioneditors/backend/sirius-components-collaborative-formdescriptioneditors/src/main/java/org/eclipse/sirius/components/collaborative/formdescriptioneditors/dto/RenameFormDescriptionEditorInput.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.collaborative.formdescriptioneditors.dto;
+
+import java.text.MessageFormat;
+import java.util.Objects;
+import java.util.UUID;
+
+import org.eclipse.sirius.components.collaborative.formdescriptioneditors.api.IFormDescriptionEditorInput;
+
+/**
+ * The input of the rename diagram mutation.
+ *
+ * @author arichard
+ */
+public final class RenameFormDescriptionEditorInput implements IFormDescriptionEditorInput {
+
+    private UUID id;
+
+    private String editingContextId;
+
+    private String formDescriptionEditorId;
+
+    private String newLabel;
+
+    public RenameFormDescriptionEditorInput() {
+        // Used by Jackson
+    }
+
+    public RenameFormDescriptionEditorInput(UUID id, String editingContextId, String formDescriptionEditorId, String newLabel) {
+        this.id = Objects.requireNonNull(id);
+        this.editingContextId = Objects.requireNonNull(editingContextId);
+        this.formDescriptionEditorId = Objects.requireNonNull(formDescriptionEditorId);
+        this.newLabel = Objects.requireNonNull(newLabel);
+    }
+
+    @Override
+    public UUID getId() {
+        return this.id;
+    }
+
+    public String getEditingContextId() {
+        return this.editingContextId;
+    }
+
+    @Override
+    public String getRepresentationId() {
+        return this.formDescriptionEditorId;
+    }
+
+    public String getNewLabel() {
+        return this.newLabel;
+    }
+
+    @Override
+    public String toString() {
+        String pattern = "{0} '{'id: {1}, editingContextId: {2}, formDescriptionEditorId: {3}, newLabel: {4}'}'"; //$NON-NLS-1$
+        return MessageFormat.format(pattern, this.getClass().getSimpleName(), this.id, this.editingContextId, this.formDescriptionEditorId, this.newLabel);
+    }
+}

--- a/packages/formdescriptioneditors/backend/sirius-components-collaborative-formdescriptioneditors/src/main/java/org/eclipse/sirius/components/collaborative/formdescriptioneditors/handlers/RenameFormDescriptionEditorEventHandler.java
+++ b/packages/formdescriptioneditors/backend/sirius-components-collaborative-formdescriptioneditors/src/main/java/org/eclipse/sirius/components/collaborative/formdescriptioneditors/handlers/RenameFormDescriptionEditorEventHandler.java
@@ -1,0 +1,92 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.collaborative.formdescriptioneditors.handlers;
+
+import java.util.Objects;
+
+import org.eclipse.sirius.components.collaborative.api.ChangeDescription;
+import org.eclipse.sirius.components.collaborative.api.ChangeKind;
+import org.eclipse.sirius.components.collaborative.api.IRepresentationPersistenceService;
+import org.eclipse.sirius.components.collaborative.api.Monitoring;
+import org.eclipse.sirius.components.collaborative.dto.RenameRepresentationSuccessPayload;
+import org.eclipse.sirius.components.collaborative.formdescriptioneditors.api.IFormDescriptionEditorContext;
+import org.eclipse.sirius.components.collaborative.formdescriptioneditors.api.IFormDescriptionEditorEventHandler;
+import org.eclipse.sirius.components.collaborative.formdescriptioneditors.api.IFormDescriptionEditorInput;
+import org.eclipse.sirius.components.collaborative.formdescriptioneditors.dto.RenameFormDescriptionEditorInput;
+import org.eclipse.sirius.components.collaborative.formdescriptioneditors.messages.ICollaborativeFormDescriptionEditorMessageService;
+import org.eclipse.sirius.components.core.api.ErrorPayload;
+import org.eclipse.sirius.components.core.api.IEditingContext;
+import org.eclipse.sirius.components.core.api.IPayload;
+import org.eclipse.sirius.components.formdescriptioneditors.FormDescriptionEditor;
+import org.springframework.stereotype.Service;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import reactor.core.publisher.Sinks.Many;
+import reactor.core.publisher.Sinks.One;
+
+/**
+ * Handler used to rename a form.
+ *
+ * @author arichard
+ */
+@Service
+public class RenameFormDescriptionEditorEventHandler implements IFormDescriptionEditorEventHandler {
+
+    private final IRepresentationPersistenceService representationPersistenceService;
+
+    private final ICollaborativeFormDescriptionEditorMessageService messageService;
+
+    private final Counter counter;
+
+    public RenameFormDescriptionEditorEventHandler(IRepresentationPersistenceService representationPersistenceService, ICollaborativeFormDescriptionEditorMessageService messageService,
+            MeterRegistry meterRegistry) {
+        this.representationPersistenceService = Objects.requireNonNull(representationPersistenceService);
+        this.messageService = Objects.requireNonNull(messageService);
+
+        // @formatter:off
+        this.counter = Counter.builder(Monitoring.EVENT_HANDLER)
+                .tag(Monitoring.NAME, this.getClass().getSimpleName())
+                .register(meterRegistry);
+        // @formatter:on
+    }
+
+    @Override
+    public boolean canHandle(IFormDescriptionEditorInput formDescriptionEditorInput) {
+        return formDescriptionEditorInput instanceof RenameFormDescriptionEditorInput;
+    }
+
+    @Override
+    public void handle(One<IPayload> payloadSink, Many<ChangeDescription> changeDescriptionSink, IEditingContext editingContext, IFormDescriptionEditorContext formDescriptionEditorContext,
+            IFormDescriptionEditorInput formDescriptionEditorInput) {
+        this.counter.increment();
+
+        String message = this.messageService.invalidInput(formDescriptionEditorInput.getClass().getSimpleName(), RenameFormDescriptionEditorInput.class.getSimpleName());
+        IPayload payload = new ErrorPayload(formDescriptionEditorInput.getId(), message);
+        ChangeDescription changeDescription = new ChangeDescription(ChangeKind.NOTHING, formDescriptionEditorInput.getRepresentationId(), formDescriptionEditorInput);
+
+        if (formDescriptionEditorInput instanceof RenameFormDescriptionEditorInput) {
+            RenameFormDescriptionEditorInput renameRepresentationInput = (RenameFormDescriptionEditorInput) formDescriptionEditorInput;
+            String newLabel = renameRepresentationInput.getNewLabel();
+
+            FormDescriptionEditor renamedFormDescriptionEditor = FormDescriptionEditor.newFormDescriptionEditor(formDescriptionEditorContext.getFormDescriptionEditor()).label(newLabel).build();
+            this.representationPersistenceService.save(editingContext, renamedFormDescriptionEditor);
+
+            payload = new RenameRepresentationSuccessPayload(formDescriptionEditorInput.getId(), renamedFormDescriptionEditor);
+            changeDescription = new ChangeDescription(ChangeKind.REPRESENTATION_RENAMING, renameRepresentationInput.getRepresentationId(), formDescriptionEditorInput);
+        }
+
+        payloadSink.tryEmitValue(payload);
+        changeDescriptionSink.tryEmitNext(changeDescription);
+    }
+}

--- a/packages/formdescriptioneditors/backend/sirius-components-collaborative-formdescriptioneditors/src/test/java/org/eclipse/sirius/components/collaborative/formdescriptioneditors/handlers/RenameFormDescriptionEditorEventHandlerTests.java
+++ b/packages/formdescriptioneditors/backend/sirius-components-collaborative-formdescriptioneditors/src/test/java/org/eclipse/sirius/components/collaborative/formdescriptioneditors/handlers/RenameFormDescriptionEditorEventHandlerTests.java
@@ -1,0 +1,92 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.collaborative.formdescriptioneditors.handlers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.eclipse.sirius.components.collaborative.api.ChangeDescription;
+import org.eclipse.sirius.components.collaborative.api.ChangeKind;
+import org.eclipse.sirius.components.collaborative.api.IRepresentationPersistenceService;
+import org.eclipse.sirius.components.collaborative.dto.RenameRepresentationSuccessPayload;
+import org.eclipse.sirius.components.collaborative.formdescriptioneditors.api.IFormDescriptionEditorContext;
+import org.eclipse.sirius.components.collaborative.formdescriptioneditors.dto.RenameFormDescriptionEditorInput;
+import org.eclipse.sirius.components.collaborative.formdescriptioneditors.messages.ICollaborativeFormDescriptionEditorMessageService;
+import org.eclipse.sirius.components.core.api.IEditingContext;
+import org.eclipse.sirius.components.core.api.IPayload;
+import org.eclipse.sirius.components.formdescriptioneditors.FormDescriptionEditor;
+import org.junit.jupiter.api.Test;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import reactor.core.publisher.Sinks;
+import reactor.core.publisher.Sinks.Many;
+import reactor.core.publisher.Sinks.One;
+
+/**
+ * Unit tests of the rename representation event handler.
+ *
+ * @author arichard
+ */
+public class RenameFormDescriptionEditorEventHandlerTests {
+    private static final String OLD_LABEL = "oldLabel"; //$NON-NLS-1$
+
+    private static final String NEW_LABEL = "newLabel"; //$NON-NLS-1$
+
+    @Test
+    public void testRenameRepresentation() {
+        String projectId = UUID.randomUUID().toString();
+        String formDescriptionEditorDescriptionId = UUID.randomUUID().toString();
+        String representationId = UUID.randomUUID().toString();
+        UUID targetObjectId = UUID.randomUUID();
+
+        // @formatter:off
+        FormDescriptionEditor formDescriptionEditor = FormDescriptionEditor.newFormDescriptionEditor(representationId)
+                .label(OLD_LABEL)
+                .descriptionId(formDescriptionEditorDescriptionId)
+                .targetObjectId(targetObjectId.toString())
+                .widgets(List.of())
+                .build();
+        // @formatter:on
+
+        RenameFormDescriptionEditorEventHandler handler = new RenameFormDescriptionEditorEventHandler(new IRepresentationPersistenceService.NoOp(),
+                new ICollaborativeFormDescriptionEditorMessageService.NoOp(), new SimpleMeterRegistry());
+
+        var input = new RenameFormDescriptionEditorInput(UUID.randomUUID(), projectId, representationId, NEW_LABEL);
+        assertThat(handler.canHandle(input)).isTrue();
+
+        Many<ChangeDescription> changeDescriptionSink = Sinks.many().unicast().onBackpressureBuffer();
+        One<IPayload> payloadSink = Sinks.one();
+
+        IFormDescriptionEditorContext formDescriptionEditorContext = new IFormDescriptionEditorContext() {
+
+            @Override
+            public void update(FormDescriptionEditor updatedFormDescriptionEditor) {
+            }
+
+            @Override
+            public FormDescriptionEditor getFormDescriptionEditor() {
+                return formDescriptionEditor;
+            }
+        };
+        handler.handle(payloadSink, changeDescriptionSink, new IEditingContext.NoOp(), formDescriptionEditorContext, input);
+
+        ChangeDescription changeDescription = changeDescriptionSink.asFlux().blockFirst();
+        assertThat(changeDescription.getKind()).isEqualTo(ChangeKind.REPRESENTATION_RENAMING);
+
+        IPayload payload = payloadSink.asMono().block();
+        assertThat(payload).isInstanceOf(RenameRepresentationSuccessPayload.class);
+        assertThat(((RenameRepresentationSuccessPayload) payload).getRepresentation().getLabel()).isEqualTo(NEW_LABEL);
+    }
+}


### PR DESCRIPTION
Bug: https://github.com/eclipse-sirius/sirius-components/issues/1354
Signed-off-by: Axel RICHARD <axel.richard@obeo.fr>

# Pull request template

## General purpose
What is the main goal of this pull request?
- [x] Bug fixes
- [ ] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [x] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [x] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [x] Have the relevant issues been added to the pull request?
- [x] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [x] Have the relevant issues been added to the same project and milestone as the pull request?
- [x] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [x] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?