### PR TITLE
[5527] Add Pin/Unpin support to the Details view

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -158,7 +158,8 @@ Instead, a new button available in the diagram's toolbar can be used to trigger 
 - https://github.com/eclipse-sirius/sirius-web/issues/5463[#5463] [diagram] Add visibility field in the style of a label to be able to hide a label from the appearance palette.
 - https://github.com/eclipse-sirius/sirius-web/issues/5526[#5526] [core] Add support for "Show in ..." actions to "push" the local selection from a representation or view into another one (provided it supports it).
 - https://github.com/eclipse-sirius/sirius-web/issues/5580[#5580] [diagram] Fix an issue that could cause label to be layout with a smaller width
-
+- https://github.com/eclipse-sirius/sirius-web/issues/5527[#5527] [sirius-web] The _Details_ view can now be pinned to keep showing the details of the same element even if others are selected in other parts of the UI.
+While it is pinned, other panels and representation can use the new "Show in Details" action to force it to update its local selection.
 
 === Improvements
 

--- a/integration-tests-cypress/cypress/e2e/project/diagrams/direct-edit-label.cy.ts
+++ b/integration-tests-cypress/cypress/e2e/project/diagrams/direct-edit-label.cy.ts
@@ -36,7 +36,8 @@ describe('Diagram - edit node label', () => {
     it('Then we can use direct by typing after creating a new node', () => {
       const diagram = new Diagram();
       //Open the palette
-      cy.getByTestId('rf__wrapper').should('exist').rightclick(100, 800).rightclick(100, 800);
+      cy.getByTestId('rf__wrapper').should('exist');
+      cy.getByTestId('rf__wrapper').rightclick(100, 800);
       diagram.getPalette().should('exist');
       //Create a new node
       diagram.getPalette().getByTestId('toolSection-Creation Tools').should('exist');

--- a/integration-tests-playwright/playwright/e2e/edge-style.spec.ts
+++ b/integration-tests-playwright/playwright/e2e/edge-style.spec.ts
@@ -11,12 +11,12 @@
  *     Obeo - initial API and implementation
  *******************************************************************************/
 
-import { test, expect } from '@playwright/test';
-import { PlaywrightProject } from '../helpers/PlaywrightProject';
+import { expect, test } from '@playwright/test';
+import { PlaywrightDetails } from '../helpers/PlaywrightDetails';
 import { PlaywrightEdge } from '../helpers/PlaywrightEdge';
 import { PlaywrightExplorer } from '../helpers/PlaywrightExplorer';
-import { PlaywrightDetails } from '../helpers/PlaywrightDetails';
 import { PlaywrightNode } from '../helpers/PlaywrightNode';
+import { PlaywrightProject } from '../helpers/PlaywrightProject';
 
 test.describe('diagram - edgeStyle', () => {
   let projectId;
@@ -48,7 +48,7 @@ test.describe('diagram - edgeStyle', () => {
     await playwrightExplorer.createRepresentation('Root', 'diagramEdges - simple edges', 'diagram');
     const playwrightEdge = new PlaywrightEdge(page);
 
-    await playwrightExplorer.select('TestConditionalEdgeStyle');
+    await playwrightExplorer.showIn('TestConditionalEdgeStyle', 'Details');
     await new PlaywrightDetails(page).setText('Name', 'TestObliqueEdgeType');
 
     //Move the node so it's easier to identify the edge type

--- a/integration-tests-playwright/playwright/e2e/label.spec.ts
+++ b/integration-tests-playwright/playwright/e2e/label.spec.ts
@@ -11,10 +11,10 @@
  *     Obeo - initial API and implementation
  *******************************************************************************/
 import { expect, test } from '@playwright/test';
+import { PlaywrightDetails } from '../helpers/PlaywrightDetails';
 import { PlaywrightNode } from '../helpers/PlaywrightNode';
 import { PlaywrightNodeLabel } from '../helpers/PlaywrightNodeLabel';
 import { PlaywrightProject } from '../helpers/PlaywrightProject';
-import { PlaywrightDetails } from '../helpers/PlaywrightDetails';
 
 test.describe('diagram - label', () => {
   let projectId;
@@ -54,6 +54,11 @@ test.describe('diagram - label', () => {
   test('when a node with an empty label is selected, then the label is not highlighted', async ({ page }) => {
     const dataSourceNode = new PlaywrightNode(page, 'DataSource1');
     await dataSourceNode.click();
+
+    await dataSourceNode.openPalette();
+    await page.getByTestId('toolSection-Show in').click();
+    await page.getByTestId('push-diagram-selection-to-details').click();
+
     const playwrightDetails = new PlaywrightDetails(page);
     await playwrightDetails.setText('Name', '');
 

--- a/integration-tests-playwright/playwright/helpers/PlaywrightExplorer.ts
+++ b/integration-tests-playwright/playwright/helpers/PlaywrightExplorer.ts
@@ -80,9 +80,9 @@ export class PlaywrightExplorer {
     await this.page.getByTestId('explorer-reveal-selection-button').click();
   }
 
-  async showIn(treeItemLabel: string, selectionTargetId: string) {
+  async showIn(treeItemLabel: string, selectionTargetLabel: string) {
     await this.explorerLocator.locator(`[data-treeitemlabel="${treeItemLabel}"]`).click();
     await this.explorerLocator.getByTestId(`${treeItemLabel}-more`).click();
-    await this.page.getByTestId(`push-selection-to-${selectionTargetId}`).click();
+    await this.page.getByTestId(`push-selection-to-${selectionTargetLabel}`).click();
   }
 }

--- a/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/workbench-views/details/DetailsView.tsx
+++ b/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/workbench-views/details/DetailsView.tsx
@@ -12,12 +12,16 @@
  *******************************************************************************/
 import {
   RepresentationLoadingIndicator,
+  Selection,
   useSelection,
   WorkbenchViewComponentProps,
   WorkbenchViewHandle,
 } from '@eclipse-sirius/sirius-components-core';
 import { FormBasedView, FormContext, FormHandle } from '@eclipse-sirius/sirius-components-forms';
+import SyncLockOutlinedIcon from '@mui/icons-material/SyncLockOutlined';
+import SyncOutlinedIcon from '@mui/icons-material/SyncOutlined';
 import Box from '@mui/material/Box';
+import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import { ForwardedRef, forwardRef, MutableRefObject, useEffect, useRef, useState } from 'react';
 import { makeStyles } from 'tss-react/mui';
@@ -30,9 +34,28 @@ const useDetailsViewStyles = makeStyles()((theme) => ({
   idle: {
     padding: theme.spacing(1),
   },
-  form: {
+  view: {
+    display: 'grid',
+    gridTemplateColumns: 'auto',
+    gridTemplateRows: 'auto 1fr',
+    justifyItems: 'stretch',
+    overflow: 'auto',
+  },
+  toolbar: {
     display: 'flex',
-    flexDirection: 'column',
+    flexDirection: 'row',
+    overflow: 'hidden',
+    height: theme.spacing(4),
+    paddingLeft: theme.spacing(1),
+    paddingRight: theme.spacing(1),
+    borderBottomWidth: '1px',
+    borderBottomStyle: 'solid',
+    justifyContent: 'right',
+    alignItems: 'center',
+    borderBottomColor: theme.palette.divider,
+  },
+  content: {
+    overflow: 'auto',
   },
 }));
 
@@ -46,17 +69,29 @@ export const DetailsView = forwardRef<WorkbenchViewHandle, WorkbenchViewComponen
   ) => {
     const [state, setState] = useState<DetailsViewState>({
       form: null,
+      objectIds: [],
+      pinned: false,
     });
 
-    const formBasedViewRef: MutableRefObject<FormHandle | null> = useRef<FormHandle | null>(null);
+    const applySelection = (selection: Selection) => {
+      setState((prevState) => ({
+        ...prevState,
+        objectIds: selection.entries.map((entry) => entry.id),
+      }));
+    };
 
-    useDetailsViewHandle(id, formBasedViewRef, ref);
+    const formBasedViewRef: MutableRefObject<FormHandle | null> = useRef<FormHandle | null>(null);
+    useDetailsViewHandle(id, formBasedViewRef, applySelection, ref);
 
     const { selection } = useSelection();
+    useEffect(() => {
+      if (!state.pinned) {
+        applySelection(selection);
+      }
+    }, [selection, state.pinned]);
 
-    const objectIds: string[] = selection.entries.map((entry) => entry.id);
-    const skip = objectIds.length === 0;
-    const { payload, complete, loading } = useDetailsViewSubscription(editingContextId, objectIds, skip);
+    const skip = state.objectIds.length === 0;
+    const { payload, complete, loading } = useDetailsViewSubscription(editingContextId, state.objectIds, skip);
 
     useEffect(() => {
       if (isFormRefreshedEventPayload(payload)) {
@@ -68,14 +103,29 @@ export const DetailsView = forwardRef<WorkbenchViewHandle, WorkbenchViewComponen
     const detailsViewConfiguration = initialConfiguration as unknown as DetailsViewConfiguration;
     const initialSelectedPageId = detailsViewConfiguration?.selectedPageId ?? null;
 
+    const toolbar = (
+      <Tooltip
+        title={
+          state.pinned
+            ? 'Pinned. Click to follow the global selection.'
+            : 'Unpinned. Click to pin the view to the current selection.'
+        }
+        data-testid="details-toggle-pin"
+        onClick={() => setState((prevState) => ({ ...prevState, pinned: !prevState.pinned }))}>
+        {state.pinned ? <SyncLockOutlinedIcon /> : <SyncOutlinedIcon />}
+      </Tooltip>
+    );
+
+    let contents: JSX.Element = <></>;
+
     if (complete || skip) {
-      return (
+      contents = (
         <div className={classes.idle}>
           <Typography variant="subtitle2">No object selected</Typography>
         </div>
       );
     } else {
-      return (
+      contents = (
         <Box
           sx={{
             display: 'grid',
@@ -84,7 +134,7 @@ export const DetailsView = forwardRef<WorkbenchViewHandle, WorkbenchViewComponen
           }}
           data-representation-kind="form-details">
           {!state.form || loading ? (
-            <Box sx={{ gridRow: '1', gridColumn: '1', zIndex: 1 }}>
+            <Box sx={{ gridRow: '1', gridColumn: '1' }}>
               <RepresentationLoadingIndicator />
             </Box>
           ) : null}
@@ -107,5 +157,13 @@ export const DetailsView = forwardRef<WorkbenchViewHandle, WorkbenchViewComponen
         </Box>
       );
     }
+
+    return (
+      <div className={classes.view}>
+        <div className={classes.toolbar}>{toolbar}</div>
+
+        <div className={classes.content}>{contents}</div>
+      </div>
+    );
   }
 );

--- a/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/workbench-views/details/DetailsView.types.ts
+++ b/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/workbench-views/details/DetailsView.types.ts
@@ -15,6 +15,8 @@ import { GQLForm } from '@eclipse-sirius/sirius-components-forms';
 
 export interface DetailsViewState {
   form: GQLForm | null;
+  objectIds: string[];
+  pinned: boolean;
 }
 
 export interface DetailsViewConfiguration {

--- a/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/workbench-views/details/useDetailsViewHandle.ts
+++ b/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/workbench-views/details/useDetailsViewHandle.ts
@@ -11,13 +11,14 @@
  *     Obeo - initial API and implementation
  *******************************************************************************/
 
-import { WorkbenchViewHandle } from '@eclipse-sirius/sirius-components-core';
+import { Selection, WorkbenchViewHandle } from '@eclipse-sirius/sirius-components-core';
 import { FormHandle } from '@eclipse-sirius/sirius-components-forms';
 import { ForwardedRef, MutableRefObject, useImperativeHandle } from 'react';
 
 export const useDetailsViewHandle = (
   id: string,
   formBasedViewRef: MutableRefObject<FormHandle | null>,
+  applySelection: (selection: Selection) => void,
   ref: ForwardedRef<WorkbenchViewHandle>
 ) => {
   const detailsViewHandlerProvider = () => {
@@ -28,7 +29,7 @@ export const useDetailsViewHandle = (
           selectedPageId: formBasedViewRef.current?.selectedPageId || null,
         };
       },
-      applySelection: null,
+      applySelection,
     };
   };
   useImperativeHandle(ref, detailsViewHandlerProvider, [id, formBasedViewRef]);


### PR DESCRIPTION
This also makes it a possible 'Show in' target.

Bug: https://github.com/eclipse-sirius/sirius-web/issues/5527
Signed-off-by: Pierre-Charles David <pierre-charles.david@obeo.fr>

# Pull request template

## General purpose
What is the main goal of this pull request?
- [ ] Bug fixes
- [x] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [ ] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [ ] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?