### PR TITLE
[5197] Include edges connected to border nodes in ELK input

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -164,6 +164,8 @@ The link to libraries has become a standard menu item which can be hidden provid
 - https://github.com/eclipse-sirius/sirius-web/issues/5207[#5207] [diagram] Fix an issue that prevented palette tools to open dialogs
 - https://github.com/eclipse-sirius/sirius-web/issues/5156[#5156] [diagram] Fix an issue where the edges were not correctly centered on the handle
 - https://github.com/eclipse-sirius/sirius-web/issues/5225[#5225] [diagram] Fix an issue where `synchronizeLayoutData` was called twice when moving the handle of a manually layouted edge
+- https://github.com/eclipse-sirius/sirius-web/issues/5197[#5197] [diagram] Include edges connected to border nodes in ELK input for improved automatic layout
+
 
 === New Features
 

--- a/integration-tests/cypress/e2e/project/diagrams/arrange-all.cy.ts
+++ b/integration-tests/cypress/e2e/project/diagrams/arrange-all.cy.ts
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Obeo.
+ * Copyright (c) 2024, 2025 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -13,6 +13,8 @@
 
 import { Project } from '../../../pages/Project';
 import { Flow } from '../../../usecases/Flow';
+import { Studio } from '../../../usecases/Studio';
+import { Details } from '../../../workbench/Details';
 import { Diagram } from '../../../workbench/Diagram';
 import { Explorer } from '../../../workbench/Explorer';
 
@@ -25,6 +27,7 @@ describe('Diagram - arrange all', () => {
         const project = new Project();
         project.visit(projectId);
         project.disableDeletionConfirmationDialog();
+        new Diagram().disableFitView();
         const explorer = new Explorer();
         explorer.expandWithDoubleClick('Flow');
         explorer.expandWithDoubleClick('NewSystem');
@@ -56,6 +59,88 @@ describe('Diagram - arrange all', () => {
     it('Check loading indicator is present during arrange action', () => {
       cy.getByTestId('arrange-all').click();
       cy.getByTestId('arrange-all-circular-loading').should('exist');
+    });
+  });
+  context('Given a view with edge on border node', () => {
+    const domainName: string = 'diagramEdgeOnBorderNode';
+    let instanceProjectId: string = '';
+    const diagramDescriptionName = `${domainName} - simple edge on border node`;
+    const diagramTitle = 'Simple edge on border node';
+
+    beforeEach(() => {
+      const studio = new Studio();
+      const explorer = new Explorer();
+      const details = new Details();
+      studio.createProjectFromDomain('Cypress - Studio Instance', domainName, 'Root').then((res) => {
+        instanceProjectId = res.projectId;
+      });
+      new Diagram().disableFitView();
+
+      explorer.createObject('Root', 'entity1s-Entity1');
+      details.getTextField('Name').should('have.value', '');
+      details.getTextField('Name').type('parent{enter}');
+      explorer.createObject('Root', 'entity1s-Entity1');
+      details.getTextField('Name').type('A{enter}');
+      explorer.createObject('Root', 'entity2s-Entity2');
+      details.getTextField('Name').should('have.value', '');
+      details.getTextField('Name').type('B{enter}');
+      explorer.createObject('parent', 'entity1ContainEntity2-Entity2');
+      details.getTextField('Name').should('have.value', '');
+      details.getTextField('Name').type('C{enter}');
+      explorer.createObject('parent', 'entity1ContainEntity1-Entity1');
+      details.getTextField('Name').should('have.value', '');
+      details.getTextField('Name').type('D{enter}');
+      explorer.select('A');
+      details.getTextField('Name').should('have.value', 'A');
+      details.getReferenceWidget('Entity1 Linked To Entity2').should('exist');
+      details.openReferenceWidgetOptions('Entity1 Linked To Entity2');
+      details.selectReferenceWidgetOption('C');
+      explorer.select('D');
+      details.getTextField('Name').should('have.value', 'D');
+      details.getReferenceWidget('Entity1 Linked To Entity2').should('exist');
+      details.openReferenceWidgetOptions('Entity1 Linked To Entity2');
+      details.selectReferenceWidgetOption('B');
+      new Explorer().createRepresentation('Root', diagramDescriptionName, diagramTitle);
+      new Diagram().centerViewport();
+    });
+
+    afterEach(() => cy.deleteProject(instanceProjectId));
+
+    it('Check arrange all take into account the edges', () => {
+      const diagram = new Diagram();
+      // eslint-disable-next-line cypress/no-unnecessary-waiting
+      cy.wait(500);
+      diagram.getNodes(diagramTitle, 'A').should('exist');
+      diagram.getNodes(diagramTitle, 'B').should('exist');
+      diagram.getNodes(diagramTitle, 'parent').should('exist');
+      diagram.arrangeAll();
+      let positionLeftA: number,
+        positionTopA: number,
+        positionLeftB: number,
+        positionTopB: number,
+        positionLeftParent: number,
+        positionTopParent: number;
+      diagram.getNodes(diagramTitle, 'A').then(($el) => {
+        const rect = $el[0]?.getBoundingClientRect();
+        positionLeftA = rect?.left ?? 0;
+        positionTopA = rect?.top ?? 0;
+      });
+      diagram.getNodes(diagramTitle, 'B').then(($el) => {
+        const rect = $el[0]?.getBoundingClientRect();
+        positionLeftB = rect?.left ?? 0;
+        positionTopB = rect?.top ?? 0;
+      });
+
+      diagram.getNodes(diagramTitle, 'parent').then(($el) => {
+        const rect = $el[0]?.getBoundingClientRect();
+        positionLeftParent = rect?.left ?? 0;
+        positionTopParent = rect?.top ?? 0;
+        // verify layout order: nodeA > nodeParent > nodeB
+        expect(positionLeftB).to.be.greaterThan(positionLeftParent);
+        expect(positionLeftParent).to.be.greaterThan(positionLeftA);
+        expect(positionTopA).to.be.greaterThan(positionTopParent);
+        expect(positionTopB).to.be.greaterThan(positionTopParent);
+      });
     });
   });
 });

--- a/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/layout/useArrangeAll.ts
+++ b/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/layout/useArrangeAll.ts
@@ -174,6 +174,20 @@ export const useArrangeAll = (reactFlowWrapper: React.MutableRefObject<HTMLDivEl
     const edges: Edge<EdgeData>[] = getEdges();
     for (const [parentNodeId, nodes] of subNodes) {
       const parentNode = allNodes.find((node) => node.id === parentNodeId);
+      const subGroupEdges: Edge<EdgeData>[] = [];
+      edges.forEach((edge) => {
+        const isTargetInside = nodes.some((node) => node.id === edge.target);
+        const isSourceInside = nodes.some((node) => node.id === edge.source);
+        if (isTargetInside && isSourceInside) {
+          subGroupEdges.push(edge);
+        }
+        if (isTargetInside && !isSourceInside) {
+          edge.target = parentNodeId;
+        }
+        if (!isTargetInside && isSourceInside) {
+          edge.source = parentNodeId;
+        }
+      });
       if ((parentNode && isListData(parentNode)) || nodes.every((node) => node.data.isBorderNode)) {
         // No elk layout for child of container list or for border node
         layoutedAllNodes = [...layoutedAllNodes, ...nodes.reverse()];
@@ -186,20 +200,6 @@ export const useArrangeAll = (reactFlowWrapper: React.MutableRefObject<HTMLDivEl
         .map((node) => {
           return parentNodeWithNewSize.find((layoutNode) => layoutNode.id === node.id) ?? node;
         });
-      const subGroupEdges: Edge<EdgeData>[] = [];
-      edges.forEach((edge) => {
-        const isTargetInside = subGroupNodes.some((node) => node.id === edge.target);
-        const isSourceInside = subGroupNodes.some((node) => node.id === edge.source);
-        if (isTargetInside && isSourceInside) {
-          subGroupEdges.push(edge);
-        }
-        if (isTargetInside && !isSourceInside) {
-          edge.target = parentNodeId;
-        }
-        if (!isTargetInside && isSourceInside) {
-          edge.source = parentNodeId;
-        }
-      });
       await getELKLayout(
         subGroupNodes,
         subGroupEdges,

--- a/packages/sirius-web/backend/sirius-web-e2e-tests/src/main/java/org/eclipse/sirius/web/e2e/tests/diagramEdge/DiagramEdgeOnBorderNodeDomainProvider.java
+++ b/packages/sirius-web/backend/sirius-web-e2e-tests/src/main/java/org/eclipse/sirius/web/e2e/tests/diagramEdge/DiagramEdgeOnBorderNodeDomainProvider.java
@@ -1,0 +1,105 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.e2e.tests.diagramEdge;
+
+import java.util.List;
+
+import org.eclipse.sirius.components.core.api.IEditingContext;
+import org.eclipse.sirius.components.domain.Attribute;
+import org.eclipse.sirius.components.domain.DataType;
+import org.eclipse.sirius.components.domain.Domain;
+import org.eclipse.sirius.components.domain.DomainFactory;
+import org.eclipse.sirius.components.domain.Entity;
+import org.eclipse.sirius.components.domain.Relation;
+import org.eclipse.sirius.web.application.studio.services.api.IDomainProvider;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+
+/**
+ * Used to contribute domains for arrange-all.cy.ts tests.
+ *
+ * @author frouene
+ */
+@SuppressWarnings("checkstyle:MultipleStringLiterals")
+@Profile("test")
+@Service
+public class DiagramEdgeOnBorderNodeDomainProvider implements IDomainProvider {
+
+    public static final String DOMAIN_NAME = "diagramEdgeOnBorderNode";
+
+    @Override
+    public List<Domain> getDomains(IEditingContext editingContext) {
+        var domain = DomainFactory.eINSTANCE.createDomain();
+        domain.setName(DOMAIN_NAME);
+
+        Entity root = DomainFactory.eINSTANCE.createEntity();
+        root.setName("Root");
+        domain.getTypes().add(root);
+
+        Entity entity1 = this.createContainmentChild(root, "Entity1", "entity1s");
+        domain.getTypes().add(entity1);
+        Entity entity2 = this.createContainmentChild(root, "Entity2", "entity2s");
+        domain.getTypes().add(entity2);
+
+        Relation entity1ContainEntity2 = DomainFactory.eINSTANCE.createRelation();
+        entity1ContainEntity2.setName("entity1ContainEntity2");
+        entity1ContainEntity2.setContainment(true);
+        entity1ContainEntity2.setOptional(true);
+        entity1ContainEntity2.setMany(true);
+        entity1ContainEntity2.setTargetType(entity2);
+        entity1.getRelations().add(entity1ContainEntity2);
+
+        Relation entity1ContainEntity1 = DomainFactory.eINSTANCE.createRelation();
+        entity1ContainEntity1.setName("entity1ContainEntity1");
+        entity1ContainEntity1.setContainment(true);
+        entity1ContainEntity1.setOptional(true);
+        entity1ContainEntity1.setMany(true);
+        entity1ContainEntity1.setTargetType(entity1);
+        entity1.getRelations().add(entity1ContainEntity1);
+
+        Relation entity1LinkedToEntity2 = DomainFactory.eINSTANCE.createRelation();
+        entity1LinkedToEntity2.setName("entity1LinkedToEntity2");
+        entity1LinkedToEntity2.setContainment(false);
+        entity1LinkedToEntity2.setOptional(true);
+        entity1LinkedToEntity2.setMany(true);
+        entity1LinkedToEntity2.setTargetType(entity2);
+        entity1.getRelations().add(entity1LinkedToEntity2);
+
+        this.addAttribute(entity1, "name", DataType.STRING);
+        this.addAttribute(entity2, "name", DataType.STRING);
+
+
+        return List.of(domain);
+    }
+
+    private Entity createContainmentChild(Entity root, String name, String relationName) {
+        Entity entity = DomainFactory.eINSTANCE.createEntity();
+        entity.setName(name);
+        Relation relation = DomainFactory.eINSTANCE.createRelation();
+        relation.setName(relationName);
+        relation.setContainment(true);
+        relation.setOptional(true);
+        relation.setMany(true);
+        relation.setTargetType(entity);
+        root.getRelations().add(relation);
+        return entity;
+    }
+
+    private void addAttribute(Entity entity, String name, DataType type) {
+        Attribute attr = DomainFactory.eINSTANCE.createAttribute();
+        attr.setName(name);
+        attr.setOptional(true);
+        attr.setType(type);
+        entity.getAttributes().add(attr);
+    }
+}

--- a/packages/sirius-web/backend/sirius-web-e2e-tests/src/main/java/org/eclipse/sirius/web/e2e/tests/diagramEdge/DiagramEdgeOnBorderNodeViewProvider.java
+++ b/packages/sirius-web/backend/sirius-web-e2e-tests/src/main/java/org/eclipse/sirius/web/e2e/tests/diagramEdge/DiagramEdgeOnBorderNodeViewProvider.java
@@ -1,0 +1,176 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.e2e.tests.diagramEdge;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.eclipse.sirius.components.emf.ResourceMetadataAdapter;
+import org.eclipse.sirius.components.emf.services.IDAdapter;
+import org.eclipse.sirius.components.emf.services.JSONResourceFactory;
+import org.eclipse.sirius.components.view.View;
+import org.eclipse.sirius.components.view.builder.generated.diagram.DiagramBuilders;
+import org.eclipse.sirius.components.view.builder.generated.view.ViewBuilders;
+import org.eclipse.sirius.components.view.builder.providers.IColorProvider;
+import org.eclipse.sirius.components.view.diagram.ArrangeLayoutDirection;
+import org.eclipse.sirius.components.view.diagram.DiagramDescription;
+import org.eclipse.sirius.components.view.diagram.DiagramElementDescription;
+import org.eclipse.sirius.components.view.diagram.EdgeDescription;
+import org.eclipse.sirius.components.view.diagram.InsideLabelPosition;
+import org.eclipse.sirius.components.view.diagram.LabelTextAlign;
+import org.eclipse.sirius.components.view.diagram.LineStyle;
+import org.eclipse.sirius.components.view.diagram.NodeDescription;
+import org.eclipse.sirius.components.view.diagram.SynchronizationPolicy;
+import org.eclipse.sirius.components.view.diagram.UserResizableDirection;
+import org.eclipse.sirius.emfjson.resource.JsonResource;
+import org.eclipse.sirius.web.e2e.tests.services.SiriusWebE2EColorPaletteBuilderProvider;
+import org.eclipse.sirius.web.e2e.tests.services.SiriusWebE2EColorProvider;
+import org.eclipse.sirius.web.e2e.tests.services.api.IE2EViewProvider;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+
+/**
+ * The view provider for the arrange-all.cy.ts test suite.
+ *
+ * @author frouene
+ */
+@Profile("test")
+@Service
+@SuppressWarnings("checkstyle:MultipleStringLiterals")
+public class DiagramEdgeOnBorderNodeViewProvider implements IE2EViewProvider {
+
+    @Override
+    public List<View> createViews() {
+        var colorPalette = new SiriusWebE2EColorPaletteBuilderProvider().getColorPaletteBuilder().build();
+        IColorProvider colorProvider = new SiriusWebE2EColorProvider(List.of(colorPalette));
+
+        var diagramDescription = this.createDiagramDescription(colorProvider);
+
+        var view = new ViewBuilders().newView()
+                .colorPalettes(colorPalette)
+                .descriptions(diagramDescription)
+                .build();
+
+        view.eAllContents().forEachRemaining(eObject ->
+                eObject.eAdapters().add(new IDAdapter(UUID.nameUUIDFromBytes(EcoreUtil.getURI(eObject).toString().getBytes())))
+        );
+
+        String resourcePath = UUID.nameUUIDFromBytes("DiagramEdgeOnBorderNode".getBytes()).toString();
+        JsonResource resource = new JSONResourceFactory().createResourceFromPath(resourcePath);
+        resource.eAdapters().add(new ResourceMetadataAdapter("DiagramEdgeOnBorderNodeView"));
+        resource.getContents().add(view);
+
+        return List.of(view);
+    }
+
+    private DiagramDescription createDiagramDescription(IColorProvider colorProvider) {
+        var nodeDescription1 = this.getNodeDescription(colorProvider, "Entity1");
+        var nodeDescription2 = this.getNodeDescription(colorProvider, "Entity2");
+        nodeDescription1.getReusedBorderNodeDescriptions().add(nodeDescription1);
+        nodeDescription1.getReusedBorderNodeDescriptions().add(nodeDescription2);
+
+        var edgeDescription1 = this.getEdgeDescription(colorProvider, nodeDescription1, nodeDescription2);
+
+
+        return new DiagramBuilders()
+                .newDiagramDescription()
+                .name(DiagramEdgeOnBorderNodeDomainProvider.DOMAIN_NAME + " - simple edge on border node")
+                .domainType(DiagramEdgeOnBorderNodeDomainProvider.DOMAIN_NAME + "::Root")
+                .titleExpression(DiagramEdgeOnBorderNodeDomainProvider.DOMAIN_NAME + " diagram")
+                .autoLayout(false)
+                .arrangeLayoutDirection(ArrangeLayoutDirection.UNDEFINED)
+                .nodeDescriptions(nodeDescription1, nodeDescription2)
+                .edgeDescriptions(edgeDescription1)
+                .build();
+    }
+
+
+    private NodeDescription getNodeDescription(IColorProvider colorProvider, String entityName) {
+        return new DiagramBuilders()
+                .newNodeDescription()
+                .name(entityName)
+                .domainType(DiagramEdgeOnBorderNodeDomainProvider.DOMAIN_NAME + "::" + entityName)
+                .semanticCandidatesExpression("aql:self.eContents()")
+                .synchronizationPolicy(SynchronizationPolicy.SYNCHRONIZED)
+                .collapsible(true)
+                .userResizable(UserResizableDirection.BOTH)
+                .keepAspectRatio(false)
+                .defaultWidthExpression("50")
+                .defaultHeightExpression("50")
+                .style(
+                        new DiagramBuilders()
+                                .newRectangularNodeStyleDescription()
+                                .background(colorProvider.getColor(SiriusWebE2EColorPaletteBuilderProvider.COLOR_BLUE))
+                                .borderColor(colorProvider.getColor(SiriusWebE2EColorPaletteBuilderProvider.BORDER_BLUE))
+                                .borderRadius(3)
+                                .borderSize(1)
+                                .borderLineStyle(LineStyle.SOLID)
+                                .childrenLayoutStrategy(new DiagramBuilders().newListLayoutStrategyDescription().build())
+                                .build()
+                )
+                .insideLabel(
+                        new DiagramBuilders()
+                                .newInsideLabelDescription()
+                                .labelExpression("aql:self.name")
+                                .textAlign(LabelTextAlign.LEFT)
+                                .position(InsideLabelPosition.TOP_CENTER)
+                                .style(
+                                        new DiagramBuilders()
+                                                .newInsideLabelStyle()
+                                                .fontSize(14)
+                                                .italic(false)
+                                                .bold(false)
+                                                .underline(false)
+                                                .strikeThrough(false)
+                                                .borderColor(colorProvider.getColor(SiriusWebE2EColorPaletteBuilderProvider.COLOR_DARK))
+                                                .borderRadius(3)
+                                                .borderSize(0)
+                                                .borderLineStyle(LineStyle.SOLID)
+                                                .labelColor(colorProvider.getColor(SiriusWebE2EColorPaletteBuilderProvider.COLOR_DARK))
+                                                .background(colorProvider.getColor(SiriusWebE2EColorPaletteBuilderProvider.COLOR_TRANSPARENT))
+                                                .withHeader(false)
+                                                .build()
+                                )
+                                .build()
+                )
+                .build();
+    }
+
+    private EdgeDescription getEdgeDescription(IColorProvider colorProvider, DiagramElementDescription sourceDescription, DiagramElementDescription targetDescription) {
+        return new DiagramBuilders()
+                .newEdgeDescription()
+                .name("LinkedTo Edge")
+                .isDomainBasedEdge(false)
+                .synchronizationPolicy(SynchronizationPolicy.SYNCHRONIZED)
+                .sourceExpression("aql:self")
+                .sourceDescriptions(sourceDescription)
+                .targetExpression("aql:self.entity1LinkedToEntity2")
+                .targetDescriptions(targetDescription)
+                .style(
+                        new DiagramBuilders()
+                                .newEdgeStyle()
+                                .fontSize(14)
+                                .color(colorProvider.getColor(SiriusWebE2EColorPaletteBuilderProvider.COLOR_DARK))
+                                .background(colorProvider.getColor(SiriusWebE2EColorPaletteBuilderProvider.COLOR_TRANSPARENT))
+                                .borderColor(colorProvider.getColor(SiriusWebE2EColorPaletteBuilderProvider.COLOR_DARK))
+                                .borderRadius(3)
+                                .borderSize(0)
+                                .borderLineStyle(LineStyle.SOLID)
+                                .build()
+                )
+                .build();
+    }
+
+
+}


### PR DESCRIPTION
Issue #5197 

Fix Edges whose source or target was a border node were previously excluded from the ELK layout graph, leading to suboptimal results.

I'm mostly poking in the dark but it gave good results on my side. I might not be able to work further on it so anyone stepping in will have to go through to the merge.

This fix ensures that edges touching the group (even via a border node) are preserved, and any endpoint outside the group is rewritten to its container ID—ensuring valid connectivity without referencing missing nodes.

Fixes layout issues when using ArrangeAll on diagrams with border nodes.

# Pull request template

## General purpose
What is the main goal of this pull request?
- [x] Bug fixes
- [ ] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [x] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [x] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [x] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [x] Have the relevant issues been added to the same project and milestone as the pull request?
- [ ] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?