### PR TITLE
[5953] Provide AdapterFactory Descriptors instead of AdapterFactories

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -62,7 +62,22 @@ They have been replaced by proper transactional event listeners and new events s
 Those events did not exist in the past and it was impossible for someone to listen for the removal of some `ProjectSemanticData` or some `SemanticData`.
 Downstream projects which made some hypothesis on the impact of the deletion of a project will now be able to remove those hypothesis and listen to regular events.
 - https://github.com/eclipse-sirius/sirius-web/issues/5522[#5522] [core] `OmniboxCommandOverrideContribution` and `OmniboxCommandComponentProps` now use `OmniboxCommand` instead of `GQLOmniboxCommand` type.
-
+- https://github.com/eclipse-sirius/sirius-web/issues/5953[#5953] [emf] Provide `AdapterFactory Descriptors` instead of `AdapterFactories`.
+Downstream projects contributing custom `AdapterFactory` @Bean must now contribute `AdapterFactory.Descriptor` @Bean instead.
+For example, the Papaya AdapterFactory is now contributed like this:
+```
+@Bean
+public ComposedAdapterFactory.Descriptor papayaAdapterFactoryDescriptor() {
+    return PapayaItemProviderAdapterFactory::new;
+}
+````
+instead of the previous way:
+```
+@Bean
+public AdapterFactory papayaAdapterFactory() {
+    return new PapayaItemProviderAdapterFactory();
+}
+````
 
 === Dependency update
 

--- a/packages/emf/backend/sirius-components-emf-forms/src/main/java/org/eclipse/sirius/components/emf/forms/EBooleanIfDescriptionProvider.java
+++ b/packages/emf/backend/sirius-components-emf-forms/src/main/java/org/eclipse/sirius/components/emf/forms/EBooleanIfDescriptionProvider.java
@@ -20,7 +20,6 @@ import java.util.function.Function;
 import org.eclipse.emf.ecore.EAttribute;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EcorePackage;
-import org.eclipse.emf.edit.provider.ComposedAdapterFactory;
 import org.eclipse.sirius.components.core.api.IIdentityService;
 import org.eclipse.sirius.components.emf.forms.api.IEMFFormIfDescriptionProvider;
 import org.eclipse.sirius.components.emf.forms.api.IPropertiesValidationProvider;
@@ -48,15 +47,12 @@ public class EBooleanIfDescriptionProvider implements IEMFFormIfDescriptionProvi
 
     private final IIdentityService identityService;
 
-    private final ComposedAdapterFactory composedAdapterFactory;
-
     private final IPropertiesValidationProvider propertiesValidationProvider;
 
     private final IWidgetReadOnlyProvider widgetReadOnlyProvider;
 
-    public EBooleanIfDescriptionProvider(IIdentityService identityService, ComposedAdapterFactory composedAdapterFactory, IPropertiesValidationProvider propertiesValidationProvider, IWidgetReadOnlyProvider widgetReadOnlyProvider) {
+    public EBooleanIfDescriptionProvider(IIdentityService identityService, IPropertiesValidationProvider propertiesValidationProvider, IWidgetReadOnlyProvider widgetReadOnlyProvider) {
         this.identityService = Objects.requireNonNull(identityService);
-        this.composedAdapterFactory = Objects.requireNonNull(composedAdapterFactory);
         this.propertiesValidationProvider = Objects.requireNonNull(propertiesValidationProvider);
         this.widgetReadOnlyProvider = Objects.requireNonNull(widgetReadOnlyProvider);
     }
@@ -102,7 +98,7 @@ public class EBooleanIfDescriptionProvider implements IEMFFormIfDescriptionProvi
     }
 
     private Function<VariableManager, String> getLabelProvider() {
-        return new EStructuralFeatureLabelProvider(EMFFormDescriptionProvider.ESTRUCTURAL_FEATURE, this.composedAdapterFactory);
+        return new EStructuralFeatureLabelProvider(EMFFormDescriptionProvider.ESTRUCTURAL_FEATURE);
     }
 
     private Function<VariableManager, Boolean> getValueProvider() {

--- a/packages/emf/backend/sirius-components-emf-forms/src/main/java/org/eclipse/sirius/components/emf/forms/EEnumIfDescriptionProvider.java
+++ b/packages/emf/backend/sirius-components-emf-forms/src/main/java/org/eclipse/sirius/components/emf/forms/EEnumIfDescriptionProvider.java
@@ -27,7 +27,6 @@ import org.eclipse.emf.ecore.EEnumLiteral;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecore.util.EcoreUtil;
-import org.eclipse.emf.edit.provider.ComposedAdapterFactory;
 import org.eclipse.sirius.components.core.api.IIdentityService;
 import org.eclipse.sirius.components.emf.forms.api.IEMFFormIfDescriptionProvider;
 import org.eclipse.sirius.components.emf.forms.api.IPropertiesValidationProvider;
@@ -60,15 +59,12 @@ public class EEnumIfDescriptionProvider implements IEMFFormIfDescriptionProvider
 
     private final IIdentityService identityService;
 
-    private final ComposedAdapterFactory composedAdapterFactory;
-
     private final IPropertiesValidationProvider propertiesValidationProvider;
 
     private final IWidgetReadOnlyProvider widgetReadOnlyProvider;
 
-    public EEnumIfDescriptionProvider(IIdentityService identityService, ComposedAdapterFactory composedAdapterFactory, IPropertiesValidationProvider propertiesValidationProvider, IWidgetReadOnlyProvider widgetReadOnlyProvider) {
+    public EEnumIfDescriptionProvider(IIdentityService identityService, IPropertiesValidationProvider propertiesValidationProvider, IWidgetReadOnlyProvider widgetReadOnlyProvider) {
         this.identityService = Objects.requireNonNull(identityService);
-        this.composedAdapterFactory = Objects.requireNonNull(composedAdapterFactory);
         this.propertiesValidationProvider = Objects.requireNonNull(propertiesValidationProvider);
         this.widgetReadOnlyProvider = Objects.requireNonNull(widgetReadOnlyProvider);
     }
@@ -117,7 +113,7 @@ public class EEnumIfDescriptionProvider implements IEMFFormIfDescriptionProvider
     }
 
     private Function<VariableManager, String> getLabelProvider() {
-        return new EStructuralFeatureLabelProvider(EMFFormDescriptionProvider.ESTRUCTURAL_FEATURE, this.composedAdapterFactory);
+        return new EStructuralFeatureLabelProvider(EMFFormDescriptionProvider.ESTRUCTURAL_FEATURE);
     }
 
     private Function<VariableManager, List<?>> getOptionsProvider() {
@@ -146,7 +142,7 @@ public class EEnumIfDescriptionProvider implements IEMFFormIfDescriptionProvider
     }
 
     private Function<VariableManager, String> getOptionLabelProvider() {
-        return new EEnumLiteralLabelProvider(EMFFormDescriptionProvider.ESTRUCTURAL_FEATURE, this.composedAdapterFactory);
+        return new EEnumLiteralLabelProvider(EMFFormDescriptionProvider.ESTRUCTURAL_FEATURE);
     }
 
     private Function<VariableManager, Boolean> getOptionSelectedProvider() {

--- a/packages/emf/backend/sirius-components-emf-forms/src/main/java/org/eclipse/sirius/components/emf/forms/EStringIfDescriptionProvider.java
+++ b/packages/emf/backend/sirius-components-emf-forms/src/main/java/org/eclipse/sirius/components/emf/forms/EStringIfDescriptionProvider.java
@@ -22,7 +22,6 @@ import org.eclipse.emf.ecore.EClassifier;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EcorePackage;
 import org.eclipse.emf.ecore.util.EcoreUtil;
-import org.eclipse.emf.edit.provider.ComposedAdapterFactory;
 import org.eclipse.sirius.components.core.api.IIdentityService;
 import org.eclipse.sirius.components.emf.forms.api.IEMFFormIfDescriptionProvider;
 import org.eclipse.sirius.components.emf.forms.api.IPropertiesValidationProvider;
@@ -50,15 +49,12 @@ public class EStringIfDescriptionProvider implements IEMFFormIfDescriptionProvid
 
     private final IIdentityService identityService;
 
-    private final ComposedAdapterFactory composedAdapterFactory;
-
     private final IPropertiesValidationProvider propertiesValidationProvider;
 
     private final IWidgetReadOnlyProvider widgetReadOnlyProvider;
 
-    public EStringIfDescriptionProvider(IIdentityService identityService, ComposedAdapterFactory composedAdapterFactory, IPropertiesValidationProvider propertiesValidationProvider, IWidgetReadOnlyProvider widgetReadOnlyProvider) {
+    public EStringIfDescriptionProvider(IIdentityService identityService, IPropertiesValidationProvider propertiesValidationProvider, IWidgetReadOnlyProvider widgetReadOnlyProvider) {
         this.identityService = Objects.requireNonNull(identityService);
-        this.composedAdapterFactory = Objects.requireNonNull(composedAdapterFactory);
         this.propertiesValidationProvider = Objects.requireNonNull(propertiesValidationProvider);
         this.widgetReadOnlyProvider = Objects.requireNonNull(widgetReadOnlyProvider);
     }
@@ -105,7 +101,7 @@ public class EStringIfDescriptionProvider implements IEMFFormIfDescriptionProvid
     }
 
     private Function<VariableManager, String> getLabelProvider() {
-        return new EStructuralFeatureLabelProvider(EMFFormDescriptionProvider.ESTRUCTURAL_FEATURE, this.composedAdapterFactory);
+        return new EStructuralFeatureLabelProvider(EMFFormDescriptionProvider.ESTRUCTURAL_FEATURE);
     }
 
     private Function<VariableManager, String> getValueProvider() {

--- a/packages/emf/backend/sirius-components-emf-forms/src/main/java/org/eclipse/sirius/components/emf/forms/EStructuralFeatureLabelProvider.java
+++ b/packages/emf/backend/sirius-components-emf-forms/src/main/java/org/eclipse/sirius/components/emf/forms/EStructuralFeatureLabelProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2024 Obeo.
+ * Copyright (c) 2019, 2025 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -16,11 +16,13 @@ import java.util.Objects;
 import java.util.function.Function;
 
 import org.eclipse.emf.common.notify.Adapter;
-import org.eclipse.emf.common.notify.AdapterFactory;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EStructuralFeature;
+import org.eclipse.emf.edit.domain.AdapterFactoryEditingDomain;
 import org.eclipse.emf.edit.provider.IItemPropertyDescriptor;
 import org.eclipse.emf.edit.provider.IItemPropertySource;
+import org.eclipse.sirius.components.core.api.IEditingContext;
+import org.eclipse.sirius.components.emf.services.api.IEMFEditingContext;
 import org.eclipse.sirius.components.representations.VariableManager;
 
 /**
@@ -32,20 +34,20 @@ public class EStructuralFeatureLabelProvider implements Function<VariableManager
 
     private final String featureVariableName;
 
-    private final AdapterFactory adapterFactory;
-
-    public EStructuralFeatureLabelProvider(String featureVariableName, AdapterFactory adapterFactory) {
+    public EStructuralFeatureLabelProvider(String featureVariableName) {
         this.featureVariableName = Objects.requireNonNull(featureVariableName);
-        this.adapterFactory = Objects.requireNonNull(adapterFactory);
     }
 
     @Override
     public String apply(VariableManager variableManager) {
-        Object object = variableManager.getVariables().get(VariableManager.SELF);
-        Object feature = variableManager.getVariables().get(this.featureVariableName);
+        var object = variableManager.getVariables().get(VariableManager.SELF);
+        var feature = variableManager.getVariables().get(this.featureVariableName);
+        var optionalAdapterFactory = variableManager.get(IEditingContext.EDITING_CONTEXT, IEMFEditingContext.class)
+                .map(IEMFEditingContext::getDomain)
+                .map(AdapterFactoryEditingDomain::getAdapterFactory);
 
-        if (object instanceof EObject eObject && feature instanceof EStructuralFeature eStructuralFeature) {
-            Adapter adapter = this.adapterFactory.adapt(eObject, IItemPropertySource.class);
+        if (object instanceof EObject eObject && feature instanceof EStructuralFeature eStructuralFeature && optionalAdapterFactory.isPresent()) {
+            Adapter adapter = optionalAdapterFactory.get().adapt(eObject, IItemPropertySource.class);
 
             if (adapter instanceof IItemPropertySource itemPropertySource) {
                 IItemPropertyDescriptor descriptor = itemPropertySource.getPropertyDescriptor(eObject, eStructuralFeature);

--- a/packages/emf/backend/sirius-components-emf-forms/src/main/java/org/eclipse/sirius/components/emf/forms/InstantIfDescriptionProvider.java
+++ b/packages/emf/backend/sirius-components-emf-forms/src/main/java/org/eclipse/sirius/components/emf/forms/InstantIfDescriptionProvider.java
@@ -22,7 +22,6 @@ import java.util.function.Function;
 import org.eclipse.emf.ecore.EAttribute;
 import org.eclipse.emf.ecore.EClassifier;
 import org.eclipse.emf.ecore.EObject;
-import org.eclipse.emf.edit.provider.ComposedAdapterFactory;
 import org.eclipse.sirius.components.core.api.IIdentityService;
 import org.eclipse.sirius.components.emf.forms.api.IEMFFormIfDescriptionProvider;
 import org.eclipse.sirius.components.emf.forms.api.IPropertiesValidationProvider;
@@ -51,15 +50,12 @@ public class InstantIfDescriptionProvider implements IEMFFormIfDescriptionProvid
 
     private final IIdentityService identityService;
 
-    private final ComposedAdapterFactory composedAdapterFactory;
-
     private final IPropertiesValidationProvider propertiesValidationProvider;
 
     private final IWidgetReadOnlyProvider widgetReadOnlyProvider;
 
-    public InstantIfDescriptionProvider(IIdentityService identityService, ComposedAdapterFactory composedAdapterFactory, IPropertiesValidationProvider propertiesValidationProvider, IWidgetReadOnlyProvider widgetReadOnlyProvider) {
+    public InstantIfDescriptionProvider(IIdentityService identityService, IPropertiesValidationProvider propertiesValidationProvider, IWidgetReadOnlyProvider widgetReadOnlyProvider) {
         this.identityService = Objects.requireNonNull(identityService);
-        this.composedAdapterFactory = Objects.requireNonNull(composedAdapterFactory);
         this.propertiesValidationProvider = Objects.requireNonNull(propertiesValidationProvider);
         this.widgetReadOnlyProvider = Objects.requireNonNull(widgetReadOnlyProvider);
     }
@@ -107,7 +103,7 @@ public class InstantIfDescriptionProvider implements IEMFFormIfDescriptionProvid
     }
 
     private Function<VariableManager, String> getLabelProvider() {
-        return new EStructuralFeatureLabelProvider(EMFFormDescriptionProvider.ESTRUCTURAL_FEATURE, this.composedAdapterFactory);
+        return new EStructuralFeatureLabelProvider(EMFFormDescriptionProvider.ESTRUCTURAL_FEATURE);
     }
 
     private Function<VariableManager, String> getValueProvider() {

--- a/packages/emf/backend/sirius-components-emf-forms/src/main/java/org/eclipse/sirius/components/emf/forms/LocalDateIfDescriptionProvider.java
+++ b/packages/emf/backend/sirius-components-emf-forms/src/main/java/org/eclipse/sirius/components/emf/forms/LocalDateIfDescriptionProvider.java
@@ -22,7 +22,6 @@ import java.util.function.Function;
 import org.eclipse.emf.ecore.EAttribute;
 import org.eclipse.emf.ecore.EClassifier;
 import org.eclipse.emf.ecore.EObject;
-import org.eclipse.emf.edit.provider.ComposedAdapterFactory;
 import org.eclipse.sirius.components.core.api.IIdentityService;
 import org.eclipse.sirius.components.emf.forms.api.IEMFFormIfDescriptionProvider;
 import org.eclipse.sirius.components.emf.forms.api.IPropertiesValidationProvider;
@@ -51,19 +50,17 @@ public class LocalDateIfDescriptionProvider implements IEMFFormIfDescriptionProv
 
     private final IIdentityService identityService;
 
-    private final ComposedAdapterFactory composedAdapterFactory;
-
     private final IPropertiesValidationProvider propertiesValidationProvider;
 
     private final IWidgetReadOnlyProvider widgetReadOnlyProvider;
 
-    public LocalDateIfDescriptionProvider(IIdentityService identityService, ComposedAdapterFactory composedAdapterFactory, IPropertiesValidationProvider propertiesValidationProvider, IWidgetReadOnlyProvider widgetReadOnlyProvider) {
+    public LocalDateIfDescriptionProvider(IIdentityService identityService, IPropertiesValidationProvider propertiesValidationProvider, IWidgetReadOnlyProvider widgetReadOnlyProvider) {
         this.identityService = Objects.requireNonNull(identityService);
-        this.composedAdapterFactory = Objects.requireNonNull(composedAdapterFactory);
         this.propertiesValidationProvider = Objects.requireNonNull(propertiesValidationProvider);
         this.widgetReadOnlyProvider = Objects.requireNonNull(widgetReadOnlyProvider);
     }
 
+    @Override
     public List<IfDescription> getIfDescriptions() {
         Function<VariableManager, String> targetObjectIdProvider = variableManager -> variableManager.get(VariableManager.SELF, Object.class)
                 .map(this.identityService::getId)
@@ -106,7 +103,7 @@ public class LocalDateIfDescriptionProvider implements IEMFFormIfDescriptionProv
     }
 
     private Function<VariableManager, String> getLabelProvider() {
-        return new EStructuralFeatureLabelProvider(EMFFormDescriptionProvider.ESTRUCTURAL_FEATURE, this.composedAdapterFactory);
+        return new EStructuralFeatureLabelProvider(EMFFormDescriptionProvider.ESTRUCTURAL_FEATURE);
     }
 
     private Function<VariableManager, String> getValueProvider() {

--- a/packages/emf/backend/sirius-components-emf-forms/src/main/java/org/eclipse/sirius/components/emf/forms/NonContainmentReferenceIfDescriptionProvider.java
+++ b/packages/emf/backend/sirius-components-emf-forms/src/main/java/org/eclipse/sirius/components/emf/forms/NonContainmentReferenceIfDescriptionProvider.java
@@ -24,7 +24,6 @@ import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EReference;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecore.InternalEObject;
-import org.eclipse.emf.edit.provider.ComposedAdapterFactory;
 import org.eclipse.sirius.components.collaborative.api.ChangeKind;
 import org.eclipse.sirius.components.core.api.IFeedbackMessageService;
 import org.eclipse.sirius.components.core.api.IIdentityService;
@@ -57,8 +56,6 @@ public class NonContainmentReferenceIfDescriptionProvider implements IEMFFormIfD
 
     private static final String REFERENCE_WIDGET_DESCRIPTION_ID = "NonContainmentReferenceIfDescriptionProvider.ReferenceWidget";
 
-    private final ComposedAdapterFactory composedAdapterFactory;
-
     private final IIdentityService identityService;
 
     private final ILabelService labelService;
@@ -71,9 +68,8 @@ public class NonContainmentReferenceIfDescriptionProvider implements IEMFFormIfD
 
     private final IWidgetReadOnlyProvider widgetReadOnlyProvider;
 
-    public NonContainmentReferenceIfDescriptionProvider(ComposedAdapterFactory composedAdapterFactory, IIdentityService identityService, ILabelService labelService, IEMFKindService emfKindService,
+    public NonContainmentReferenceIfDescriptionProvider(IIdentityService identityService, ILabelService labelService, IEMFKindService emfKindService,
                                                         IFeedbackMessageService feedbackMessageService, IPropertiesValidationProvider propertiesValidationProvider, IWidgetReadOnlyProvider widgetReadOnlyProvider) {
-        this.composedAdapterFactory = Objects.requireNonNull(composedAdapterFactory);
         this.identityService = Objects.requireNonNull(identityService);
         this.labelService = Objects.requireNonNull(labelService);
         this.propertiesValidationProvider = Objects.requireNonNull(propertiesValidationProvider);
@@ -153,7 +149,7 @@ public class NonContainmentReferenceIfDescriptionProvider implements IEMFFormIfD
     }
 
     private Function<VariableManager, List<?>> getOptionsProvider() {
-        return new EStructuralFeatureChoiceOfValueProvider(EMFFormDescriptionProvider.ESTRUCTURAL_FEATURE, this.composedAdapterFactory);
+        return new EStructuralFeatureChoiceOfValueProvider(EMFFormDescriptionProvider.ESTRUCTURAL_FEATURE);
     }
 
     private EStructuralFeature.Setting resolveSetting(VariableManager variableManager) {
@@ -192,7 +188,7 @@ public class NonContainmentReferenceIfDescriptionProvider implements IEMFFormIfD
     }
 
     private Function<VariableManager, String> getLabelProvider() {
-        return new EStructuralFeatureLabelProvider(EMFFormDescriptionProvider.ESTRUCTURAL_FEATURE, this.composedAdapterFactory);
+        return new EStructuralFeatureLabelProvider(EMFFormDescriptionProvider.ESTRUCTURAL_FEATURE);
     }
 
     private String getTypeName(VariableManager variableManager) {

--- a/packages/emf/backend/sirius-components-emf-forms/src/main/java/org/eclipse/sirius/components/emf/forms/NumberDataTypeDescriptionProvider.java
+++ b/packages/emf/backend/sirius-components-emf-forms/src/main/java/org/eclipse/sirius/components/emf/forms/NumberDataTypeDescriptionProvider.java
@@ -17,14 +17,13 @@ import java.util.Objects;
 import java.util.function.Function;
 
 import org.eclipse.emf.ecore.EcorePackage;
-import org.eclipse.emf.edit.provider.ComposedAdapterFactory;
 import org.eclipse.sirius.components.core.api.IIdentityService;
+import org.eclipse.sirius.components.emf.forms.api.IEMFFormIfDescriptionProvider;
 import org.eclipse.sirius.components.emf.forms.api.IPropertiesValidationProvider;
 import org.eclipse.sirius.components.emf.forms.api.IWidgetReadOnlyProvider;
 import org.eclipse.sirius.components.emf.services.messages.IEMFMessageService;
 import org.eclipse.sirius.components.forms.description.IfDescription;
 import org.eclipse.sirius.components.representations.VariableManager;
-import org.eclipse.sirius.components.emf.forms.api.IEMFFormIfDescriptionProvider;
 import org.springframework.stereotype.Service;
 
 /**
@@ -37,17 +36,14 @@ public class NumberDataTypeDescriptionProvider implements IEMFFormIfDescriptionP
 
     private final IIdentityService identityService;
 
-    private final ComposedAdapterFactory composedAdapterFactory;
-
     private final IPropertiesValidationProvider propertiesValidationProvider;
 
     private final IEMFMessageService emfMessageService;
 
     private final IWidgetReadOnlyProvider widgetReadOnlyProvider;
 
-    public NumberDataTypeDescriptionProvider(IIdentityService identityService, ComposedAdapterFactory composedAdapterFactory, IPropertiesValidationProvider propertiesValidationProvider, IEMFMessageService emfMessageService, IWidgetReadOnlyProvider widgetReadOnlyProvider) {
+    public NumberDataTypeDescriptionProvider(IIdentityService identityService, IPropertiesValidationProvider propertiesValidationProvider, IEMFMessageService emfMessageService, IWidgetReadOnlyProvider widgetReadOnlyProvider) {
         this.identityService = Objects.requireNonNull(identityService);
-        this.composedAdapterFactory = Objects.requireNonNull(composedAdapterFactory);
         this.propertiesValidationProvider = Objects.requireNonNull(propertiesValidationProvider);
         this.emfMessageService = Objects.requireNonNull(emfMessageService);
         this.widgetReadOnlyProvider = Objects.requireNonNull(widgetReadOnlyProvider);
@@ -74,7 +70,7 @@ public class NumberDataTypeDescriptionProvider implements IEMFFormIfDescriptionP
                 EcorePackage.Literals.EBIG_DECIMAL
         );
         return dataTypes.stream()
-                .map(dataType -> new NumberIfDescriptionProvider(dataType, this.composedAdapterFactory, this.propertiesValidationProvider, this.emfMessageService, semanticTargetIdProvider, this.widgetReadOnlyProvider).getIfDescription())
+                .map(dataType -> new NumberIfDescriptionProvider(dataType, this.propertiesValidationProvider, this.emfMessageService, semanticTargetIdProvider, this.widgetReadOnlyProvider).getIfDescription())
                 .toList();
     }
 }

--- a/packages/emf/backend/sirius-components-emf-forms/src/main/java/org/eclipse/sirius/components/emf/forms/NumberIfDescriptionProvider.java
+++ b/packages/emf/backend/sirius-components-emf-forms/src/main/java/org/eclipse/sirius/components/emf/forms/NumberIfDescriptionProvider.java
@@ -22,7 +22,6 @@ import org.eclipse.emf.ecore.EAttribute;
 import org.eclipse.emf.ecore.EDataType;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.util.EcoreUtil;
-import org.eclipse.emf.edit.provider.ComposedAdapterFactory;
 import org.eclipse.sirius.components.emf.forms.api.IPropertiesValidationProvider;
 import org.eclipse.sirius.components.emf.forms.api.IWidgetReadOnlyProvider;
 import org.eclipse.sirius.components.emf.services.messages.IEMFMessageService;
@@ -44,8 +43,6 @@ public class NumberIfDescriptionProvider {
 
     private final EDataType eDataType;
 
-    private final ComposedAdapterFactory composedAdapterFactory;
-
     private final IPropertiesValidationProvider propertiesValidationProvider;
 
     private final IEMFMessageService emfMessageService;
@@ -54,10 +51,9 @@ public class NumberIfDescriptionProvider {
 
     private final IWidgetReadOnlyProvider widgetReadOnlyProvider;
 
-    public NumberIfDescriptionProvider(EDataType eDataType, ComposedAdapterFactory composedAdapterFactory, IPropertiesValidationProvider propertiesValidationProvider,
+    public NumberIfDescriptionProvider(EDataType eDataType, IPropertiesValidationProvider propertiesValidationProvider,
                                        IEMFMessageService emfMessageService, Function<VariableManager, String> semanticTargetIdProvider, IWidgetReadOnlyProvider widgetReadOnlyProvider) {
         this.eDataType = Objects.requireNonNull(eDataType);
-        this.composedAdapterFactory = Objects.requireNonNull(composedAdapterFactory);
         this.propertiesValidationProvider = Objects.requireNonNull(propertiesValidationProvider);
         this.emfMessageService = Objects.requireNonNull(emfMessageService);
         this.semanticTargetIdProvider = Objects.requireNonNull(semanticTargetIdProvider);
@@ -108,7 +104,7 @@ public class NumberIfDescriptionProvider {
     }
 
     private Function<VariableManager, String> getLabelProvider() {
-        return new EStructuralFeatureLabelProvider(EMFFormDescriptionProvider.ESTRUCTURAL_FEATURE, this.composedAdapterFactory);
+        return new EStructuralFeatureLabelProvider(EMFFormDescriptionProvider.ESTRUCTURAL_FEATURE);
     }
 
     private Function<VariableManager, String> getValueProvider() {

--- a/packages/emf/backend/sirius-components-emf/src/main/java/org/eclipse/sirius/components/emf/configuration/EMFConfiguration.java
+++ b/packages/emf/backend/sirius-components-emf/src/main/java/org/eclipse/sirius/components/emf/configuration/EMFConfiguration.java
@@ -17,7 +17,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 
-import org.eclipse.emf.common.notify.AdapterFactory;
 import org.eclipse.emf.ecore.EPackage;
 import org.eclipse.emf.ecore.EValidator;
 import org.eclipse.emf.ecore.impl.EPackageRegistryImpl;
@@ -62,11 +61,13 @@ public class EMFConfiguration {
     }
 
     @Bean
-    public ComposedAdapterFactory composedAdapterFactory(List<AdapterFactory> adapterFactories) {
-        ComposedAdapterFactory composedAdapterFactory = new ComposedAdapterFactory(adapterFactories);
-        composedAdapterFactory.addAdapterFactory(new EcoreAdapterFactory());
-        composedAdapterFactory.addAdapterFactory(new ReflectiveItemProviderAdapterFactory());
-        return composedAdapterFactory;
+    public ComposedAdapterFactory.Descriptor ecoreAdapterFactoryDescriptor() {
+        return EcoreAdapterFactory::new;
+    }
+
+    @Bean
+    public ComposedAdapterFactory.Descriptor reflectiveItemProviderAdapterFactoryDescriptor() {
+        return ReflectiveItemProviderAdapterFactory::new;
     }
 
     @Bean

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/editingcontext/EditingContext.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/editingcontext/EditingContext.java
@@ -22,6 +22,7 @@ import org.eclipse.emf.ecore.change.ChangeDescription;
 import org.eclipse.emf.ecore.change.util.ChangeRecorder;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.edit.domain.AdapterFactoryEditingDomain;
+import org.eclipse.emf.edit.provider.IDisposable;
 import org.eclipse.sirius.components.collaborative.representations.change.IRepresentationChange;
 import org.eclipse.sirius.components.representations.IRepresentationDescription;
 import org.eclipse.sirius.components.view.View;
@@ -88,6 +89,7 @@ public class EditingContext implements IViewEditingContext {
         return this.inputId2RepresentationChanges;
     }
 
+    @Override
     public Map<String, IViewConversionData> getViewConversionData() {
         return this.viewConversionData;
     }
@@ -96,6 +98,9 @@ public class EditingContext implements IViewEditingContext {
     public void dispose() {
         this.changeRecorder.dispose();
         this.getDomain().getResourceSet().getResources().forEach(Resource::unload);
+        if (this.editingDomain.getAdapterFactory() instanceof IDisposable disposable) {
+            disposable.dispose();
+        }
     }
 
 }

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/studio/views/details/services/CustomizableEStringIfDescriptionProvider.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/studio/views/details/services/CustomizableEStringIfDescriptionProvider.java
@@ -23,7 +23,6 @@ import org.eclipse.emf.ecore.EClassifier;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EcorePackage;
 import org.eclipse.emf.ecore.util.EcoreUtil;
-import org.eclipse.emf.edit.provider.ComposedAdapterFactory;
 import org.eclipse.sirius.components.emf.forms.EStructuralFeatureLabelProvider;
 import org.eclipse.sirius.components.emf.forms.WidgetReadOnlyProvider;
 import org.eclipse.sirius.components.emf.forms.api.IPropertiesValidationProvider;
@@ -47,8 +46,6 @@ public class CustomizableEStringIfDescriptionProvider {
 
     private static final String TEXTAREA_DESCRIPTION_ID = "Textarea";
 
-    private final ComposedAdapterFactory composedAdapterFactory;
-
     private final IPropertiesValidationProvider propertiesValidationProvider;
 
     private final ITextfieldCustomizer customizer;
@@ -57,8 +54,7 @@ public class CustomizableEStringIfDescriptionProvider {
 
     private final WidgetReadOnlyProvider widgetReadOnlyProvider;
 
-    public CustomizableEStringIfDescriptionProvider(ComposedAdapterFactory composedAdapterFactory, IPropertiesValidationProvider propertiesValidationProvider, ITextfieldCustomizer customizer, Function<VariableManager, String> semanticTargetIdProvider, WidgetReadOnlyProvider widgetReadOnlyProvider) {
-        this.composedAdapterFactory = Objects.requireNonNull(composedAdapterFactory);
+    public CustomizableEStringIfDescriptionProvider(IPropertiesValidationProvider propertiesValidationProvider, ITextfieldCustomizer customizer, Function<VariableManager, String> semanticTargetIdProvider, WidgetReadOnlyProvider widgetReadOnlyProvider) {
         this.propertiesValidationProvider = Objects.requireNonNull(propertiesValidationProvider);
         this.customizer = Objects.requireNonNull(customizer);
         this.semanticTargetIdProvider = Objects.requireNonNull(semanticTargetIdProvider);
@@ -103,7 +99,7 @@ public class CustomizableEStringIfDescriptionProvider {
     }
 
     private Function<VariableManager, String> getLabelProvider() {
-        return new EStructuralFeatureLabelProvider(StudioDetailsViewWidgetDescriptionProvider.ESTRUCTURAL_FEATURE, this.composedAdapterFactory);
+        return new EStructuralFeatureLabelProvider(StudioDetailsViewWidgetDescriptionProvider.ESTRUCTURAL_FEATURE);
     }
 
     private Function<VariableManager, String> getValueProvider() {

--- a/packages/sirius-web/backend/sirius-web-infrastructure/src/main/java/org/eclipse/sirius/web/infrastructure/configuration/emf/EMFAdapterFactoryConfiguration.java
+++ b/packages/sirius-web/backend/sirius-web-infrastructure/src/main/java/org/eclipse/sirius/web/infrastructure/configuration/emf/EMFAdapterFactoryConfiguration.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.sirius.web.infrastructure.configuration.emf;
 
-import org.eclipse.emf.common.notify.AdapterFactory;
+import org.eclipse.emf.edit.provider.ComposedAdapterFactory;
 import org.eclipse.sirius.components.domain.provider.DomainItemProviderAdapterFactory;
 import org.eclipse.sirius.components.view.deck.provider.DeckItemProviderAdapterFactory;
 import org.eclipse.sirius.components.view.diagram.customnodes.provider.CustomnodesItemProviderAdapterFactory;
@@ -36,63 +36,64 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class EMFAdapterFactoryConfiguration {
 
+
     @Bean
-    public AdapterFactory domainAdapterFactory() {
-        return new DomainItemProviderAdapterFactory();
+    public ComposedAdapterFactory.Descriptor domainAdapterFactoryDescriptor() {
+        return DomainItemProviderAdapterFactory::new;
     }
 
     @Bean
-    public AdapterFactory viewAdapterFactory() {
-        return new ViewItemProviderAdapterFactory();
+    public ComposedAdapterFactory.Descriptor viewAdapterFactoryDescriptor() {
+        return ViewItemProviderAdapterFactory::new;
     }
 
     @Bean
-    public AdapterFactory diagramAdapterFactory() {
-        return new DiagramItemProviderAdapterFactory();
+    public ComposedAdapterFactory.Descriptor diagramAdapterFactoryDescriptor() {
+        return DiagramItemProviderAdapterFactory::new;
     }
 
     @Bean
-    public AdapterFactory customNodesAdapterFactory() {
-        return new CustomnodesItemProviderAdapterFactory();
+    public ComposedAdapterFactory.Descriptor customnodesAdapterFactoryDescriptor() {
+        return CustomnodesItemProviderAdapterFactory::new;
     }
 
     @Bean
-    public AdapterFactory referenceWidgetAdapterFactory() {
-        return new ReferenceItemProviderAdapterFactory();
+    public ComposedAdapterFactory.Descriptor referenceAdapterFactoryDescriptor() {
+        return ReferenceItemProviderAdapterFactory::new;
     }
 
     @Bean
-    public AdapterFactory formAdapterFactory() {
-        return new FormItemProviderAdapterFactory();
+    public ComposedAdapterFactory.Descriptor formAdapterFactoryDescriptor() {
+        return FormItemProviderAdapterFactory::new;
     }
 
     @Bean
-    public AdapterFactory deckAdapterFactory() {
-        return new DeckItemProviderAdapterFactory();
+    public ComposedAdapterFactory.Descriptor deckAdapterFactoryDescriptor() {
+        return DeckItemProviderAdapterFactory::new;
     }
 
     @Bean
-    public AdapterFactory ganttAdapterFactory() {
-        return new GanttItemProviderAdapterFactory();
+    public ComposedAdapterFactory.Descriptor ganttAdapterFactoryDescriptor() {
+        return GanttItemProviderAdapterFactory::new;
     }
 
     @Bean
-    public AdapterFactory treeAdapterFactory() {
-        return new TreeItemProviderAdapterFactory();
+    public ComposedAdapterFactory.Descriptor treeAdapterFactoryDescriptor() {
+        return TreeItemProviderAdapterFactory::new;
     }
 
     @Bean
-    public AdapterFactory tableAdapterFactory() {
-        return new TableItemProviderAdapterFactory();
+    public ComposedAdapterFactory.Descriptor tableAdapterFactoryDescriptor() {
+        return TableItemProviderAdapterFactory::new;
     }
 
     @Bean
-    public AdapterFactory tableWidgetAdapterFactory() {
-        return new TableWidgetItemProviderAdapterFactory();
+    public ComposedAdapterFactory.Descriptor tableWidgetAdapterFactoryDescriptor() {
+        return TableWidgetItemProviderAdapterFactory::new;
     }
 
     @Bean
-    public AdapterFactory customCellsAdapterFactory() {
-        return new CustomcellsItemProviderAdapterFactory();
+    public ComposedAdapterFactory.Descriptor customcellsWidgetAdapterFactoryDescriptor() {
+        return CustomcellsItemProviderAdapterFactory::new;
     }
 }

--- a/packages/sirius-web/backend/sirius-web-papaya/src/main/java/org/eclipse/sirius/web/papaya/configuration/PapayaEMFConfiguration.java
+++ b/packages/sirius-web/backend/sirius-web-papaya/src/main/java/org/eclipse/sirius/web/papaya/configuration/PapayaEMFConfiguration.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Obeo.
+ * Copyright (c) 2024, 2025 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.sirius.web.papaya.configuration;
 
-import org.eclipse.emf.common.notify.AdapterFactory;
+import org.eclipse.emf.edit.provider.ComposedAdapterFactory;
 import org.eclipse.sirius.components.papaya.provider.PapayaItemProviderAdapterFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -26,7 +26,7 @@ import org.springframework.context.annotation.Configuration;
 public class PapayaEMFConfiguration {
 
     @Bean
-    public AdapterFactory papayaAdapterFactory() {
-        return new PapayaItemProviderAdapterFactory();
+    public ComposedAdapterFactory.Descriptor papayaAdapterFactoryDescriptor() {
+        return PapayaItemProviderAdapterFactory::new;
     }
 }

--- a/packages/sirius-web/backend/sirius-web-papaya/src/main/java/org/eclipse/sirius/web/papaya/representations/table/DisplayNameProvider.java
+++ b/packages/sirius-web/backend/sirius-web-papaya/src/main/java/org/eclipse/sirius/web/papaya/representations/table/DisplayNameProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Obeo.
+ * Copyright (c) 2024, 2025 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -15,9 +15,9 @@ package org.eclipse.sirius.web.papaya.representations.table;
 import java.util.Objects;
 
 import org.eclipse.emf.common.notify.Adapter;
+import org.eclipse.emf.common.notify.AdapterFactory;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EStructuralFeature;
-import org.eclipse.emf.edit.provider.ComposedAdapterFactory;
 import org.eclipse.emf.edit.provider.IItemPropertyDescriptor;
 import org.eclipse.emf.edit.provider.IItemPropertySource;
 
@@ -28,14 +28,14 @@ import org.eclipse.emf.edit.provider.IItemPropertySource;
  */
 public class DisplayNameProvider {
 
-    private final ComposedAdapterFactory composedAdapterFactory;
+    private final AdapterFactory adapterFactory;
 
-    public DisplayNameProvider(ComposedAdapterFactory composedAdapterFactory) {
-        this.composedAdapterFactory = Objects.requireNonNull(composedAdapterFactory);
+    public DisplayNameProvider(AdapterFactory adapterFactory) {
+        this.adapterFactory = Objects.requireNonNull(adapterFactory);
     }
 
     public String getDisplayName(EObject eObject, EStructuralFeature eStructuralFeature) {
-        Adapter adapter = this.composedAdapterFactory.adapt(eObject, IItemPropertySource.class);
+        Adapter adapter = this.adapterFactory.adapt(eObject, IItemPropertySource.class);
         if (adapter instanceof IItemPropertySource itemPropertySource) {
             IItemPropertyDescriptor descriptor = itemPropertySource.getPropertyDescriptor(eObject, eStructuralFeature);
             if (descriptor != null) {

--- a/packages/sirius-web/backend/sirius-web-papaya/src/main/java/org/eclipse/sirius/web/papaya/services/library/publishers/JavaStandardLibraryPublisher.java
+++ b/packages/sirius-web/backend/sirius-web-papaya/src/main/java/org/eclipse/sirius/web/papaya/services/library/publishers/JavaStandardLibraryPublisher.java
@@ -20,6 +20,7 @@ import java.util.UUID;
 import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.emf.edit.domain.AdapterFactoryEditingDomain;
+import org.eclipse.emf.edit.provider.IDisposable;
 import org.eclipse.sirius.components.emf.ResourceMetadataAdapter;
 import org.eclipse.sirius.components.emf.services.IDAdapter;
 import org.eclipse.sirius.components.emf.services.JSONResourceFactory;
@@ -84,6 +85,9 @@ public class JavaStandardLibraryPublisher implements IPapayaLibraryPublisher {
             this.createJava002(command, editingDomain.getResourceSet());
         } else if (command.version().equals("0.0.3")) {
             this.createJava003(command, editingDomain.getResourceSet());
+        }
+        if (editingDomain.getAdapterFactory() instanceof IDisposable disposable) {
+            disposable.dispose();
         }
     }
 

--- a/packages/sirius-web/backend/sirius-web-papaya/src/main/java/org/eclipse/sirius/web/papaya/services/library/publishers/ReactiveStreamsLibraryPublisher.java
+++ b/packages/sirius-web/backend/sirius-web-papaya/src/main/java/org/eclipse/sirius/web/papaya/services/library/publishers/ReactiveStreamsLibraryPublisher.java
@@ -20,6 +20,7 @@ import java.util.UUID;
 import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.emf.edit.domain.AdapterFactoryEditingDomain;
+import org.eclipse.emf.edit.provider.IDisposable;
 import org.eclipse.sirius.components.emf.ResourceMetadataAdapter;
 import org.eclipse.sirius.components.emf.services.IDAdapter;
 import org.eclipse.sirius.components.emf.services.JSONResourceFactory;
@@ -94,6 +95,9 @@ public class ReactiveStreamsLibraryPublisher implements IPapayaLibraryPublisher 
         } else if (command.version().equals("0.0.3") && optionalJava003Library.isPresent()) {
             var java003Library = optionalJava003Library.get();
             this.createReactiveStreams(command, editingDomain.getResourceSet(), java003Library);
+        }
+        if (editingDomain.getAdapterFactory() instanceof IDisposable disposable) {
+            disposable.dispose();
         }
     }
 

--- a/packages/sirius-web/backend/sirius-web-papaya/src/main/java/org/eclipse/sirius/web/papaya/services/library/publishers/ReactorLibraryPublisher.java
+++ b/packages/sirius-web/backend/sirius-web-papaya/src/main/java/org/eclipse/sirius/web/papaya/services/library/publishers/ReactorLibraryPublisher.java
@@ -20,6 +20,7 @@ import java.util.UUID;
 import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.emf.edit.domain.AdapterFactoryEditingDomain;
+import org.eclipse.emf.edit.provider.IDisposable;
 import org.eclipse.sirius.components.emf.ResourceMetadataAdapter;
 import org.eclipse.sirius.components.emf.services.IDAdapter;
 import org.eclipse.sirius.components.emf.services.JSONResourceFactory;
@@ -94,6 +95,9 @@ public class ReactorLibraryPublisher implements IPapayaLibraryPublisher {
             var java003Library = optionalJava003Library.get();
             var reactiveStreams003Library = optionalReactiveStreams003Library.get();
             this.createReactor(command, editingDomain.getResourceSet(), List.of(java003Library, reactiveStreams003Library));
+        }
+        if (editingDomain.getAdapterFactory() instanceof IDisposable disposable) {
+            disposable.dispose();
         }
     }
 

--- a/packages/starters/backend/sirius-components-flow-starter/src/main/java/org/eclipse/sirius/components/flow/starter/configuration/FlowEMFConfiguration.java
+++ b/packages/starters/backend/sirius-components-flow-starter/src/main/java/org/eclipse/sirius/components/flow/starter/configuration/FlowEMFConfiguration.java
@@ -14,7 +14,7 @@ package org.eclipse.sirius.components.flow.starter.configuration;
 
 import fr.obeo.dsl.designer.sample.flow.provider.FlowItemProviderAdapterFactory;
 
-import org.eclipse.emf.common.notify.AdapterFactory;
+import org.eclipse.emf.edit.provider.ComposedAdapterFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -27,8 +27,7 @@ import org.springframework.context.annotation.Configuration;
 public class FlowEMFConfiguration {
 
     @Bean
-    public AdapterFactory flowAdapterFactory() {
-        return new FlowItemProviderAdapterFactory();
+    public ComposedAdapterFactory.Descriptor flowAdapterFactoryDescriptor() {
+        return FlowItemProviderAdapterFactory::new;
     }
-
 }

--- a/packages/starters/backend/sirius-components-task-starter/src/main/java/org/eclipse/sirius/components/task/starter/configuration/TaskEMFConfiguration.java
+++ b/packages/starters/backend/sirius-components-task-starter/src/main/java/org/eclipse/sirius/components/task/starter/configuration/TaskEMFConfiguration.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2024 Obeo.
+ * Copyright (c) 2023, 2025 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.sirius.components.task.starter.configuration;
 
-import org.eclipse.emf.common.notify.AdapterFactory;
+import org.eclipse.emf.edit.provider.ComposedAdapterFactory;
 import org.eclipse.sirius.components.task.provider.TaskItemProviderAdapterFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -26,7 +26,7 @@ import org.springframework.context.annotation.Configuration;
 public class TaskEMFConfiguration {
 
     @Bean
-    public AdapterFactory taskAdapterFactory() {
-        return new TaskItemProviderAdapterFactory();
+    public ComposedAdapterFactory.Descriptor taskAdapterFactoryDescriptor() {
+        return TaskItemProviderAdapterFactory::new;
     }
 }

--- a/packages/view/backend/sirius-components-view-emf/src/main/java/org/eclipse/sirius/components/view/emf/diagram/NodeStylePropertiesConfigurer.java
+++ b/packages/view/backend/sirius-components-view-emf/src/main/java/org/eclipse/sirius/components/view/emf/diagram/NodeStylePropertiesConfigurer.java
@@ -29,7 +29,6 @@ import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.emf.edit.domain.EditingDomain;
-import org.eclipse.emf.edit.provider.ComposedAdapterFactory;
 import org.eclipse.sirius.components.collaborative.forms.services.api.IPropertiesDescriptionRegistry;
 import org.eclipse.sirius.components.collaborative.forms.services.api.IPropertiesDescriptionRegistryConfigurer;
 import org.eclipse.sirius.components.core.api.IEditingContext;
@@ -83,15 +82,12 @@ public class NodeStylePropertiesConfigurer implements IPropertiesDescriptionRegi
 
     private final ILabelService labelService;
 
-    private final ComposedAdapterFactory composedAdapterFactory;
-
     public NodeStylePropertiesConfigurer(ICustomImageMetadataSearchService customImageSearchService, PropertiesConfigurerService propertiesConfigurerService,
-            IPropertiesWidgetCreationService propertiesWidgetCreationService, ILabelService labelService, ComposedAdapterFactory composedAdapterFactory) {
+            IPropertiesWidgetCreationService propertiesWidgetCreationService, ILabelService labelService) {
         this.customImageSearchService = Objects.requireNonNull(customImageSearchService);
         this.propertiesConfigurerService = Objects.requireNonNull(propertiesConfigurerService);
         this.propertiesWidgetCreationService = Objects.requireNonNull(propertiesWidgetCreationService);
         this.labelService = Objects.requireNonNull(labelService);
-        this.composedAdapterFactory = Objects.requireNonNull(composedAdapterFactory);
     }
 
     @Override
@@ -161,7 +157,7 @@ public class NodeStylePropertiesConfigurer implements IPropertiesDescriptionRegi
     }
 
     private Function<VariableManager, List<?>> getBorderNodeOptionsProvider() {
-        return new EStructuralFeatureChoiceOfValueProvider(EMFFormDescriptionProvider.ESTRUCTURAL_FEATURE, this.composedAdapterFactory);
+        return new EStructuralFeatureChoiceOfValueProvider(EMFFormDescriptionProvider.ESTRUCTURAL_FEATURE);
     }
 
     private List<NodeDescription> getSubNodes(VariableManager variableManager) {

--- a/scripts/check-pr.js
+++ b/scripts/check-pr.js
@@ -49,7 +49,7 @@ for (const issue of closingIssuesReferences.nodes) {
     labels.nodes.filter((label) => label.name.startsWith("type:")).length >= 1;
   const hasOneDifficultyLabel =
     labels.nodes.filter((label) => label.name.startsWith("difficulty:"))
-      .length === 1;
+      .length >= 1;
 
   if (
     !hasAtLeastOnePackageLabel ||


### PR DESCRIPTION
Bug: https://github.com/eclipse-sirius/sirius-web/issues/5953

# Pull request template

## General purpose
What is the main goal of this pull request?
- [ ] Bug fixes
- [x] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [x] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [x] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [x] Have the relevant issues been added to the pull request?
- [x] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [x] Have the relevant issues been added to the same project and milestone as the pull request?
- [x] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [x] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?