### PR TITLE
[5450] By default, only try to rewrite proxies on writable Resources

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -156,6 +156,8 @@ This includes any resource that is not persisted, not only the libraries.
 - https://github.com/eclipse-sirius/sirius-web/issues/4886[#4886] [core] Add in the shared URL for a project which representations are opened.
 - https://github.com/eclipse-sirius/sirius-web/issues/5431[#5431] [core] Support EObject-typed containments
 - https://github.com/eclipse-sirius/sirius-web/issues/5433[#5433] [core] Calculate child creation descriptions based on container object
+- https://github.com/eclipse-sirius/sirius-web/issues/5450[#5450] [sirius-web] Default implementation of `IRewriteProxiesResourceFilter` now relies on `IReadOnlyObjectPredicate` instead of always returning `true`.
+
 
 
 == v2025.8.0

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/project/services/DefaultRewriteProxiesResourceFilter.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/project/services/DefaultRewriteProxiesResourceFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Obeo.
+ * Copyright (c) 2024, 2025 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -12,7 +12,10 @@
  *******************************************************************************/
 package org.eclipse.sirius.web.application.project.services;
 
+import java.util.Objects;
+
 import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.sirius.components.core.api.IReadOnlyObjectPredicate;
 import org.eclipse.sirius.web.application.project.services.api.IRewriteProxiesResourceFilter;
 import org.springframework.stereotype.Service;
 
@@ -24,8 +27,15 @@ import org.springframework.stereotype.Service;
 @Service
 public class DefaultRewriteProxiesResourceFilter implements IRewriteProxiesResourceFilter {
 
+    private final IReadOnlyObjectPredicate readOnlyObjectPredicate;
+
+    public DefaultRewriteProxiesResourceFilter(IReadOnlyObjectPredicate readOnlyObjectPredicate) {
+        this.readOnlyObjectPredicate = Objects.requireNonNull(readOnlyObjectPredicate);
+    }
+
     @Override
     public boolean shouldRewriteProxies(Resource resource) {
-        return true;
+        return !this.readOnlyObjectPredicate.test(resource);
     }
+
 }


### PR DESCRIPTION
Fixes #5450 by not trying to rewrite the proxies in resources we do not have write access to.

# Pull request template

## General purpose
What is the main goal of this pull request?
- [ ] Bug fixes
- [X] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [ ] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [ ] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Review

### How to test this PR?

When uploading a project, `RewriteProxiesEventHandler ` does not try to rewrite proxies in read-only resources (e.g. imported libraries).

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?