### PR TITLE
[5667] Extract the dynamic age indicator

### DIFF
--- a/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/workbench-views/search/SearchResults.tsx
+++ b/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/workbench-views/search/SearchResults.tsx
@@ -63,12 +63,8 @@ const useSecondsSince = (startTime: number, refreshDelay: number = 1000): number
   return secondsSince;
 };
 
-export const SearchResults = ({ loading, query, result, timestamp }: SearchResultProps) => {
-  const { classes } = useSearchResultStyles();
-  const { setSelection } = useSelection();
-  const { selectionTargets } = useSelectionTargets();
-
-  const resultsAge = useSecondsSince(timestamp, 10_000);
+const AgeIndicator = ({ timestamp }: { timestamp: number }) => {
+  const resultsAge = useSecondsSince(timestamp, 60_000);
   const resultsAgeText =
     resultsAge < 60
       ? `less than a minute`
@@ -77,6 +73,17 @@ export const SearchResults = ({ loading, query, result, timestamp }: SearchResul
       : resultsAge < 86_400
       ? `${Math.floor(resultsAge / 3_600)}h`
       : `${Math.floor(resultsAge / 86_400)}d`;
+  return (
+    <Typography variant="caption" color="secondary">
+      {`Performed ${resultsAgeText} ago`}
+    </Typography>
+  );
+};
+
+export const SearchResults = ({ loading, query, result, timestamp }: SearchResultProps) => {
+  const { classes } = useSearchResultStyles();
+  const { setSelection } = useSelection();
+  const { selectionTargets } = useSelectionTargets();
 
   const matches = result?.matches || [];
 
@@ -104,9 +111,7 @@ export const SearchResults = ({ loading, query, result, timestamp }: SearchResul
           <Typography variant="subtitle2" color="secondary">
             {`${matches.length} result${matches.length > 1 ? 's' : ''} for '${query.text}'`}
           </Typography>
-          <Typography variant="caption" color="secondary">
-            {`Performed ${resultsAgeText} ago`}
-          </Typography>
+          <AgeIndicator timestamp={timestamp} />
         </div>
       </>
     );


### PR DESCRIPTION
This avoids re-rendering the whole results component on every 'tick',
which can be an issue at the moment with large result sets.

Also increase the tick from 10s to 1min: there is no need to update
more frequently than that given the precision of the text message.

Bug: https://github.com/eclipse-sirius/sirius-web/issues/5667
Signed-off-by: Pierre-Charles David <pierre-charles.david@obeo.fr>

# Pull request template

## General purpose
What is the main goal of this pull request?
- [ ] Bug fixes
- [x] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [ ] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [ ] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?