### PR TITLE
[doc] Add shape to include selected project setting tab in the URL

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -6,6 +6,7 @@
 
 - Add support for diagram customization
 - Add the ability to share the workbench state
+- Add selected project setting tab to the URL
 
 
 === Architectural decision records
@@ -117,6 +118,7 @@ In this package, you can now find the following default implementations:
 
 === Shapes
 
+- Control the views available in a workbench
 
 
 === Architectural decision records

--- a/doc/iterations/2025.8/add_selected_project_setting_tab_to_the_url.adoc
+++ b/doc/iterations/2025.8/add_selected_project_setting_tab_to_the_url.adoc
@@ -1,0 +1,44 @@
+= (S) Add selected project setting tab to the URL
+
+== Problem
+
+When opening a project, its settings can be reached from the contextual menu of the project (in the center of the top navigation bar).
+
+In the Sirius Web default application, the settings have 1 tab "Images" for the project-scoped custom images.
+The URL looks like: `/projects/:projectId/settings`.
+
+Downstream applications (or future versions of Sirius Web) might include additional project setting tabs through the frontend data extension point defined in `packages\sirius-web\frontend\sirius-web-application\src\views\project-settings\ProjectSettingsViewExtensionPoints.tsx`.
+For an application with additional project setting tabs, it would make sense to be able to share a URL that points to a specific tab.
+
+== Key Result
+
+Users shall be able to share a URL that reflects the currently-selected project setting tab.
+
+=== Acceptance Criteria
+
+* When navigating among the project setting tabs, the URL updates to reflect the currently-selected tab.
+* Reversely, when resolving such a URL, the application opens the tab specified in the URL.
+
+== Solution
+
+The tabs contributed can all be identified thanks to a unique identifier.
+We can use this identifier as the last segment of the URL `/projects/:projectId/settings/:tabId`.
+When opening the project settings page, if the URL includes a tab identifier, then the corresponding tab is selected and opened.
+Otherwise, the first tab is opened and its identifier added to the URL.
+
+=== Breadboarding
+
+N/A
+
+=== Cutting backs
+
+* It would be nice for downstream applications to be able to specify the default project setting tab, but this is out of the scope of this shape.
+* It would be nice for downstream applications to be able to tweak other project setting tab contributions (e.g. change the order or titles), but this is out of the scope of this shape.
+
+== Rabbit holes
+
+N/A
+
+== No-gos
+
+N/A


### PR DESCRIPTION
Shape for #4899 where we want to be able to link to a specific tab from the project settings.

# Pull request template

## General purpose
What is the main goal of this pull request?
- [ ] Bug fixes
- [X] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [ ] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [ ] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`