### PR TITLE
[doc] Add shape for loading indicators for project/document downloads

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -4,7 +4,7 @@
 
 === Shapes
 
-
+- Add loading indicator for downloads
 
 === Architectural decision records
 

--- a/doc/iterations/2025.4/add_loading_indicator_for_downloads.adoc
+++ b/doc/iterations/2025.4/add_loading_indicator_for_downloads.adoc
@@ -1,0 +1,41 @@
+= (S-M) Add loading indicator for downloads
+
+== Problem
+
+Projects can be downloaded through the contextual menu of the `/projects` page and of the `/project/$projectId/edit` page.
+Documents can be downloaded through the contextual menu in the Explorer view.
+
+These operations can take a bit of time as the backend produces the corresponding file (zip file for projects, serialized file for the document, etc.), especially on larger projects and documents.
+
+During these operations, the user has no feedback that something is actually going on, resulting in the possibility of them getting confused (has an issue occurred?) and/or leaving the page or re-trying the operation.
+
+== Key Result
+
+There should be a loading indicator for these operations.
+
+=== Acceptance Criteria
+
+* The loading indicator starts when the operation gets triggered by the user.
+* The loading indicator ends when the bulk of the operation is finished and the user can interact with the application to decide what to do with the downloaded file.
+
+== Solution
+
+* The loading indicator used will be a Material UI CircularProgress.
+* It will replace the icon of the ongoing action upon selection of the action.
+* We will rely on the completion of the resource fetching (e.g. the call to `https://sirius-web.staging.factory.obeo.fr/api/projects/$projectId` has finished) to terminate the loading indicator.
+
+=== Breadboarding
+
+
+
+=== Cutting backs
+
+* If possible we want to keep the action as an href to the corresponding API call (e.g. `https://sirius-web.staging.factory.obeo.fr/api/projects/$projectId`).
+
+== Rabbit holes
+
+
+
+== No-gos
+
+


### PR DESCRIPTION
Shape for #4950.

# Pull request template

## General purpose
What is the main goal of this pull request?
- [ ] Bug fixes
- [ ] New features
- [X] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [ ] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [ ] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`