### PR TITLE
[2195] Set border color to None now set the color to none

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -63,6 +63,7 @@ A suitable implementation is to get the id of the `self` object using `IObjectSe
 - https://github.com/eclipse-sirius/sirius-web/issues/2192[#2192] [view] Fix an issue where the _Shape_ property of an ImageNodeStyle was not mandatory.
 An error message is now displayed if the _Shape_ is not set. 
 - https://github.com/eclipse-sirius/sirius-web/issues/2309[#2309] [diagram] Fix an issue where the edge labels where not always centered on react-flow diagrams
+- https://github.com/eclipse-sirius/sirius-web/issues/2195[#2195] [view] Fix an issue where a border color set to _None_ would set the color to a default color, not none.
 
 === New Features
 
@@ -72,7 +73,7 @@ An error message is now displayed if the _Shape_ is not set.
 - https://github.com/eclipse-sirius/sirius-web/issues/2253[#2253] [diagram] Add the possibility of organizing palette tools into sections
 - https://github.com/eclipse-sirius/sirius-web/issues/2236[#2236] [forms] It is now possible to use `For` and `If` constructs inside the definition of Form (currently only inside _Groups_ and _Flexbox containers_).
 Both constructs are commonly combined together, with e.g. _For_ iterating on the different features of the current semantic element and several _If_ inside the loop to decide which concrete widget(s) to instantiate depending on the feature's type.
-They can however also be used independently (e.g. a single _If_ ouside of a _For_ to make the presence of a widget conditional) and combined in arbitrary ways (e.g. nested loops or conditionals).
+They can however also be used independently (e.g. a single _If_ outside of a _For_ to make the presence of a widget conditional) and combined in arbitrary ways (e.g. nested loops or conditionals).
 Note that this first version has a known limitation: _FormDescriptions_ which use _For_ or _If_ elements can not be reliably edited using the _Form Description Editor_.
 This will be fixed in the next version.
 

--- a/packages/view/backend/sirius-components-view-emf/src/main/java/org/eclipse/sirius/components/view/emf/diagram/StylesFactory.java
+++ b/packages/view/backend/sirius-components-view-emf/src/main/java/org/eclipse/sirius/components/view/emf/diagram/StylesFactory.java
@@ -52,7 +52,6 @@ public final class StylesFactory {
     }
 
     public LabelStyleDescription createLabelStyleDescription(NodeStyleDescription nodeStyle) {
-        // @formatter:off
         return LabelStyleDescription.newLabelStyleDescription()
                                     .colorProvider(variableManager -> Optional.ofNullable(nodeStyle.getLabelColor())
                                                                               .filter(FixedColor.class::isInstance)
@@ -72,11 +71,9 @@ public final class StylesFactory {
                                         return iconURL;
                                     })
                                     .build();
-        // @formatter:on
     }
 
     public LabelStyleDescription createEdgeLabelStyleDescription(org.eclipse.sirius.components.view.diagram.EdgeStyle edgeStyle) {
-        // @formatter:off
         return LabelStyleDescription.newLabelStyleDescription()
                                     .colorProvider(variableManager -> Optional.ofNullable(edgeStyle.getColor())
                                                                               .filter(FixedColor.class::isInstance)
@@ -96,11 +93,9 @@ public final class StylesFactory {
                                         return iconURL;
                                     })
                                     .build();
-        // @formatter:on
     }
 
     public EdgeStyle createEdgeStyle(org.eclipse.sirius.components.view.diagram.EdgeStyle edgeStyle) {
-        // @formatter:off
         return EdgeStyle.newEdgeStyle()
                         .color(Optional.ofNullable(edgeStyle.getColor())
                                        .filter(FixedColor.class::isInstance)
@@ -112,7 +107,6 @@ public final class StylesFactory {
                         .sourceArrow(ArrowStyle.valueOf(edgeStyle.getSourceArrowStyle().getLiteral()))
                         .targetArrow(ArrowStyle.valueOf(edgeStyle.getTargetArrowStyle().getLiteral()))
                         .build();
-        // @formatter:on
     }
 
     public String getNodeType(NodeStyleDescription nodeStyleDescription) {
@@ -140,7 +134,6 @@ public final class StylesFactory {
                 result = IconLabelNodeStyle.newIconLabelNodeStyle().backgroundColor("transparent").build();
                 break;
             case NodeType.NODE_RECTANGLE:
-                // @formatter:off
                 result = RectangularNodeStyle.newRectangularNodeStyle()
                     .withHeader(((RectangularNodeStyleDescription) nodeStyle).isWithHeader())
                     .color(Optional.ofNullable(nodeStyle.getColor())
@@ -152,13 +145,12 @@ public final class StylesFactory {
                                          .filter(FixedColor.class::isInstance)
                                          .map(FixedColor.class::cast)
                                          .map(FixedColor::getValue)
-                                         .orElse(DEFAULT_COLOR))
+                                         .orElse(""))
                     .borderSize(nodeStyle.getBorderSize())
                     .borderStyle(LineStyle.valueOf(nodeStyle.getBorderLineStyle().getLiteral()))
                     .borderRadius(nodeStyle.getBorderRadius())
                     .build();
                 break;
-                // @formatter:on
             default:
                 for (INodeStyleProvider iNodeStyleProvider : this.iNodeStyleProviders) {
                     Optional<INodeStyle> nodeStyleOpt = iNodeStyleProvider.createNodeStyle(nodeStyle, optionalEditingContextId);
@@ -169,7 +161,6 @@ public final class StylesFactory {
                 }
         }
         if (result == null) {
-            // @formatter:off
             result = RectangularNodeStyle.newRectangularNodeStyle()
                    .withHeader(true)
                    .color(Optional.ofNullable(nodeStyle.getColor())
@@ -181,15 +172,13 @@ public final class StylesFactory {
                                         .filter(FixedColor.class::isInstance)
                                         .map(FixedColor.class::cast)
                                         .map(FixedColor::getValue)
-                                        .orElse(DEFAULT_COLOR))
+                                        .orElse(""))
                    .borderSize(nodeStyle.getBorderSize())
                    .borderStyle(LineStyle.valueOf(nodeStyle.getBorderLineStyle().getLiteral()))
                    .borderRadius(nodeStyle.getBorderRadius())
                    .build();
-            // @formatter:on
         }
 
         return result;
     }
-    // CHECKSTYLE:ON
 }


### PR DESCRIPTION
Instead of set the color to a default color

Bug: https://github.com/eclipse-sirius/sirius-web/issues/2195

# Pull request template

## General purpose
What is the main goal of this pull request?
- [x] Bug fixes
- [ ] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [x] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [x] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [x] Have the relevant issues been added to the pull request?
- [x] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [x] Have the relevant issues been added to the same project and milestone as the pull request?
- [x] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?