### PR TITLE
[5204] Fix regression in the Explorer layout when the filter bar is visible

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -311,7 +311,7 @@ These `useEffect` now read the state value from `prevState` instead of `state`, 
 - https://github.com/eclipse-sirius/sirius-web/issues/5003[#5003] [diagram] Fix an issue with the position of smart edges when having an edge on another edge
 - https://github.com/eclipse-sirius/sirius-web/issues/5000[#5000] [sirius-web] Fix a crash when importing an unsynchronised diagram if the targetObject of a node was from a library.
 - https://github.com/eclipse-sirius/sirius-web/issues/5023[#5000] [sirius-web] Keep the view state modifier (hidden, faded, normal) of the nodes when importing an unsynchronised diagram.
-
+- https://github.com/eclipse-sirius/sirius-web/issues/5204[#5204] [explorer] Fix regression in the Explorer layout when the filter bar is visible
 
 === New Features
 

--- a/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/workbench-views/explorer/ExplorerView.tsx
+++ b/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/workbench-views/explorer/ExplorerView.tsx
@@ -43,12 +43,14 @@ const useStyles = makeStyles()((theme: Theme) => ({
   treeView: {
     display: 'grid',
     gridTemplateColumns: 'auto',
-    gridTemplateRows: 'auto 1fr',
+    gridTemplateRows: 'auto auto 1fr',
     justifyItems: 'stretch',
     overflow: 'auto',
   },
-  treeContent: {
+  treeFilter: {
     paddingTop: theme.spacing(1),
+  },
+  treeContent: {
     overflow: 'auto',
   },
 }));
@@ -212,30 +214,32 @@ export const ExplorerView = ({ editingContextId, readOnly }: WorkbenchViewCompon
     }));
   };
 
-  let filterBar: JSX.Element;
+  let filterBar: JSX.Element = <div />;
   if (state.filterBar) {
     filterBar = (
-      <FilterBar
-        onTextChange={(event) => {
-          const {
-            target: { value },
-          } = event;
-          setState((prevState) => {
-            return { ...prevState, filterBarText: value };
-          });
-        }}
-        onFilterButtonClick={(enabled) =>
-          setState((prevState) => ({
-            ...prevState,
-            filterBarTreeFiltering: enabled,
-          }))
-        }
-        onClose={() =>
-          setState((prevState) => {
-            return { ...prevState, filterBar: false, filterBarText: '', filterBarTreeFiltering: false };
-          })
-        }
-      />
+      <div className={styles.treeFilter}>
+        <FilterBar
+          onTextChange={(event) => {
+            const {
+              target: { value },
+            } = event;
+            setState((prevState) => {
+              return { ...prevState, filterBarText: value };
+            });
+          }}
+          onFilterButtonClick={(enabled) =>
+            setState((prevState) => ({
+              ...prevState,
+              filterBarTreeFiltering: enabled,
+            }))
+          }
+          onClose={() =>
+            setState((prevState) => {
+              return { ...prevState, filterBar: false, filterBarText: '', filterBarTreeFiltering: false };
+            })
+          }
+        />
+      </div>
     );
   }
 


### PR DESCRIPTION
Bug: https://github.com/eclipse-sirius/sirius-web/issues/5204
Signed-off-by: Pierre-Charles David <pierre-charles.david@obeo.fr>


https://github.com/user-attachments/assets/7681e833-fdec-444c-b33d-1ba3885ac92f




# Pull request template

## General purpose
What is the main goal of this pull request?
- [x] Bug fixes
- [ ] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [x] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [x] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [x] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [ ] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

