### PR TITLE
[4618] Ensure layout-related mutations use a unique event id

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -36,6 +36,8 @@
 - https://github.com/eclipse-sirius/sirius-web/issues/4495[#4495] [form] Add an user indicator when executing form actions
 - https://github.com/eclipse-sirius/sirius-web/issues/4614[#4614] [view] Reduce the coupling of the `ViewFormDescriptionConverter`
 - https://github.com/eclipse-sirius/sirius-web/issues/4609[#4609] [sirius-web] Separate the representation metadata from the project bounded context.
+- https://github.com/eclipse-sirius/sirius-web/issues/4618[#4618] [diagram] Ensure layout-related mutations use a unique event id.
+Except for the specific case where `cause === 'refresh'` in `DiagramRenderer` (which corresponds to a layout update *after* an existing operation which caused the refresh, in which case we must reuse the original event id), other diagram-related mutations should behave like all the others and get a unique event id to clearly identify them.
 
 
 == v2025.2.0

--- a/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/DiagramRenderer.tsx
+++ b/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/DiagramRenderer.tsx
@@ -238,7 +238,7 @@ export const DiagramRenderer = memo(({ diagramRefreshedEventPayload }: DiagramRe
   const { transformUndraggableListNodeChanges, applyMoveChange } = useMoveChange();
   const { transformResizeListNodeChanges } = useResizeChange();
   const { applyHandleChange } = useHandleChange();
-  const { layoutOnBoundsChange } = useLayoutOnBoundsChange(diagramRefreshedEventPayload.id);
+  const { layoutOnBoundsChange } = useLayoutOnBoundsChange();
   const { filterReadOnlyChanges } = useFilterReadOnlyChanges();
   const {
     helperLinesEnabled,

--- a/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/adjust-size/useAdjustSize.tsx
+++ b/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/adjust-size/useAdjustSize.tsx
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Obeo.
+ * Copyright (c) 2024, 2025 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -11,9 +11,6 @@
  *     Obeo - initial API and implementation
  *******************************************************************************/
 import { Edge, Node, useReactFlow } from '@xyflow/react';
-import { useContext } from 'react';
-import { DiagramContext } from '../../contexts/DiagramContext';
-import { DiagramContextValue } from '../../contexts/DiagramContext.types';
 import { EdgeData, NodeData } from '../DiagramRenderer.types';
 import { RawDiagram } from '../layout/layout.types';
 import { useLayout } from '../layout/useLayout';
@@ -24,7 +21,6 @@ import { UseAdjustSizeValue } from './useAdjustSize.types';
 
 export const useAdjustSize = (): UseAdjustSizeValue => {
   const { layout } = useLayout();
-  const { refreshEventPayloadId } = useContext<DiagramContextValue>(DiagramContext);
   const { synchronizeLayoutData } = useSynchronizeLayoutData();
   const { hideDiagramElementPalette } = useDiagramElementPalette();
   const { getNodes, getEdges, setNodes, setEdges } = useReactFlow<Node<NodeData>, Edge<EdgeData>>();
@@ -58,7 +54,7 @@ export const useAdjustSize = (): UseAdjustSizeValue => {
           nodes: nodes,
           edges: laidOutDiagram.edges,
         };
-        synchronizeLayoutData(refreshEventPayloadId, finalDiagram);
+        synchronizeLayoutData(crypto.randomUUID(), finalDiagram);
         hideDiagramElementPalette();
       });
     }

--- a/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/edge/useEditableEdgePath.ts
+++ b/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/edge/useEditableEdgePath.ts
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Obeo.
+ * Copyright (c) 2024, 2025 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -11,19 +11,16 @@
  *     Obeo - initial API and implementation
  *******************************************************************************/
 import { Edge, Node } from '@xyflow/react';
-import { useCallback, useContext } from 'react';
-import { UseEditableEdgePathValue } from './useEditableEdgePath.types';
-import { NodeData, EdgeData } from '../DiagramRenderer.types';
-import { RawDiagram } from '../layout/layout.types';
-import { DiagramNodeType } from '../node/NodeTypes.types';
+import { useCallback } from 'react';
 import { useStore } from '../../representation/useStore';
+import { EdgeData, NodeData } from '../DiagramRenderer.types';
+import { RawDiagram } from '../layout/layout.types';
 import { useSynchronizeLayoutData } from '../layout/useSynchronizeLayoutData';
-import { DiagramContextValue } from '../../contexts/DiagramContext.types';
-import { DiagramContext } from '../../contexts/DiagramContext';
+import { DiagramNodeType } from '../node/NodeTypes.types';
+import { UseEditableEdgePathValue } from './useEditableEdgePath.types';
 
 export const useEditableEdgePath = (): UseEditableEdgePathValue => {
   const { getEdges, getNodes, setEdges } = useStore();
-  const { refreshEventPayloadId } = useContext<DiagramContextValue>(DiagramContext);
   const { synchronizeLayoutData } = useSynchronizeLayoutData();
 
   const synchronizeEdgeLayoutData = useCallback(
@@ -32,9 +29,9 @@ export const useEditableEdgePath = (): UseEditableEdgePathValue => {
         nodes: [...getNodes()] as Node<NodeData, DiagramNodeType>[],
         edges: edges,
       };
-      synchronizeLayoutData(refreshEventPayloadId, finalDiagram);
+      synchronizeLayoutData(crypto.randomUUID(), finalDiagram);
     },
-    [refreshEventPayloadId, getNodes, synchronizeLayoutData]
+    [getNodes, synchronizeLayoutData]
   );
 
   const removeEdgeLayoutData = useCallback(

--- a/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/layout-events/useLayoutOnBoundsChange.ts
+++ b/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/layout-events/useLayoutOnBoundsChange.ts
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2024 Obeo.
+ * Copyright (c) 2023, 2025 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -21,7 +21,7 @@ import { useSynchronizeLayoutData } from '../layout/useSynchronizeLayoutData';
 import { DiagramNodeType } from '../node/NodeTypes.types';
 import { UseLayoutOnBoundsChangeValue } from './useLayoutOnBoundsChange.types';
 
-export const useLayoutOnBoundsChange = (refreshEventPayloadId: string): UseLayoutOnBoundsChangeValue => {
+export const useLayoutOnBoundsChange = (): UseLayoutOnBoundsChangeValue => {
   const { layout } = useLayout();
   const { synchronizeLayoutData } = useSynchronizeLayoutData();
   const { getEdges, getNodes } = useStore();
@@ -116,11 +116,11 @@ export const useLayoutOnBoundsChange = (refreshEventPayloadId: string): UseLayou
             edges: laidOutDiagram.edges,
           };
 
-          synchronizeLayoutData(refreshEventPayloadId, finalDiagram);
+          synchronizeLayoutData(crypto.randomUUID(), finalDiagram);
         });
       }
     },
-    [refreshEventPayloadId, synchronizeLayoutData, getNodes]
+    [synchronizeLayoutData, getNodes]
   );
 
   return { layoutOnBoundsChange };

--- a/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/layout/useArrangeAll.ts
+++ b/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/layout/useArrangeAll.ts
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Obeo.
+ * Copyright (c) 2024, 2025 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -14,9 +14,6 @@ import { useMultiToast } from '@eclipse-sirius/sirius-components-core';
 import { Edge, Node, useReactFlow, useViewport } from '@xyflow/react';
 import { LayoutOptions } from 'elkjs/lib/elk-api';
 import ELK, { ElkLabel, ElkNode } from 'elkjs/lib/elk.bundled';
-import { useContext } from 'react';
-import { DiagramContext } from '../../contexts/DiagramContext';
-import { DiagramContextValue } from '../../contexts/DiagramContext.types';
 import { useDiagramDescription } from '../../contexts/useDiagramDescription';
 import { EdgeData, NodeData } from '../DiagramRenderer.types';
 import { ListNodeData } from '../node/ListNode.types';
@@ -123,7 +120,6 @@ export const useArrangeAll = (reactFlowWrapper: React.MutableRefObject<HTMLDivEl
   const { layout } = useLayout();
   const { synchronizeLayoutData } = useSynchronizeLayoutData();
   const { diagramDescription } = useDiagramDescription();
-  const { refreshEventPayloadId } = useContext<DiagramContextValue>(DiagramContext);
   const { resolveNodeOverlap } = useOverlap();
   const { addErrorMessage } = useMultiToast();
 
@@ -277,7 +273,7 @@ export const useArrangeAll = (reactFlowWrapper: React.MutableRefObject<HTMLDivEl
             nodes: laidOutNodesWithElk,
             edges: laidOutDiagram.edges,
           };
-          synchronizeLayoutData(refreshEventPayloadId, finalDiagram);
+          synchronizeLayoutData(crypto.randomUUID(), finalDiagram);
           resolve();
         });
       });

--- a/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/layout/useDistributeElements.ts
+++ b/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/layout/useDistributeElements.ts
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Obeo.
+ * Copyright (c) 2024, 2025 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -12,9 +12,7 @@
  *******************************************************************************/
 import { useMultiToast } from '@eclipse-sirius/sirius-components-core';
 import { Edge, Node, XYPosition, useReactFlow } from '@xyflow/react';
-import { useCallback, useContext } from 'react';
-import { DiagramContext } from '../../contexts/DiagramContext';
-import { DiagramContextValue } from '../../contexts/DiagramContext.types';
+import { useCallback } from 'react';
 import { EdgeData, NodeData } from '../DiagramRenderer.types';
 import { DiagramNodeType } from '../node/NodeTypes.types';
 import { useOverlap } from '../overlap/useOverlap';
@@ -40,7 +38,6 @@ export const useDistributeElements = (): UseDistributeElementsValue => {
   const { layout } = useLayout();
   const { synchronizeLayoutData } = useSynchronizeLayoutData();
   const { addMessages } = useMultiToast();
-  const { refreshEventPayloadId } = useContext<DiagramContextValue>(DiagramContext);
   const { resolveNodeOverlap } = useOverlap();
 
   const processLayoutTool = (
@@ -85,7 +82,7 @@ export const useDistributeElements = (): UseDistributeElementsValue => {
           nodes: overlapFreeNodesAfterLayout as Node<NodeData, DiagramNodeType>[],
           edges: laidOutDiagram.edges,
         };
-        synchronizeLayoutData(refreshEventPayloadId, finalDiagram);
+        synchronizeLayoutData(crypto.randomUUID(), finalDiagram);
       });
     }
   };
@@ -157,11 +154,11 @@ export const useDistributeElements = (): UseDistributeElementsValue => {
               nodes: laidOutDiagram.nodes,
               edges: laidOutDiagram.edges,
             };
-            synchronizeLayoutData(refreshEventPayloadId, finalDiagram);
+            synchronizeLayoutData(crypto.randomUUID(), finalDiagram);
           });
         }
       },
-      [resolveNodeOverlap, refreshEventPayloadId]
+      [resolveNodeOverlap]
     );
   };
 
@@ -219,7 +216,7 @@ export const useDistributeElements = (): UseDistributeElementsValue => {
           ['left', 'right', 'center'].includes(orientation) ? 'vertical' : 'horizontal'
         );
       },
-      [resolveNodeOverlap, refreshEventPayloadId]
+      [resolveNodeOverlap]
     );
   };
 
@@ -242,7 +239,7 @@ export const useDistributeElements = (): UseDistributeElementsValue => {
           refElementId
         );
       },
-      [resolveNodeOverlap, refreshEventPayloadId]
+      [resolveNodeOverlap]
     );
   };
 
@@ -444,7 +441,7 @@ export const useDistributeElements = (): UseDistributeElementsValue => {
         refElementId
       );
     },
-    [resolveNodeOverlap, refreshEventPayloadId]
+    [resolveNodeOverlap]
   );
 
   return {


### PR DESCRIPTION
Except for the specific case where cause === 'refresh' in DiagramRenderer (which corresponds to a layout update *after* an existing operation which caused the refresh, in which case we must reuse the original event id), other diagram-related mutations should behave like all the others and get a unique event id to clearly identify them.

Signed-off-by: Pierre-Charles David <pierre-charles.david@obeo.fr>

# Pull request template

## General purpose
What is the main goal of this pull request?
- [ ] Bug fixes
- [x] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [ ] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [ ] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?