### PR TITLE
[5689] Applying a selection to the workbench should include the opened representation (if any)

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -50,6 +50,7 @@ This also includes an update from ANTLR 4.10.1 to 4.13.2.
 Use `org.eclipse.emf.ecore.util.ECrossReferenceAdapter.getCrossReferenceAdapter(Notifier)` to obtain it instead of looking for an `EditingContextCrossReferenceAdapter`.
 - https://github.com/eclipse-sirius/sirius-web/issues/5599[#5599] Ensure that the project download uses the proper editing context
 - https://github.com/eclipse-sirius/sirius-web/issues/5366[#5366] [core] Fix version comparison for migration participants
+- https://github.com/eclipse-sirius/sirius-web/issues/5689[#5689] [sirius-web] Applying a selection (e.g. from the Omnibox) to the workbench now correctly applies it the opened representation (if any)
 
 
 === New Features

--- a/integration-tests-cypress/cypress/e2e/project/omnibox.cy.ts
+++ b/integration-tests-cypress/cypress/e2e/project/omnibox.cy.ts
@@ -13,6 +13,7 @@
 
 import { Project } from '../../pages/Project';
 import { Flow } from '../../usecases/Flow';
+import { Diagram } from '../../workbench/Diagram';
 import { Explorer } from '../../workbench/Explorer';
 import { Omnibox } from '../../workbench/Omnibox';
 
@@ -29,15 +30,25 @@ describe('Project - Omnibox', () => {
 
     afterEach(() => cy.deleteProject(projectId));
 
-    it('Then the omnibox can be display and used to select an element in the workbench', () => {
+    it('Then the omnibox can be displayed and used to select an element in the workbench', () => {
       const explorer = new Explorer();
+
+      explorer.expandWithDoubleClick('robot');
+      explorer.createRepresentation('System', 'Topography', 'Topography');
+
       const omnibox = new Omnibox();
       omnibox.display();
       omnibox.sendQuery('').findByTestId('Search').click();
       omnibox.sendQuery('').findByTestId('DSP').click();
       omnibox.shouldBeClosed();
+
       explorer.revealGlobalSelectionInExplorer();
       explorer.getSelectedTreeItems().contains('DSP').should('exist');
+
+      const diagram = new Diagram();
+      diagram.getSelectedNodes('Topography', 'DSP').should('be.visible');
+
+      cy.getByTestId('page-tab-DSP').should('be.visible');
     });
   });
 });

--- a/packages/core/frontend/sirius-components-core/src/workbench/Workbench.tsx
+++ b/packages/core/frontend/sirius-components-core/src/workbench/Workbench.tsx
@@ -144,6 +144,8 @@ export const Workbench = forwardRef<WorkbenchHandle | null, WorkbenchProps>(
 
     const refRepresentationNavigationHandle: RefObject<RepresentationNavigationHandle | null> =
       useRef<RepresentationNavigationHandle | null>(null);
+    const refDisplayedRepresentationHandle: RefObject<WorkbenchMainRepresentationHandle | null> =
+      useRef<WorkbenchMainRepresentationHandle | null>(null);
     const refPanelsHandle: RefObject<WorkbenchPanelsHandle | null> = useRef<WorkbenchPanelsHandle | null>(null);
     useImperativeHandle(refWorkbenchHandle, () => {
       return {
@@ -161,6 +163,9 @@ export const Workbench = forwardRef<WorkbenchHandle | null, WorkbenchProps>(
               }
             });
           });
+          if (refDisplayedRepresentationHandle.current && refDisplayedRepresentationHandle.current.applySelection) {
+            refDisplayedRepresentationHandle.current.applySelection(selection);
+          }
         },
       };
     });
@@ -270,9 +275,6 @@ export const Workbench = forwardRef<WorkbenchHandle | null, WorkbenchProps>(
     const onRepresentationClick = (representation: RepresentationMetadata) => {
       setSelection({ entries: [{ id: representation.id }] });
     };
-
-    const refDisplayedRepresentationHandle: RefObject<WorkbenchMainRepresentationHandle | null> =
-      useRef<WorkbenchMainRepresentationHandle | null>(null);
 
     const { data: representationFactories } = useData(representationFactoryExtensionPoint);
     if (state.displayedRepresentationMetadata) {


### PR DESCRIPTION
Selecting an element in the Omnibox now correcly selects and reveals it:
* In the Explorer
* On the current diagram (if there is one)
* In the Details view, even if it was pinned on another element

https://github.com/user-attachments/assets/6fbc0809-1bd6-469e-8989-2048b90e2b17


Bug: https://github.com/eclipse-sirius/sirius-web/issues/5526
Signed-off-by: Pierre-Charles David <pierre-charles.david@obeo.fr>

# Pull request template

## General purpose
What is the main goal of this pull request?
- [x] Bug fixes
- [ ] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [ ] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [ ] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?