### PR TITLE
[4886] Add some view data in the shareable URL

### DIFF
--- a/integration-tests-cypress/cypress/e2e/project/workbench/workbench-configuration.cy.ts
+++ b/integration-tests-cypress/cypress/e2e/project/workbench/workbench-configuration.cy.ts
@@ -19,6 +19,7 @@ import { Workbench } from '../../../workbench/Workbench';
 import {
   workbenchConfigurationWithClosedPanels,
   workbenchConfigurationWithExpandedPanels,
+  workbenchConfigurationWithQueryView,
 } from './workbench-configuration.data';
 
 const projectName = 'Cypress - Workbench Configuration Resolution';
@@ -186,11 +187,32 @@ describe('Workbench Configuration Resolution', () => {
             },
           ]);
           const diagram: Diagram = new Diagram();
-          diagram.getDiagram('Topography2').should('not.exist');
+          diagram.getDiagram('Topography1').should('not.exist');
           diagram.getDiagram('Topography2').should('exist');
         });
       }
     );
+
+    context('When opening the project with a workbench configuration with a configuration for the "Query" view', () => {
+      let workbench: Workbench;
+      beforeEach(() => {
+        new Project().visit(projectId, undefined, {
+          qs: {
+            workbenchConfiguration: JSON.stringify(workbenchConfigurationWithQueryView),
+          },
+        });
+        workbench = new Workbench();
+      });
+      it('Then, in the "Query" view, the text is set as specified in the configuration', () => {
+        workbench.checkPanelContent('right', ['Query']);
+        cy.getByTestId('query-textfield')
+          .should('exist')
+          .get('div')
+          .get('textarea')
+          .invoke('val')
+          .should('equal', 'aql:self');
+      });
+    });
   });
 });
 

--- a/integration-tests-cypress/cypress/e2e/project/workbench/workbench-configuration.data.ts
+++ b/integration-tests-cypress/cypress/e2e/project/workbench/workbench-configuration.data.ts
@@ -60,3 +60,16 @@ export const workbenchConfigurationWithExpandedPanels: WorkbenchConfiguration = 
     },
   ],
 };
+
+const queryViewConfiguration = { id: 'query', isActive: true, queryText: 'aql:self' };
+
+export const workbenchConfigurationWithQueryView: WorkbenchConfiguration = {
+  mainPanel: null,
+  workbenchPanels: [
+    {
+      id: 'right',
+      isOpen: true,
+      views: [queryViewConfiguration],
+    },
+  ],
+};

--- a/packages/core/frontend/sirius-components-core/src/workbench/Panels.tsx
+++ b/packages/core/frontend/sirius-components-core/src/workbench/Panels.tsx
@@ -127,14 +127,24 @@ export const Panels = forwardRef<WorkbenchPanelsHandle | null, PanelsProps>(
       () => {
         return {
           getWorkbenchPanelConfigurations: () => {
-            const leftViewConfigurations: WorkbenchViewConfiguration[] = leftContributions.map((contribution) => ({
-              id: contribution.id,
-              isActive: leftPanelState.selectedContributionIds.includes(contribution.id),
-            }));
-            const rightViewConfigurations: WorkbenchViewConfiguration[] = rightContributions.map((contribution) => ({
-              id: contribution.id,
-              isActive: rightPanelState.selectedContributionIds.includes(contribution.id),
-            }));
+            const leftViewConfigurations: WorkbenchViewConfiguration[] = leftContributions.map((contribution) => {
+              const data: Record<string, unknown> =
+                leftWorkbenchViewRef.current.get(contribution.id)?.getWorkbenchViewConfiguration() ?? {};
+              return {
+                id: contribution.id,
+                isActive: leftPanelState.selectedContributionIds.includes(contribution.id),
+                ...data,
+              };
+            });
+            const rightViewConfigurations: WorkbenchViewConfiguration[] = rightContributions.map((contribution) => {
+              const data: Record<string, unknown> =
+                rightWorkbenchViewRef.current.get(contribution.id)?.getWorkbenchViewConfiguration() ?? {};
+              return {
+                id: contribution.id,
+                isActive: rightPanelState.selectedContributionIds.includes(contribution.id),
+                ...data,
+              };
+            });
             return [
               { id: 'left', isOpen: leftPanelState?.isOpen, views: leftViewConfigurations },
               { id: 'right', isOpen: rightPanelState?.isOpen, views: rightViewConfigurations },

--- a/packages/forms/frontend/sirius-components-forms/src/form/Form.tsx
+++ b/packages/forms/frontend/sirius-components-forms/src/form/Form.tsx
@@ -12,12 +12,13 @@
  *******************************************************************************/
 import Tab from '@mui/material/Tab';
 import Tabs from '@mui/material/Tabs';
-import React, { useEffect, useState } from 'react';
+import React, { ForwardedRef, forwardRef, useEffect, useState } from 'react';
 import { makeStyles } from 'tss-react/mui';
 import { Page } from '../pages/Page';
 import { ToolbarAction } from '../toolbaraction/ToolbarAction';
-import { FormProps, FormState } from './Form.types';
+import { FormHandle, FormProps, FormState } from './Form.types';
 import { GQLPage } from './FormEventFragments.types';
+import { useFormHandle } from './useFormHandle';
 
 const useFormStyles = makeStyles()((theme) => ({
   form: {
@@ -72,81 +73,96 @@ const a11yProps = (id: string) => {
   };
 };
 
-export const Form = ({ editingContextId, form, readOnly }: FormProps) => {
-  const { classes } = useFormStyles();
-  const { id, pages } = form;
+export const Form = forwardRef<FormHandle | null, FormProps>(
+  ({ editingContextId, form, initialSelectedPageId, readOnly }: FormProps, ref: ForwardedRef<FormHandle | null>) => {
+    const { classes } = useFormStyles();
+    const { id, pages } = form;
 
-  const [state, setState] = useState<FormState>({ selectedPage: pages[0] ?? null, pages });
+    let selectedPage: GQLPage | null = null;
+    if (initialSelectedPageId) {
+      selectedPage = pages.find((page) => page.id === initialSelectedPageId) ?? null;
+    } else if (pages[0]) {
+      selectedPage = pages[0];
+    }
+    const [state, setState] = useState<FormState>({ selectedPage, pages });
 
-  useEffect(() => {
-    setState(() => {
-      const selectedPage: GQLPage | null = pages.find((page) => page.id === state.selectedPage?.id) ?? null;
-      if (selectedPage) {
-        return { selectedPage, pages };
-      }
-      return { selectedPage: pages[0] ?? null, pages };
-    });
-  }, [pages, state.selectedPage?.id]);
+    useFormHandle(state.selectedPage?.id ?? null, ref);
 
-  const onChangeTab = (_: React.ChangeEvent<{}>, value: string) => {
-    const selectedPage: GQLPage | null = pages.find((page) => page.id === value) ?? null;
-    setState((prevState) => {
-      return { ...prevState, selectedPage };
-    });
-  };
+    useEffect(() => {
+      setState(() => {
+        const selectedPage: GQLPage | null = pages.find((page) => page.id === state.selectedPage?.id) ?? null;
+        if (selectedPage) {
+          return { selectedPage, pages };
+        }
+        return { selectedPage: pages[0] ?? null, pages };
+      });
+    }, [pages, state.selectedPage?.id]);
 
-  let selectedPageToolbar: JSX.Element | null = null;
-  if (state.selectedPage && state.selectedPage.toolbarActions?.length > 0) {
-    selectedPageToolbar = (
-      <div className={classes.toolbar}>
-        {state.selectedPage.toolbarActions.map((toolbarAction) => (
-          <div className={classes.toolbarAction} key={toolbarAction.id}>
-            <ToolbarAction editingContextId={editingContextId} formId={id} readOnly={readOnly} widget={toolbarAction} />
-          </div>
-        ))}
+    const onChangeTab = (_: React.ChangeEvent<{}>, value: string) => {
+      const selectedPage: GQLPage | null = pages.find((page) => page.id === value) ?? null;
+      setState((prevState) => {
+        return { ...prevState, selectedPage };
+      });
+    };
+
+    let selectedPageToolbar: JSX.Element | null = null;
+    if (state.selectedPage && state.selectedPage.toolbarActions?.length > 0) {
+      selectedPageToolbar = (
+        <div className={classes.toolbar}>
+          {state.selectedPage.toolbarActions.map((toolbarAction) => (
+            <div className={classes.toolbarAction} key={toolbarAction.id}>
+              <ToolbarAction
+                editingContextId={editingContextId}
+                formId={id}
+                readOnly={readOnly}
+                widget={toolbarAction}
+              />
+            </div>
+          ))}
+        </div>
+      );
+    }
+
+    let page: JSX.Element | null = null;
+    if (state.selectedPage) {
+      page = <Page editingContextId={editingContextId} formId={id} page={state.selectedPage} readOnly={readOnly} />;
+    }
+    const maxWidth: number = state.pages.length > 1 ? 100 : 390; // 390 is the maxWidth to fit to the default Details view
+    const variant: 'scrollable' | 'standard' = state.pages.length > 1 ? 'scrollable' : 'standard';
+    return (
+      <div data-testid="form" className={classes.form}>
+        <div className={classes.pagesListAndToolbar}>
+          <Tabs
+            classes={{ root: classes.tabsRoot }}
+            value={state.selectedPage?.id}
+            onChange={onChangeTab}
+            variant={variant}
+            scrollButtons
+            textColor="primary"
+            indicatorColor="primary">
+            {state.pages.map((page) => {
+              return (
+                <Tab
+                  {...a11yProps(page.id)}
+                  classes={{ root: classes.tabRoot }}
+                  style={{ minWidth: 1, maxWidth: maxWidth }} // Set minWidth to one to force tab width to fit the page label length
+                  value={page.id}
+                  title={page.label}
+                  label={
+                    <div className={classes.tabLabel}>
+                      <div className={classes.tabLabelText}>{page.label}</div>
+                    </div>
+                  }
+                  key={page.id}
+                  data-testid={`page-tab-${page.label}`}
+                />
+              );
+            })}
+          </Tabs>
+          {selectedPageToolbar}
+        </div>
+        {page}
       </div>
     );
   }
-
-  let page: JSX.Element | null = null;
-  if (state.selectedPage) {
-    page = <Page editingContextId={editingContextId} formId={id} page={state.selectedPage} readOnly={readOnly} />;
-  }
-  const maxWidth: number = state.pages.length > 1 ? 100 : 390; // 390 is the maxWidth to fit to the default Details view
-  const variant: 'scrollable' | 'standard' = state.pages.length > 1 ? 'scrollable' : 'standard';
-  return (
-    <div data-testid="form" className={classes.form}>
-      <div className={classes.pagesListAndToolbar}>
-        <Tabs
-          classes={{ root: classes.tabsRoot }}
-          value={state.selectedPage?.id}
-          onChange={onChangeTab}
-          variant={variant}
-          scrollButtons
-          textColor="primary"
-          indicatorColor="primary">
-          {state.pages.map((page) => {
-            return (
-              <Tab
-                {...a11yProps(page.id)}
-                classes={{ root: classes.tabRoot }}
-                style={{ minWidth: 1, maxWidth: maxWidth }} // Set minWidth to one to force tab width to fit the page label length
-                value={page.id}
-                title={page.label}
-                label={
-                  <div className={classes.tabLabel}>
-                    <div className={classes.tabLabelText}>{page.label}</div>
-                  </div>
-                }
-                key={page.id}
-                data-testid={`page-tab-${page.label}`}
-              />
-            );
-          })}
-        </Tabs>
-        {selectedPageToolbar}
-      </div>
-      {page}
-    </div>
-  );
-};
+);

--- a/packages/forms/frontend/sirius-components-forms/src/form/Form.types.ts
+++ b/packages/forms/frontend/sirius-components-forms/src/form/Form.types.ts
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2024 Obeo.
+ * Copyright (c) 2021, 2025 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -15,12 +15,17 @@ import { GQLForm, GQLPage, GQLWidget } from './FormEventFragments.types';
 export interface FormProps {
   editingContextId: string;
   form: GQLForm;
+  initialSelectedPageId: string | null;
   readOnly: boolean;
 }
 
 export interface FormState {
   selectedPage: GQLPage | null;
   pages: GQLPage[];
+}
+
+export interface FormHandle {
+  selectedPageId: string | null;
 }
 
 export type PropertySectionComponentProps<W extends GQLWidget> = {

--- a/packages/forms/frontend/sirius-components-forms/src/form/useFormHandle.ts
+++ b/packages/forms/frontend/sirius-components-forms/src/form/useFormHandle.ts
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024, 2025 Obeo.
+ * Copyright (c) 2025 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -11,12 +11,14 @@
  *     Obeo - initial API and implementation
  *******************************************************************************/
 
-import { GQLForm } from '@eclipse-sirius/sirius-components-forms';
+import { ForwardedRef, useImperativeHandle } from 'react';
+import { FormHandle } from './Form.types';
 
-export interface DetailsViewState {
-  form: GQLForm | null;
-}
-
-export interface DetailsViewConfiguration {
-  selectedPageId: string;
-}
+export const useFormHandle = (selectedPageId: string | null, ref: ForwardedRef<FormHandle>) => {
+  const formHandleProvider = (): FormHandle => {
+    return {
+      selectedPageId,
+    };
+  };
+  useImperativeHandle(ref, formHandleProvider, [selectedPageId]);
+};

--- a/packages/forms/frontend/sirius-components-forms/src/representations/FormRepresentation.tsx
+++ b/packages/forms/frontend/sirius-components-forms/src/representations/FormRepresentation.tsx
@@ -74,7 +74,9 @@ export const FormRepresentation = ({ editingContextId, representationId, readOnl
   if (state.form) {
     const { id } = state.form;
     if (state.form.pages.length > 1) {
-      content = <Form editingContextId={editingContextId} form={state.form} readOnly={readOnly} />;
+      content = (
+        <Form editingContextId={editingContextId} form={state.form} initialSelectedPageId={null} readOnly={readOnly} />
+      );
     } else if (state.form.pages.length === 1) {
       const page: GQLPage | null = state.form.pages[0] ?? null;
 

--- a/packages/forms/frontend/sirius-components-forms/src/views/FormBasedView.tsx
+++ b/packages/forms/frontend/sirius-components-forms/src/views/FormBasedView.tsx
@@ -11,8 +11,9 @@
  *     Obeo - initial API and implementation
  *******************************************************************************/
 import { DataExtension, useData } from '@eclipse-sirius/sirius-components-core';
-import { memo } from 'react';
+import { ForwardedRef, forwardRef, memo } from 'react';
 import { Form } from '../form/Form';
+import { FormHandle } from '../form/Form.types';
 import { GQLForm } from '../form/FormEventFragments.types';
 import { FormBasedViewProps, FormConverter } from './FormBasedView.types';
 import { formBasedViewFormConverterExtensionPoint } from './FormBasedViewExtensionPoints';
@@ -20,16 +21,33 @@ import { formBasedViewFormConverterExtensionPoint } from './FormBasedViewExtensi
 /**
  * Used to define workbench views based on a form.
  */
-export const FormBasedView = memo(({ editingContextId, form, readOnly, postProcessor }: FormBasedViewProps) => {
-  const { data: formConverters }: DataExtension<FormConverter[]> = useData(formBasedViewFormConverterExtensionPoint);
+export const FormBasedView = memo(
+  forwardRef<FormHandle | null, FormBasedViewProps>(
+    (
+      { editingContextId, form, initialSelectedPageId, readOnly, postProcessor }: FormBasedViewProps,
+      ref: ForwardedRef<FormHandle | null>
+    ) => {
+      const { data: formConverters }: DataExtension<FormConverter[]> = useData(
+        formBasedViewFormConverterExtensionPoint
+      );
 
-  let convertedForm: GQLForm = form;
-  formConverters.forEach((formConverter) => {
-    convertedForm = formConverter.convert(editingContextId, convertedForm);
-  });
+      let convertedForm: GQLForm = form;
+      formConverters.forEach((formConverter) => {
+        convertedForm = formConverter.convert(editingContextId, convertedForm);
+      });
 
-  if (postProcessor) {
-    return postProcessor(editingContextId, convertedForm, readOnly);
-  }
-  return <Form editingContextId={editingContextId} form={convertedForm} readOnly={readOnly} />;
-});
+      if (postProcessor) {
+        return postProcessor(editingContextId, convertedForm, readOnly);
+      }
+      return (
+        <Form
+          editingContextId={editingContextId}
+          form={convertedForm}
+          initialSelectedPageId={initialSelectedPageId}
+          readOnly={readOnly}
+          ref={ref}
+        />
+      );
+    }
+  )
+);

--- a/packages/forms/frontend/sirius-components-forms/src/views/FormBasedView.types.tsx
+++ b/packages/forms/frontend/sirius-components-forms/src/views/FormBasedView.types.tsx
@@ -15,6 +15,7 @@ import { GQLForm } from '../form/FormEventFragments.types';
 export interface FormBasedViewProps {
   editingContextId: string;
   form: GQLForm;
+  initialSelectedPageId: string | null;
   readOnly: boolean;
   postProcessor?: (editingContextId: string, form: GQLForm, readOnly: boolean) => JSX.Element;
 }

--- a/packages/sirius-web/frontend/sirius-web-application/src/diagrams/DiagramFilterForm.tsx
+++ b/packages/sirius-web/frontend/sirius-web-application/src/diagrams/DiagramFilterForm.tsx
@@ -75,6 +75,7 @@ export const DiagramFilterForm = ({ editingContextId, diagramId, readOnly }: Dia
         <FormBasedView
           editingContextId={editingContextId}
           form={state.form}
+          initialSelectedPageId={null}
           readOnly={readOnly}
           postProcessor={extractFirstGroup}
         />

--- a/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/workbench-views/details/useDetailsViewHandle.ts
+++ b/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/workbench-views/details/useDetailsViewHandle.ts
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+
+import { WorkbenchViewHandle } from '@eclipse-sirius/sirius-components-core';
+import { FormHandle } from '@eclipse-sirius/sirius-components-forms';
+import { ForwardedRef, MutableRefObject, useImperativeHandle } from 'react';
+
+export const useDetailsViewHandle = (
+  id: string,
+  formBasedViewRef: MutableRefObject<FormHandle | null>,
+  ref: ForwardedRef<WorkbenchViewHandle>
+) => {
+  const detailsViewHandlerProvider = () => {
+    return {
+      id,
+      getWorkbenchViewConfiguration: () => {
+        return {
+          selectedPageId: formBasedViewRef.current?.selectedPageId || null,
+        };
+      },
+    };
+  };
+  useImperativeHandle(ref, detailsViewHandlerProvider, [id, formBasedViewRef]);
+};

--- a/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/workbench-views/explorer/ExplorerView.types.ts
+++ b/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/workbench-views/explorer/ExplorerView.types.ts
@@ -10,6 +10,7 @@
  * Contributors:
  *     Obeo - initial API and implementation
  *******************************************************************************/
+import { WorkbenchViewConfiguration } from '@eclipse-sirius/sirius-components-core';
 import { GQLTree, GQLTreeItem, TreeFilter } from '@eclipse-sirius/sirius-components-trees';
 
 export interface ExplorerViewState {
@@ -23,4 +24,9 @@ export interface ExplorerViewState {
   tree: GQLTree | null;
   selectedTreeItemIds: string[];
   singleTreeItemSelected: GQLTreeItem | null;
+}
+
+export interface ExplorerViewConfiguration extends WorkbenchViewConfiguration {
+  activeTreeDescriptionId: string | null;
+  activeTreeFilters: TreeFilter[];
 }

--- a/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/workbench-views/explorer/useExplorerViewHandle.ts
+++ b/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/workbench-views/explorer/useExplorerViewHandle.ts
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+import { WorkbenchViewHandle } from '@eclipse-sirius/sirius-components-core';
+import { TreeFilter } from '@eclipse-sirius/sirius-components-trees';
+import { ForwardedRef, useImperativeHandle } from 'react';
+
+export const useExplorerViewHandle = (
+  id: string,
+  treeFilters: TreeFilter[],
+  activeTreeDescriptionId: string | null,
+  ref: ForwardedRef<WorkbenchViewHandle>
+) => {
+  const workbenchViewHandleProvider = (): WorkbenchViewHandle => {
+    return {
+      id,
+      getWorkbenchViewConfiguration: () => {
+        return {
+          activeTreeFilters: treeFilters,
+          activeTreeDescriptionId,
+        };
+      },
+    };
+  };
+  useImperativeHandle(ref, workbenchViewHandleProvider, [id, treeFilters, activeTreeDescriptionId]);
+};

--- a/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/workbench-views/query/QueryView.types.ts
+++ b/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/workbench-views/query/QueryView.types.ts
@@ -13,10 +13,19 @@
 
 import { GQLEvaluateExpressionSuccessPayload, GQLExpressionResult } from './useEvaluateExpression.types';
 
+export interface QueryViewConfiguration {
+  queryText: string;
+}
+
 export interface ExpressionAreaProps {
   editingContextId: string;
+  initialQueryText: string | null;
   onEvaluateExpression: (expression: string) => void;
   disabled: boolean;
+}
+
+export interface ExpressionAreaHandle {
+  getExpression: () => string;
 }
 
 export interface ResultAreaProps {

--- a/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/workbench-views/query/useExpression.tsx
+++ b/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/workbench-views/query/useExpression.tsx
@@ -14,10 +14,12 @@
 import { useEffect, useState } from 'react';
 import { UseExpressionState, UseExpressionValue } from './useExpression.types';
 
-export const useExpression = (editingContextId: string): UseExpressionValue => {
+export const useExpression = (editingContextId: string, initialExpression: string | null): UseExpressionValue => {
   const sessionStorageKey = `query_view_expression#${editingContextId}`;
 
-  const defaultValue: string = isSessionStorageAvailable()
+  const defaultValue: string = initialExpression
+    ? initialExpression
+    : isSessionStorageAvailable()
     ? window.sessionStorage.getItem(sessionStorageKey) ?? ''
     : '';
   const [state, setState] = useState<UseExpressionState>({

--- a/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/workbench-views/query/useQueryViewHandle.ts
+++ b/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/workbench-views/query/useQueryViewHandle.ts
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+import { WorkbenchViewHandle } from '@eclipse-sirius/sirius-components-core';
+import { ForwardedRef, RefObject, useImperativeHandle } from 'react';
+import { ExpressionAreaHandle } from './QueryView.types';
+
+export const useQueryViewHandle = (
+  id: string,
+  expressionAreaRef: RefObject<ExpressionAreaHandle | null>,
+  ref: ForwardedRef<WorkbenchViewHandle>
+) => {
+  const workbenchViewHandleProvider = (): WorkbenchViewHandle => {
+    return {
+      id,
+      getWorkbenchViewConfiguration: () => {
+        return {
+          queryText: expressionAreaRef.current?.getExpression() || '',
+        };
+      },
+    };
+  };
+  useImperativeHandle(ref, workbenchViewHandleProvider, [id, expressionAreaRef]);
+};

--- a/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/workbench-views/related-elements/RelatedElementsView.tsx
+++ b/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/workbench-views/related-elements/RelatedElementsView.tsx
@@ -131,6 +131,7 @@ export const RelatedElementsView = forwardRef<WorkbenchViewHandle, WorkbenchView
             <FormBasedView
               editingContextId={editingContextId}
               form={state.form}
+              initialSelectedPageId={null}
               readOnly={readOnly}
               postProcessor={extractFirstGroup}
             />

--- a/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/workbench-views/representations/RepresentationsView.tsx
+++ b/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/workbench-views/representations/RepresentationsView.tsx
@@ -153,6 +153,7 @@ export const RepresentationsView = forwardRef<WorkbenchViewHandle, WorkbenchView
             <FormBasedView
               editingContextId={editingContextId}
               form={state.form}
+              initialSelectedPageId={null}
               readOnly={readOnly}
               postProcessor={extractPlainList}
             />


### PR DESCRIPTION
Edit: Can now be reviewed, remember to remove last commit before merge.
Leaving past questions below as they may be of interest of reviewers

---
Follow-up to #5187 for #4886.

The goal is to get some early feedback to validate the implementation approach.
(note there is an extraneous commit on top just to set up a second page in the "Details" view for testing purposes)

Some questions/notes:
* In `packages/sirius-web/frontend/sirius-web-application/src/extension/DefaultExtensionRegistry.tsx` we now have to provide the RefObject creation code instead of creating it directly because we need to be inside of a BrowserRouter context for the instantiation to work. I wonder if maybe there's a better (or more React-y) way to do that?
* In the different view components (QueryView, DetailsView, etc.), the ref is typed as `WorkbenchViewHandle` when we actually provide a more specific type (e.g. `DetailsViewHandle` or `QueryViewHandle`). I think we might be able to fit it in the type system with generics, but I wonder if we want/need to do that?
* In the same spirit we need to cast the `WorkbenchViewConfiguration` down to the view-specific type (e.g. `QueryViewConfiguration`). Not sure if we want to tweak our types to not need that cast (I'm not well-versed enough in Typescript generics to see if it would be a good idea)
* On a more functional note, the configuration of a view can only be retrieved if the view is being shown, because otherwise the underlying data does not exist (e.g. when setting up an expression in the Query view and then switching back to the Details view, when creating a shareable URL then the contents of the Query view will not be shared).
---

# Pull request template

## General purpose
What is the main goal of this pull request?
- [ ] Bug fixes
- [X] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [ ] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [ ] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [X] Variables have a proper type
- [X] Functions’ arguments have a proper type
- [X] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [X] `useState<STATE_TYPE>(…)`
- [X] All components have a proper typing for their props
- [X] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [X] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Review

### How to test this PR?

* Query view:
  * Open the view, add an expression into it, create a shareable URL => check that the URL contains the expression from the view.
  * Load the above shared URL (possibly in another browser because the view relies on local storage) => the expression is set up in the Query view.
* Explorer view:
  * Create or open a studio project. In the Explorer view, use the second tree description ("Domain explorer by DSL") and disable filter "Hide in-memory studio color palettes". Create a shareable URL => check that the URL contains the ID of the selected tree description and of the disabled filter.
  * Load the above shared URL => check that in the Explorer view, the second tree description is selected and the filter is disabled.
* Details view:
  * In a studio project, create and select an `Entity` element, open the Details view and open the second tab of the form. Create a shareable URL => check that the URL contains the ID of the second tab.
  * Load the above shared URL => check that the second tab is opened in the Details view.

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?