### PR TITLE
[releng] Switch to Spring Boot 3.5.8

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -1,5 +1,41 @@
 = Changelog
 
+== 2026.1.0
+
+=== Shapes
+
+
+
+=== Architectural decision records
+
+
+
+=== Deprecation warning
+
+
+
+=== Breaking changes
+
+
+
+=== Dependency update
+
+
+
+
+=== Bug fixes
+
+
+
+=== New Features
+
+
+
+=== Improvements
+
+
+
+
 == 2025.12.0 (work in progress)
 
 === Shapes

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -20,7 +20,7 @@
 
 === Dependency update
 
-
+- [releng] Switch to https://github.com/spring-projects/spring-boot/releases/tag/v3.5.8[Spring Boot 3.5.8]
 
 
 === Bug fixes

--- a/packages/releng/backend/sirius-web-parent/pom.xml
+++ b/packages/releng/backend/sirius-web-parent/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.7</version>
+        <version>3.5.8</version>
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
 


### PR DESCRIPTION
Probably not for this iteration (the CHANGELOG will need to be updated), but this fixes (or at least works around) the compatibility issue between Testcontainers & Docker 29.
