### PR TITLE
[4094] Improve explorer rendering performances

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -184,7 +184,8 @@ This changes the behavior if there are delegates which *override* the default re
 - https://github.com/eclipse-sirius/sirius-web/issues/4874[#4874] [diagram] Move View DSL node layout strategy from node description to node style.
 This modification will enable a conditional style with a different layout strategy.
 - https://github.com/eclipse-sirius/sirius-web/issues/667[#667] [sirius-web] Restore layout and unsynchronized nodes when importing a project with a diagram
-
+- https://github.com/eclipse-sirius/sirius-web/issues/4094[#4094] [sirius-web] Improve the reacivity of the explorer rendering when hovering on a tree with many items are expanded/visible
+Handle the recursive part of the tree rendring in `Tree` instead of `TreeItem`, so that re-rendering a particular `TreeItem` has a fixed cost, independant of how many of its descendants are expanded/visible.
 
 
 == v2025.4.0

--- a/packages/diagrams/backend/sirius-components-collaborative-diagrams/src/main/java/org/eclipse/sirius/components/collaborative/diagrams/api/IDiagramContext.java
+++ b/packages/diagrams/backend/sirius-components-collaborative-diagrams/src/main/java/org/eclipse/sirius/components/collaborative/diagrams/api/IDiagramContext.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2024 Obeo and others.
+ * Copyright (c) 2019, 2025 Obeo and others.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -33,8 +33,21 @@ public interface IDiagramContext {
 
     Diagram getDiagram();
 
+    /**
+     * Used to update the internal diagram.
+     *
+     * @param updatedDiagram The updated diagram which should replace the current one
+     *
+     * @technical-debt This method should probably stop being used and be removed to use instead an immutable data structure
+     * for the diagram context. The interface itself could probably be removed entirely in favor of a simple record.
+     */
     void update(Diagram updatedDiagram);
 
+    /**
+     * Used to remove all the view creation / deletion requests and the various diagram events.
+     *
+     * @technical-debt The method should be deleted in favor of an immutable data structure for the diagram context.
+     */
     void reset();
 
     List<ViewCreationRequest> getViewCreationRequests();

--- a/packages/diagrams/backend/sirius-components-diagrams/src/main/java/org/eclipse/sirius/components/diagrams/Node.java
+++ b/packages/diagrams/backend/sirius-components-diagrams/src/main/java/org/eclipse/sirius/components/diagrams/Node.java
@@ -24,6 +24,7 @@ import org.eclipse.sirius.components.annotations.Immutable;
  *
  * @author hmarchadour
  * @author sbegaudeau
+ * @since v0.1.0
  */
 @Immutable
 public final class Node implements IDiagramElement {
@@ -93,10 +94,24 @@ public final class Node implements IDiagramElement {
         return this.targetObjectId;
     }
 
+    /**
+     * Returns the kind of the semantic element used as the target of the node.
+     *
+     * @return The kind of the semantic element
+     *
+     * @technical-debt This method should be removed since this requirement was caused by some technical debt
+     */
     public String getTargetObjectKind() {
         return this.targetObjectKind;
     }
 
+    /**
+     * Returns the label of the semantic element used as the target of the node.
+     *
+     * @return The label of the semantic element
+     *
+     * @technical-debt This method should be removed since this requirement was caused by some technical debt
+     */
     public String getTargetObjectLabel() {
         return this.targetObjectLabel;
     }

--- a/packages/diagrams/backend/sirius-components-diagrams/src/main/java/org/eclipse/sirius/components/diagrams/description/DiagramDescription.java
+++ b/packages/diagrams/backend/sirius-components-diagrams/src/main/java/org/eclipse/sirius/components/diagrams/description/DiagramDescription.java
@@ -47,6 +47,11 @@ public final class DiagramDescription implements IRepresentationDescription {
      */
     public static final String DESCRIPTION_ID = "descriptionId";
 
+    /**
+     * The name of the variable used to store the result of the rendering to allow specifiers to access data from the
+     * rendering before the entire diagram has been rendered. This variable can be used to allow the rendering of the edges
+     * to retrieve the nodes rendered beforehand.
+     */
     public static final String CACHE = "cache";
 
     /**
@@ -156,7 +161,16 @@ public final class DiagramDescription implements IRepresentationDescription {
     }
 
     /**
-     * Provides a function which will be used when a new diagram is created in order to compute its label.
+     * Provides a function which will be used when a new diagram is created in order to compute its label.<p>
+     *
+     * <p>
+     *     The following variables will at least be available when this behavior is executed:
+     * </p>
+     *
+     * <ul>
+     *     <li><strong>self</strong> - The semantic element on which the diagram is being created</li>
+     *     <li><strong>label</strong> - The text entered by the end user to use as the label of the diagram</li>
+     * </ul>
      *
      * @return A function used to compute the label of the representation.
      *
@@ -252,6 +266,14 @@ public final class DiagramDescription implements IRepresentationDescription {
 
     /**
      * Provides the function which will be used to retrieve the URL of the various images composing the icon of the diagram.
+     *
+     * <p>
+     *     The following variables will at least be available when this behavior is executed:
+     * </p>
+     *
+     * <ul>
+     *     <li><strong>self</strong> - The semantic element on which the diagram is being created</li>
+     * </ul>
      *
      * @return A function used to compute the URLs of the icon associated with the diagram.
      *

--- a/packages/diagrams/backend/sirius-components-diagrams/src/main/java/org/eclipse/sirius/components/diagrams/description/NodeDescription.java
+++ b/packages/diagrams/backend/sirius-components-diagrams/src/main/java/org/eclipse/sirius/components/diagrams/description/NodeDescription.java
@@ -30,6 +30,7 @@ import org.eclipse.sirius.components.representations.VariableManager;
  * The description of the node.
  *
  * @author sbegaudeau
+ * @since v0.1.0
  */
 @Immutable
 public final class NodeDescription implements IDiagramElementDescription {
@@ -115,18 +116,61 @@ public final class NodeDescription implements IDiagramElementDescription {
         return this.targetObjectIdProvider;
     }
 
+    /**
+     * Provides a function used to compute the kind of the semantic element used as the target of the node.
+     *
+     * @return A function used to return the kind of the semantic element.
+     *
+     * @technical-debt This method should be removed since its addition was caused by some technical debt in the explorer.
+     */
     public Function<VariableManager, String> getTargetObjectKindProvider() {
         return this.targetObjectKindProvider;
     }
 
+    /**
+     * Provides a function used to compute the label of the semantic element used as the target of the node.
+     *
+     * @return A function used to return the label of the semantic element.
+     *
+     * @technical-debt This method should be removed since its addition was caused by some technical debt in the explorer.
+     */
     public Function<VariableManager, String> getTargetObjectLabelProvider() {
         return this.targetObjectLabelProvider;
     }
 
+    /**
+     * Provides the function which will be used to compute the semantic elements which will be used as the target of some
+     * nodes created from this description.
+     *
+     * <p>
+     *     The following variables will at least be available when this behavior is executed:
+     * </p>
+     *
+     * <ul>
+     *     <li><strong>self</strong> - The semantic element used by the parent element, for example the root of the diagram
+     *     for top level nodes or the semantic element used as a target by the parent node</li>
+     *     <li><strong>editingContext</strong> - The editing context used to access any semantic element thanks to the core
+     *     services</li>
+     *     <li><strong>previousDiagram</strong> - The previously rendered diagram or null if it is being rendered for the
+     *     first time</li>
+     *     <li><strong>diagramContext</strong> - The diagram context is used to access the various events along with the
+     *     view creation and deletion requests</li>
+     * </ul>
+     *
+     * @return A function used to return the semantic elements to use as the target of the nodes.
+     */
     public Function<VariableManager, List<?>> getSemanticElementsProvider() {
         return this.semanticElementsProvider;
     }
 
+    /**
+     * Provides a predicate used to indicate if a node should be rendered from the node description.
+     *
+     * @return A predicate to determine if a node should be rendered or not
+     *
+     * @technical-debt This method should probably be removed and the predicate be integrated in the semantic elements
+     * provider by downstream specifiers.
+     */
     public Predicate<VariableManager> getShouldRenderPredicate() {
         return this.shouldRenderPredicate;
     }
@@ -167,10 +211,58 @@ public final class NodeDescription implements IDiagramElementDescription {
         return this.reusedChildNodeDescriptionIds;
     }
 
+    /**
+     * Provides a function used to execute the deletion of the node.
+     *
+     * <p>
+     *     The following variables will at least be available when this behavior is executed:
+     * </p>
+     *
+     * <ul>
+     *     <li><strong>self</strong> - The semantic element used as a target by the node to be deleted</li>
+     *     <li><strong>editingContext</strong> - The editing context used to access any semantic element thanks to the
+     *     core services</li>
+     *     <li><strong>diagramContext</strong> - The diagram context is used to access the various events along with the
+     *     view creation and deletion requests</li>
+     *     <li><strong>selectedNode</strong> - The node which should be deleted</li>
+     * </ul>
+     *
+     * @return A function provided by a specifier to trigger the deletion of the node
+     *
+     * @technical-debt This function is unused during the rendering and should thus be removed. Hardcoding such behavior
+     * into the description also provides a poor extensibility of the diagram representation by preventing downstream
+     * consumers from updating the existing behavior or adding a new one easily
+     */
     public Function<VariableManager, IStatus> getDeleteHandler() {
         return this.deleteHandler;
     }
 
+    /**
+     * Provides a function used to let end users drop nodes on another node.
+     *
+     * <p>
+     *     The following variables will at least be available when this behavior is executed:
+     * </p>
+     *
+     * <ul>
+     *     <li><strong>editingContext</strong> - The editing context used to access any semantic element thanks to the
+     *     core services</li>
+     *     <li><strong>diagramContext</strong> - The diagram context is used to access the various events along with the
+     *     view creation and deletion requests</li>
+     *     <li><strong>droppedElement</strong> - The semantic element used as a target by the dropped node</li>
+     *     <li><strong>droppedNode</strong> - The node being dropped</li>
+     *     <li><strong>targetElement</strong> - The semantic element used as a target by the target of the drop (another
+     *     node or the diagram itself)</li>
+     *     <li><strong>targetNode</strong> - The node in which the node is being dropped or null if dropped on the diagram
+     *     itself</li>
+     * </ul>
+     *
+     * @return A function provided by a specifier to drop nodes on another node
+     *
+     * @technical-debt This function is unused during the rendering and should thus be removed. Hardcoding such behavior
+     * into the description also provides a poor extensibility of the diagram representation by preventing downstream
+     * consumers from updating the existing behavior or adding a new one easily
+     */
     public Function<VariableManager, IStatus> getDropNodeHandler() {
         return this.dropNodeHandler;
     }

--- a/packages/diagrams/backend/sirius-components-diagrams/src/main/java/org/eclipse/sirius/components/diagrams/events/IDiagramEvent.java
+++ b/packages/diagrams/backend/sirius-components-diagrams/src/main/java/org/eclipse/sirius/components/diagrams/events/IDiagramEvent.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2024 THALES GLOBAL SERVICES.
+ * Copyright (c) 2021, 2025 THALES GLOBAL SERVICES.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -22,6 +22,9 @@ public interface IDiagramEvent {
 
     /**
      * The name of the variable used to store and retrieve the diagram event from a variable manager.
+     *
+     * @technical-debt This variable has probably no reason to exist since the same content can be retrieved directly
+     * from IDiagramContext#getDiagramEvents.
      */
     String DIAGRAM_EVENTS = "diagramEvents";
 }

--- a/packages/trees/frontend/sirius-components-trees/src/treeitems/TreeItem.tsx
+++ b/packages/trees/frontend/sirius-components-trees/src/treeitems/TreeItem.tsx
@@ -10,14 +10,15 @@
  * Contributors:
  *     Obeo - initial API and implementation
  *******************************************************************************/
-import { DRAG_SOURCES_TYPE, GQLStyledString, IconOverlay, StyledLabel } from '@eclipse-sirius/sirius-components-core';
-import CropDinIcon from '@mui/icons-material/CropDin';
+import { DRAG_SOURCES_TYPE, GQLStyledString, StyledLabel } from '@eclipse-sirius/sirius-components-core';
 import React, { useEffect, useRef, useState } from 'react';
 import { makeStyles } from 'tss-react/mui';
+import { GQLTreeItem } from '../views/TreeView.types';
 import { PartHovered, TreeItemProps, TreeItemState } from './TreeItem.types';
 import { TreeItemAction } from './TreeItemAction';
 import { TreeItemArrow } from './TreeItemArrow';
 import { TreeItemDirectEditInput } from './TreeItemDirectEditInput';
+import { TreeItemIcon } from './TreeItemIcon';
 import { isFilterCandidate } from './filterTreeItem';
 import { useDropTreeItem } from './useDropTreeItem';
 
@@ -97,9 +98,30 @@ export const getString = (styledString: GQLStyledString): string => {
   return styledString.styledStringFragments.map((fragments) => fragments.text).join('');
 };
 
+const getTooltipText = (item: GQLTreeItem) => {
+  let tooltipText = '';
+  if (item.kind.startsWith('siriusComponents://semantic')) {
+    const query = item.kind.substring(item.kind.indexOf('?') + 1, item.kind.length);
+    const params = new URLSearchParams(query);
+    if (params.has('domain') && params.has('entity')) {
+      tooltipText = params.get('domain') + '::' + params.get('entity');
+    }
+  } else if (item.kind.startsWith('siriusComponents://representation')) {
+    const query = item.kind.substring(item.kind.indexOf('?') + 1, item.kind.length);
+    const params = new URLSearchParams(query);
+    if (params.has('type')) {
+      tooltipText = params.get('type') ?? 'representation';
+    }
+  }
+  return tooltipText;
+};
+
 // The list of characters that will enable the direct edit mechanism.
 const directEditActivationValidCharacters = /[\w&é§èàùçÔØÁÛÊË"«»’”„´$¥€£\\¿?!=+-,;:%/{}[\]–#@*.]/;
 
+/**
+ * Renders a *single* tree item (excluding its sub-items).
+ */
 export const TreeItem = ({
   editingContextId,
   treeId,
@@ -136,9 +158,7 @@ export const TreeItem = ({
   };
 
   const onTreeItemAction = () => {
-    setState((prevState) => {
-      return { ...prevState, partHovered: null };
-    });
+    setState((prevState) => ({ ...prevState, partHovered: null }));
   };
 
   const enterEditingMode = () => {
@@ -148,36 +168,6 @@ export const TreeItem = ({
       editingKey: null,
     }));
   };
-
-  let content: JSX.Element | null = null;
-  if (item.expanded && item.children) {
-    content = (
-      <ul className={classes.ul}>
-        {item.children.map((childItem, index) => {
-          return (
-            <li key={childItem.id}>
-              <TreeItem
-                editingContextId={editingContextId}
-                treeId={treeId}
-                item={childItem}
-                itemIndex={index}
-                depth={depth + 1}
-                onExpand={onExpand}
-                onExpandAll={onExpandAll}
-                readOnly={readOnly}
-                textToHighlight={textToHighlight}
-                textToFilter={textToFilter}
-                markedItemIds={markedItemIds}
-                treeItemActionRender={treeItemActionRender}
-                onTreeItemClick={onTreeItemClick}
-                selectedTreeItemIds={selectedTreeItemIds}
-              />
-            </li>
-          );
-        })}
-      </ul>
-    );
-  }
 
   let className = classes.treeItem;
   let dataTestid: string | undefined = undefined;
@@ -201,37 +191,12 @@ export const TreeItem = ({
     }
   }, [selected]);
 
-  let image = <CropDinIcon />;
-  if (item.iconURL?.length > 0) {
-    image = <IconOverlay iconURL={item.iconURL} alt={item.kind} />;
-  }
-  let text: JSX.Element | null = null;
   const onCloseEditingMode = () => {
     setState((prevState) => {
       return { ...prevState, editingMode: false };
     });
     refDom.current.focus();
   };
-
-  const marked: boolean = markedItemIds.some((id) => id === item.id);
-  if (state.editingMode) {
-    text = (
-      <TreeItemDirectEditInput
-        editingContextId={editingContextId}
-        treeId={treeId}
-        treeItemId={item.id}
-        editingKey={state.editingKey}
-        onClose={onCloseEditingMode}></TreeItemDirectEditInput>
-    );
-  } else {
-    const styledLabelProps = {
-      styledString: item.label,
-      selected: false,
-      textToHighlight: textToHighlight ?? '',
-      marked: marked,
-    };
-    text = <StyledLabel {...styledLabelProps}></StyledLabel>;
-  }
 
   const onClick: React.MouseEventHandler<HTMLDivElement> = (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
     if (!state.editingMode && event.currentTarget.contains(event.target as HTMLElement)) {
@@ -297,26 +262,59 @@ export const TreeItem = ({
     event.preventDefault();
   };
 
-  let tooltipText = '';
-  if (item.kind.startsWith('siriusComponents://semantic')) {
-    const query = item.kind.substring(item.kind.indexOf('?') + 1, item.kind.length);
-    const params = new URLSearchParams(query);
-    if (params.has('domain') && params.has('entity')) {
-      tooltipText = params.get('domain') + '::' + params.get('entity');
-    }
-  } else if (item.kind.startsWith('siriusComponents://representation')) {
-    const query = item.kind.substring(item.kind.indexOf('?') + 1, item.kind.length);
-    const params = new URLSearchParams(query);
-    if (params.has('type')) {
-      tooltipText = params.get('type') ?? 'representation';
-    }
-  }
+  const text: JSX.Element = state.editingMode ? (
+    <TreeItemDirectEditInput
+      editingContextId={editingContextId}
+      treeId={treeId}
+      treeItemId={item.id}
+      editingKey={state.editingKey}
+      onClose={onCloseEditingMode}
+    />
+  ) : (
+    <StyledLabel
+      styledString={item.label}
+      selected={false}
+      textToHighlight={textToHighlight ?? ''}
+      marked={markedItemIds.some((id) => id === item.id)}
+    />
+  );
+
+  const itemAction = (
+    <div onClick={onTreeItemAction}>
+      {treeItemActionRender ? (
+        treeItemActionRender({
+          editingContextId: editingContextId,
+          treeId: treeId,
+          item: item,
+          depth: depth,
+          onExpand: onExpand,
+          onExpandAll: onExpandAll,
+          readOnly: readOnly,
+          onEnterEditingMode: enterEditingMode,
+          isHovered: state.partHovered === 'item',
+        })
+      ) : (
+        <TreeItemAction
+          editingContextId={editingContextId}
+          treeId={treeId}
+          item={item}
+          depth={depth}
+          onExpand={onExpand}
+          onExpandAll={onExpandAll}
+          readOnly={readOnly}
+          onEnterEditingMode={enterEditingMode}
+          isHovered={state.partHovered === 'item'}
+        />
+      )}
+    </div>
+  );
 
   let currentTreeItem: JSX.Element | null;
   if (textToFilter && isFilterCandidate(item, textToFilter)) {
     currentTreeItem = null;
   } else {
     const label = getString(item.label);
+    const tooltipText = getTooltipText(item);
     /* ref, tabindex and onFocus are used to set the React component focusabled and to set the focus to the corresponding DOM part */
     currentTreeItem = (
       <>
@@ -358,42 +356,15 @@ export const TreeItem = ({
                 onDoubleClick={() => item.hasChildren && onExpand(item.id, depth)}
                 title={tooltipText}
                 data-testid={label}>
-                {image}
+                <TreeItemIcon item={item} />
                 {text}
               </div>
-              <div onClick={onTreeItemAction}>
-                {treeItemActionRender ? (
-                  treeItemActionRender({
-                    editingContextId: editingContextId,
-                    treeId: treeId,
-                    item: item,
-                    depth: depth,
-                    onExpand: onExpand,
-                    onExpandAll: onExpandAll,
-                    readOnly: readOnly,
-                    onEnterEditingMode: enterEditingMode,
-                    isHovered: state.partHovered === 'item',
-                  })
-                ) : (
-                  <TreeItemAction
-                    editingContextId={editingContextId}
-                    treeId={treeId}
-                    item={item}
-                    depth={depth}
-                    onExpand={onExpand}
-                    onExpandAll={onExpandAll}
-                    readOnly={readOnly}
-                    onEnterEditingMode={enterEditingMode}
-                    isHovered={state.partHovered === 'item'}
-                  />
-                )}
-              </div>
+              {itemAction}
             </div>
           </div>
         </div>
-        {content}
       </>
     );
   }
-  return <>{currentTreeItem}</>;
+  return currentTreeItem;
 };

--- a/packages/trees/frontend/sirius-components-trees/src/treeitems/TreeItemIcon.tsx
+++ b/packages/trees/frontend/sirius-components-trees/src/treeitems/TreeItemIcon.tsx
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+import { IconOverlay } from '@eclipse-sirius/sirius-components-core';
+import CropDinIcon from '@mui/icons-material/CropDin';
+import { TreeItemIconProps } from './TreeItemIcon.types';
+
+export const TreeItemIcon = ({ item }: TreeItemIconProps) => {
+  if (item.iconURL?.length > 0) {
+    return <IconOverlay iconURL={item.iconURL} alt={item.kind} />;
+  } else {
+    return <CropDinIcon />;
+  }
+};

--- a/packages/trees/frontend/sirius-components-trees/src/treeitems/TreeItemIcon.types.ts
+++ b/packages/trees/frontend/sirius-components-trees/src/treeitems/TreeItemIcon.types.ts
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+import { GQLTreeItem } from '../views/TreeView.types';
+
+export interface TreeItemIconProps {
+  item: GQLTreeItem;
+}

--- a/packages/trees/frontend/sirius-components-trees/src/treeitems/TreeItemWithChildren.tsx
+++ b/packages/trees/frontend/sirius-components-trees/src/treeitems/TreeItemWithChildren.tsx
@@ -1,0 +1,85 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2025 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+import { makeStyles } from 'tss-react/mui';
+import { TreeItem } from '../treeitems/TreeItem';
+import { TreeItemWithChildrenProps } from './TreeItemWithChildren.types';
+
+const useTreeItemWithChildrenStyle = makeStyles()((_theme) => ({
+  ul: {
+    marginLeft: 0,
+  },
+}));
+
+export const TreeItemWithChildren = ({
+  editingContextId,
+  treeId,
+  item,
+  depth,
+  onExpand,
+  onExpandAll,
+  readOnly,
+  textToHighlight,
+  textToFilter,
+  markedItemIds,
+  treeItemActionRender,
+  onTreeItemClick,
+  selectedTreeItemIds,
+}: TreeItemWithChildrenProps) => {
+  const { classes } = useTreeItemWithChildrenStyle();
+  if (item.expanded && item.children) {
+    return (
+      <ul className={classes.ul}>
+        {item.children.map((childItem, index) => {
+          return (
+            <li key={childItem.id}>
+              <TreeItem
+                editingContextId={editingContextId}
+                treeId={treeId}
+                item={childItem}
+                itemIndex={index}
+                depth={depth}
+                onExpand={onExpand}
+                onExpandAll={onExpandAll}
+                readOnly={readOnly}
+                textToHighlight={textToHighlight}
+                textToFilter={textToFilter}
+                markedItemIds={markedItemIds}
+                treeItemActionRender={treeItemActionRender}
+                onTreeItemClick={onTreeItemClick}
+                selectedTreeItemIds={selectedTreeItemIds}
+              />
+              <TreeItemWithChildren
+                editingContextId={editingContextId}
+                treeId={treeId}
+                item={childItem}
+                itemIndex={index}
+                depth={depth + 1}
+                onExpand={onExpand}
+                onExpandAll={onExpandAll}
+                readOnly={readOnly}
+                textToHighlight={textToHighlight}
+                textToFilter={textToFilter}
+                markedItemIds={markedItemIds}
+                treeItemActionRender={treeItemActionRender}
+                onTreeItemClick={onTreeItemClick}
+                selectedTreeItemIds={selectedTreeItemIds}
+              />
+            </li>
+          );
+        })}
+      </ul>
+    );
+  } else {
+    return null;
+  }
+};

--- a/packages/trees/frontend/sirius-components-trees/src/treeitems/TreeItemWithChildren.types.ts
+++ b/packages/trees/frontend/sirius-components-trees/src/treeitems/TreeItemWithChildren.types.ts
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+import { GQLTreeItem } from '../views/TreeView.types';
+import { TreeItemActionProps } from './TreeItemAction.types';
+
+export interface TreeItemWithChildrenProps {
+  editingContextId: string;
+  treeId: string;
+  item: GQLTreeItem;
+  itemIndex: number;
+  depth: number;
+  onExpand: (id: string, depth: number) => void;
+  onExpandAll: (treeItem: GQLTreeItem) => void;
+  readOnly: boolean;
+  textToHighlight: string | null;
+  textToFilter: string | null;
+  markedItemIds: string[];
+  treeItemActionRender?: (props: TreeItemActionProps) => React.ReactNode;
+  onTreeItemClick: (event: React.MouseEvent<HTMLDivElement, MouseEvent>, item: GQLTreeItem) => void;
+  selectedTreeItemIds: string[];
+}

--- a/packages/trees/frontend/sirius-components-trees/src/trees/Tree.tsx
+++ b/packages/trees/frontend/sirius-components-trees/src/trees/Tree.tsx
@@ -14,6 +14,7 @@ import { makeStyles } from 'tss-react/mui';
 
 import { useEffect, useRef } from 'react';
 import { TreeItem } from '../treeitems/TreeItem';
+import { TreeItemWithChildren } from '../treeitems/TreeItemWithChildren';
 import { TreeProps } from './Tree.types';
 
 const useTreeStyle = makeStyles()((_) => ({
@@ -109,31 +110,45 @@ export const Tree = ({
   }, [treeElement, onExpand]);
 
   return (
-    <>
-      <div ref={treeElement}>
-        <ul className={classes.ul} data-testid="tree-root-elements">
-          {tree.children.map((item, index) => (
-            <li key={item.id}>
-              <TreeItem
-                editingContextId={editingContextId}
-                treeId={tree.id}
-                item={item}
-                itemIndex={index}
-                depth={1}
-                onExpand={onExpand}
-                onExpandAll={onExpandAll}
-                readOnly={readOnly}
-                textToHighlight={textToHighlight}
-                textToFilter={textToFilter}
-                markedItemIds={markedItemIds}
-                treeItemActionRender={treeItemActionRender}
-                onTreeItemClick={onTreeItemClick}
-                selectedTreeItemIds={selectedTreeItemIds}
-              />
-            </li>
-          ))}
-        </ul>
-      </div>
-    </>
+    <div ref={treeElement}>
+      <ul className={classes.ul} data-testid="tree-root-elements">
+        {tree.children.map((childItem, index) => (
+          <li key={childItem.id}>
+            <TreeItem
+              editingContextId={editingContextId}
+              treeId={tree.id}
+              item={childItem}
+              itemIndex={index}
+              depth={1}
+              onExpand={onExpand}
+              onExpandAll={onExpandAll}
+              readOnly={readOnly}
+              textToHighlight={textToHighlight}
+              textToFilter={textToFilter}
+              markedItemIds={markedItemIds}
+              treeItemActionRender={treeItemActionRender}
+              onTreeItemClick={onTreeItemClick}
+              selectedTreeItemIds={selectedTreeItemIds}
+            />
+            <TreeItemWithChildren
+              editingContextId={editingContextId}
+              treeId={tree.id}
+              item={childItem}
+              itemIndex={index}
+              depth={2}
+              onExpand={onExpand}
+              onExpandAll={onExpandAll}
+              readOnly={readOnly}
+              textToHighlight={textToHighlight}
+              textToFilter={textToFilter}
+              markedItemIds={markedItemIds}
+              treeItemActionRender={treeItemActionRender}
+              onTreeItemClick={onTreeItemClick}
+              selectedTreeItemIds={selectedTreeItemIds}
+            />
+          </li>
+        ))}
+      </ul>
+    </div>
   );
 };


### PR DESCRIPTION
This uses a different approach than the "full CSS" one envisioned initialy.

The "isHovered" state is, well, inherent part of the item's actual state as we need to pass it along to `treeItemActionRender` and `TreeItemAction` for example.

The new approach is simply to make `TreeItem` only responsible for rendering *itself* and not its children. This way it's not a performance issue anymore, and the time needed to re-render a given item is independent on the number of descendants it has in the tree.

The recursive part of the rendering is pulled up into `Tree.tsx` in a dedicated recursive component `TreeItemWithChildren`.

Before the change, with a large (~900 items) sub-tree expanded under "Eclipse EMF", simply hovering the mouse on the "Eclipse EMF" top item show a lag of about 1s, with all the 900+ items underneath re-rendered along the the "Eclipse EMF" item itself.

https://github.com/user-attachments/assets/cdd1a6a1-ac5e-4b45-aa4b-908b25be87bd


After the change, with an equivalent initial state, only the item hovered (in/out) is re-rendered, not its descendants. The UI is much more reactive.

https://github.com/user-attachments/assets/35146c69-9ee0-4f91-aa05-ce503c03d204


