### PR TITLE
[cleanup] Fix syntax errors in some AQL expressions

### DIFF
--- a/packages/emf/backend/sirius-components-interpreter/src/main/java/org/eclipse/sirius/components/interpreter/Result.java
+++ b/packages/emf/backend/sirius-components-interpreter/src/main/java/org/eclipse/sirius/components/interpreter/Result.java
@@ -66,10 +66,10 @@ public class Result {
             List<Object> list = new ArrayList<>();
             if (value instanceof Collection<?>) {
                 list = List.copyOf((Collection<?>) value);
+            } else if (value.getClass().isArray()) {
+                list = Arrays.asList((Object[]) value);
             } else if (value instanceof Object) {
                 list = List.of(value);
-            } else if (value != null && value.getClass().isArray()) {
-                list = Arrays.asList((Object[]) value);
             }
             return list;
         });
@@ -117,9 +117,7 @@ public class Result {
     public Optional<Boolean> asBoolean() {
         return this.rawValue.map(value -> {
             final boolean result;
-            if (value == null) {
-                result = false;
-            } else if (value instanceof Boolean) {
+            if (value instanceof Boolean) {
                 result = ((Boolean) value).booleanValue();
             } else {
                 String toString = value.toString();

--- a/packages/emf/backend/sirius-components-interpreter/src/test/java/org/eclipse/sirius/components/interpreter/ResultTests.java
+++ b/packages/emf/backend/sirius-components-interpreter/src/test/java/org/eclipse/sirius/components/interpreter/ResultTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 Obeo.
+ * Copyright (c) 2019, 2025 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -106,6 +106,23 @@ public class ResultTests {
         assertThat(result.asBoolean()).hasValue(true);
         assertThat(result.asObject()).isPresent();
         assertThat(result.asObject().get()).isEqualTo(listValue);
+
+        assertThat(result.asObjects()).isPresent();
+        assertThat(result.asObjects().get()).hasSize(1);
+        assertThat(result.asObjects().get().get(0)).isEqualTo(object);
+    }
+
+    @Test
+    public void testArrayResult() {
+        Object object = new Object();
+        Object[] arrayValue = new Object[] { object };
+        Result result = new Result(Optional.of(arrayValue), Status.OK);
+
+        assertThat(result.asString()).isPresent();
+        assertThat(result.asInt()).isNotPresent();
+        assertThat(result.asBoolean()).hasValue(true);
+        assertThat(result.asObject()).isPresent();
+        assertThat(result.asObject().get()).isEqualTo(arrayValue);
 
         assertThat(result.asObjects()).isPresent();
         assertThat(result.asObjects().get()).hasSize(1);

--- a/packages/sirius-web/backend/sirius-web/src/test/java/org/eclipse/sirius/web/services/diagrams/EditableLabelDiagramDescriptionProvider.java
+++ b/packages/sirius-web/backend/sirius-web/src/test/java/org/eclipse/sirius/web/services/diagrams/EditableLabelDiagramDescriptionProvider.java
@@ -107,7 +107,7 @@ public class EditableLabelDiagramDescriptionProvider implements IEditingContextP
                 .body(
                         new SetValueBuilder()
                                 .featureName("name")
-                                .valueExpression("aql:newLabel)")
+                                .valueExpression("aql:newLabel")
                                 .build()
                 )
                 .build();
@@ -143,7 +143,7 @@ public class EditableLabelDiagramDescriptionProvider implements IEditingContextP
                                 .children(
                                         new SetValueBuilder()
                                                 .featureName("name")
-                                                .valueExpression("aql:newLabel)")
+                                                .valueExpression("aql:newLabel")
                                                 .build()
                                 )
                                 .build()

--- a/packages/sirius-web/backend/sirius-web/src/test/java/org/eclipse/sirius/web/services/diagrams/RelationBasedEdgeDiagramDescriptionProvider.java
+++ b/packages/sirius-web/backend/sirius-web/src/test/java/org/eclipse/sirius/web/services/diagrams/RelationBasedEdgeDiagramDescriptionProvider.java
@@ -139,7 +139,7 @@ public class RelationBasedEdgeDiagramDescriptionProvider implements IEditingCont
                 .build();
 
         var insideLabel = new InsideLabelDescriptionBuilder()
-                .labelExpression("aql:self.name)")
+                .labelExpression("aql:self.name")
                 .style(
                         new InsideLabelStyleBuilder()
                                 .headerSeparatorDisplayMode(HeaderSeparatorDisplayMode.ALWAYS)

--- a/packages/sirius-web/backend/sirius-web/src/test/java/org/eclipse/sirius/web/services/forms/FormVariableViewPreEditingContextProcessor.java
+++ b/packages/sirius-web/backend/sirius-web/src/test/java/org/eclipse/sirius/web/services/forms/FormVariableViewPreEditingContextProcessor.java
@@ -90,7 +90,7 @@ public class FormVariableViewPreEditingContextProcessor implements IEditingConte
     private FormDescription createFormDescription() {
         TreeDescription treeDescription = new TreeDescriptionBuilder()
                 .name("Tree")
-                .childrenExpression("aql:self.eContents()}")
+                .childrenExpression("aql:self.eContents()")
                 .labelExpression("Tree")
                 .treeItemLabelExpression("aql:self.name")
                 .isCheckableExpression("aql:true")

--- a/packages/sirius-web/backend/sirius-web/src/test/java/org/eclipse/sirius/web/services/forms/FormWithFlexboxContainerDescriptionProvider.java
+++ b/packages/sirius-web/backend/sirius-web/src/test/java/org/eclipse/sirius/web/services/forms/FormWithFlexboxContainerDescriptionProvider.java
@@ -96,7 +96,7 @@ public class FormWithFlexboxContainerDescriptionProvider implements IEditingCont
         var childCountDescription = new FormBuilders().newLabelDescription()
                 .name("Child count")
                 .labelExpression("Child count")
-                .valueExpression("aql:self.eAllContents()->size")
+                .valueExpression("aql:self.eAllContents()->size()")
                 .build();
 
         var conditionalStyle = new FormBuilders().newConditionalContainerBorderStyle()

--- a/packages/sirius-web/backend/sirius-web/src/test/java/org/eclipse/sirius/web/services/selection/SelectionDescriptionProvider.java
+++ b/packages/sirius-web/backend/sirius-web/src/test/java/org/eclipse/sirius/web/services/selection/SelectionDescriptionProvider.java
@@ -190,7 +190,7 @@ public class SelectionDescriptionProvider implements IEditingContextProcessor {
     private SelectionDialogDescription createSelectionDialog() {
         this.selectionDialogTreeDescription = new SelectionDialogTreeDescriptionBuilder()
                 .elementsExpression("aql:self.eResource()")
-                .childrenExpression("aql:if self.oclIsKindOf(papaya::NamedElement) then self.eContents() else self.getContents() endif  ")
+                .childrenExpression("aql:if self.oclIsKindOf(papaya::NamedElement) then self.eContents() else self.getContents() endif")
                 .isSelectableExpression("aql:self.oclIsKindOf(papaya::Component)")
                 .build();
         return new SelectionDialogDescriptionBuilder()
@@ -203,7 +203,7 @@ public class SelectionDescriptionProvider implements IEditingContextProcessor {
     private SelectionDialogDescription createEdgeSelectionDialog() {
         var edgeSelectionDialogTreeDescription = new SelectionDialogTreeDescriptionBuilder()
                 .elementsExpression("aql:self.eResource()")
-                .childrenExpression("aql:if self.oclIsKindOf(papaya::NamedElement) then self.eContents() else self.getContents() endif  ")
+                .childrenExpression("aql:if self.oclIsKindOf(papaya::NamedElement) then self.eContents() else self.getContents() endif")
                 .isSelectableExpression("aql:self.oclIsKindOf(papaya::Component)")
                 .build();
         return new SelectionDialogDescriptionBuilder()

--- a/packages/sirius-web/backend/sirius-web/src/test/java/org/eclipse/sirius/web/services/tables/ViewTableDescriptionProvider.java
+++ b/packages/sirius-web/backend/sirius-web/src/test/java/org/eclipse/sirius/web/services/tables/ViewTableDescriptionProvider.java
@@ -112,8 +112,7 @@ public class ViewTableDescriptionProvider implements IEditingContextProcessor {
                 .headerIndexLabelExpression("aql:rowIndex")
                 .headerLabelExpression("aql:self.name")
                 .contextMenuEntries(contextMenuEntry)
-                .depthLevelExpression(
-                        "aql:if self.oclIsKindOf(papaya::Type) then 0 else if self.oclIsKindOf(papaya::Operation) then 1 else if self.oclIsKindOf(papaya::Parameter) then 2 else endif endif endif")
+                .depthLevelExpression("aql:if self.oclIsKindOf(papaya::Type) then 0 else if self.oclIsKindOf(papaya::Operation) then 1 else if self.oclIsKindOf(papaya::Parameter) then 2 else 0 endif endif endif")
                 .build();
 
         var setNameOperation = new ViewBuilders().newSetValue()


### PR DESCRIPTION
Found looking at the build logs:

```
% grep 'An error has occurred with the expression' 0_Build.txt | \
  sed -e 's/^.*An error/An error/' | \
  sort | \
  uniq -c | \
  sort -rn
```

```
    105 An error has occurred with the expression 'aql:if self.oclIsKindOf(papaya::NamedElement) then self.eContents() else self.getContents() endif  ': text remaining after expression "  ".
     85 An error has occurred with the expression 'aql:if self.oclIsKindOf(papaya::Type) then 0 else if self.oclIsKindOf(papaya::Operation) then 1 else if self.oclIsKindOf(papaya::Parameter) then 2 else endif endif endif': missing expression
     85 An error has occurred with the expression 'aql:if self.oclIsKindOf(papaya::Type) then 0 else if self.oclIsKindOf(papaya::Operation) then 1 else if self.oclIsKindOf(papaya::Parameter) then 2 else endif endif endif': incomplet conditional
     33 An error has occurred with the expression 'aql:self.eContents()}': text remaining after expression "}".
     12 An error has occurred with the expression 'aql:self.name)': text remaining after expression ")".
      2 An error has occurred with the expression 'aql:newLabel)': text remaining after expression ")".
      1 An error has occurred with the expression 'aql:self.eAllContents()->size': missing collection service call
```
