### PR TITLE
[3205] Fix invalid project name in rename dialog after a first rename

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -76,6 +76,7 @@ Note that the impact analysis dialog may contain error messages _and_ partial im
 - https://github.com/eclipse-sirius/sirius-web/issues/5918[#5918] [tree] Fix tree representations flickering when expanding/collapsing an item
 - https://github.com/eclipse-sirius/sirius-web/issues/5834[#5834] [diagram] Fix hidden edge handles when selected from the global selection
 - https://github.com/eclipse-sirius/sirius-web/issues/5949[#5949] [validation] Fix too many recursions on the validation view when models with too many errors are in the project.
+- https://github.com/eclipse-sirius/sirius-web/issues/3205[#3205] [sirius-web] Fix an issue where the project rename dialog displayed an outdated name as the current value
 
 
 === New Features

--- a/packages/sirius-web/frontend/sirius-web-application/src/modals/rename-project/RenameProjectModal.tsx
+++ b/packages/sirius-web/frontend/sirius-web-application/src/modals/rename-project/RenameProjectModal.tsx
@@ -21,11 +21,11 @@ import { useTranslation } from 'react-i18next';
 import { RenameProjectModalProps, RenameProjectModalState } from './RenameProjectModal.types';
 import { useRenameProject } from './useRenameProject';
 
-export const RenameProjectModal = ({ project, onCancel, onSuccess }: RenameProjectModalProps) => {
+export const RenameProjectModal = ({ projectId, projectName, onCancel, onSuccess }: RenameProjectModalProps) => {
   const { t } = useTranslation('sirius-web-application', { keyPrefix: 'renameProjectModal' });
 
   const [state, setState] = useState<RenameProjectModalState>({
-    newName: project.name,
+    newName: projectName,
     pristine: true,
   });
 
@@ -38,7 +38,7 @@ export const RenameProjectModal = ({ project, onCancel, onSuccess }: RenameProje
 
   const onRenameProject = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
     event.preventDefault();
-    renameProject(project.id, state.newName);
+    renameProject(projectId, state.newName);
   };
 
   useEffect(() => {

--- a/packages/sirius-web/frontend/sirius-web-application/src/modals/rename-project/RenameProjectModal.types.ts
+++ b/packages/sirius-web/frontend/sirius-web-application/src/modals/rename-project/RenameProjectModal.types.ts
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2024 Obeo.
+ * Copyright (c) 2021, 2025 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -12,7 +12,8 @@
  *******************************************************************************/
 
 export interface RenameProjectModalProps {
-  project: Project;
+  projectId: string;
+  projectName: string;
   onSuccess: () => void;
   onCancel: () => void;
 }

--- a/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/navbar/EditProjectNavbar.tsx
+++ b/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/navbar/EditProjectNavbar.tsx
@@ -119,6 +119,7 @@ export const EditProjectNavbar = ({ workbenchHandle }: EditProjectNavbarProps) =
       {state.anchorEl ? (
         <EditProjectNavbarContextMenu
           anchorEl={state.anchorEl}
+          projectName={state.projectName}
           onClose={onCloseContextMenu}
           workbenchHandle={workbenchHandle}
         />

--- a/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/navbar/context-menu/EditProjectNavbarContextMenu.tsx
+++ b/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/navbar/context-menu/EditProjectNavbarContextMenu.tsx
@@ -34,6 +34,7 @@ import { ShareProjectMenuItem } from './ShareProjectMenuItem';
 
 export const EditProjectNavbarContextMenu = ({
   anchorEl,
+  projectName,
   onClose,
   workbenchHandle,
 }: EditProjectNavbarContextMenuProps) => {
@@ -58,7 +59,12 @@ export const EditProjectNavbarContextMenu = ({
     <ContextMenuContainer>
       <Menu open anchorEl={anchorEl} data-testid="navbar-contextmenu" onClose={onClose}>
         {project.capabilities.canRename ? (
-          <RenameProjectMenuItem project={project} onCancel={onClose} onSuccess={onClose} />
+          <RenameProjectMenuItem
+            projectId={project.id}
+            projectName={projectName}
+            onCancel={onClose}
+            onSuccess={onClose}
+          />
         ) : null}
         <ShareProjectMenuItem workbenchHandle={workbenchHandle} />
         {project.capabilities.canDuplicate ? (

--- a/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/navbar/context-menu/EditProjectNavbarContextMenu.types.ts
+++ b/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/navbar/context-menu/EditProjectNavbarContextMenu.types.ts
@@ -15,6 +15,7 @@ import { WorkbenchHandle } from '@eclipse-sirius/sirius-components-core';
 
 export interface EditProjectNavbarContextMenuProps {
   anchorEl: HTMLElement;
+  projectName: string;
   onClose: () => void;
   workbenchHandle: WorkbenchHandle;
 }

--- a/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/navbar/context-menu/RenameProjectMenuItem.tsx
+++ b/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/navbar/context-menu/RenameProjectMenuItem.tsx
@@ -20,7 +20,7 @@ import { useTranslation } from 'react-i18next';
 import { RenameProjectModal } from '../../../../modals/rename-project/RenameProjectModal';
 import { RenameProjectMenuItemProps, RenameProjectMenuItemState } from './RenameProjectMenuItem.types';
 
-export const RenameProjectMenuItem = ({ project, onCancel, onSuccess }: RenameProjectMenuItemProps) => {
+export const RenameProjectMenuItem = ({ projectId, projectName, onCancel, onSuccess }: RenameProjectMenuItemProps) => {
   const [state, setState] = useState<RenameProjectMenuItemState>({
     showModal: false,
   });
@@ -44,7 +44,12 @@ export const RenameProjectMenuItem = ({ project, onCancel, onSuccess }: RenamePr
         <ListItemText primary={t('rename')} />
       </MenuItem>
       {state.showModal ? (
-        <RenameProjectModal project={project} onCancel={handleCancel} onSuccess={handleSuccess} />
+        <RenameProjectModal
+          projectId={projectId}
+          projectName={projectName}
+          onCancel={handleCancel}
+          onSuccess={handleSuccess}
+        />
       ) : null}
     </>
   );

--- a/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/navbar/context-menu/RenameProjectMenuItem.types.ts
+++ b/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/navbar/context-menu/RenameProjectMenuItem.types.ts
@@ -12,7 +12,8 @@
  *******************************************************************************/
 
 export interface RenameProjectMenuItemProps {
-  project: Project;
+  projectId: string;
+  projectName: string;
   onSuccess: () => void;
   onCancel: () => void;
 }

--- a/packages/sirius-web/frontend/sirius-web-application/src/views/project-browser/list-projects-area/ProjectActionButton.tsx
+++ b/packages/sirius-web/frontend/sirius-web-application/src/views/project-browser/list-projects-area/ProjectActionButton.tsx
@@ -86,7 +86,12 @@ const ProjectContextMenu = ({ menuAnchor, project, onChange, onClose }: ProjectC
         open={true}
         onClose={onClose}>
         {project.capabilities.canRename ? (
-          <RenameProjectMenuItem project={project} onCancel={onClose} onSuccess={onChange} />
+          <RenameProjectMenuItem
+            projectId={project.id}
+            projectName={project.name}
+            onCancel={onClose}
+            onSuccess={onChange}
+          />
         ) : null}
         {project.capabilities.canDuplicate ? (
           <DuplicateProjectMenuItem projectId={project.id} onClick={onClose} />


### PR DESCRIPTION
I hesitated between multiple approaches, not sure this is the best one.

Other options:

* update the ProjectContext itself on rename, but this means a full rerender;
* add a new custom context specific to the EditProjectNavbar, but this feels overkill for this use case;
* reuse but override the enclosing ProjectContext.Provider with one local to the EditProjectNavbar;

I finally settled on drilling down just the required projectName (& projectId) props from EditProjectNavbar who has the updated value to the menu item(s).

Bug: https://github.com/eclipse-sirius/sirius-web/issues/3205
Signed-off-by: Pierre-Charles David <pierre-charles.david@obeo.fr>

# Pull request template

## General purpose
What is the main goal of this pull request?
- [x] Bug fixes
- [ ] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [ ] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [ ] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?