### PR TITLE
[cleanup] Rename VariableManager.hasVariable into hasLocalVariable to reduce confusion

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -70,14 +70,16 @@ For example, the Papaya AdapterFactory is now contributed like this:
 public ComposedAdapterFactory.Descriptor papayaAdapterFactoryDescriptor() {
     return PapayaItemProviderAdapterFactory::new;
 }
-````
+```
 instead of the previous way:
 ```
 @Bean
 public AdapterFactory papayaAdapterFactory() {
     return new PapayaItemProviderAdapterFactory();
 }
-````
+```
+- The method `VariableManager.hasVariable()` has been renamed into `hasLocalVariable()` to make its semantics clearer.
+
 
 === Dependency update
 

--- a/packages/core/backend/sirius-components-representations/src/main/java/org/eclipse/sirius/components/representations/VariableManager.java
+++ b/packages/core/backend/sirius-components-representations/src/main/java/org/eclipse/sirius/components/representations/VariableManager.java
@@ -108,7 +108,15 @@ public class VariableManager {
         return this.parent;
     }
 
-    public boolean hasVariable(String name) {
+    /**
+     * Checks whether this specific VariableManager has a definition for a variable with the given name.
+     * This does <em>not</em> consider parent variable managers.
+     *
+     * @param name
+     *            the variable name to check.
+     * @return true if there is a local definition for a variable with the given name.
+     */
+    public boolean hasLocalVariable(String name) {
         return this.variables.containsKey(name);
     }
 

--- a/packages/sirius-web/backend/sirius-web/src/test/java/org/eclipse/sirius/web/services/forms/MasterDetailsFormDescriptionProvider.java
+++ b/packages/sirius-web/backend/sirius-web/src/test/java/org/eclipse/sirius/web/services/forms/MasterDetailsFormDescriptionProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Obeo.
+ * Copyright (c) 2024, 2025 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -66,7 +66,7 @@ public class MasterDetailsFormDescriptionProvider implements IEditingContextRepr
                 .optionLabelProvider(variableManager -> variableManager.get(SelectComponent.CANDIDATE_VARIABLE, String.class).orElse(""))
                 .newValueHandler((variableManager, newValue) -> {
                     var currentVariableManager = variableManager;
-                    while (!currentVariableManager.hasVariable(CUSTOM_VARIABLE)) {
+                    while (!currentVariableManager.hasLocalVariable(CUSTOM_VARIABLE)) {
                         currentVariableManager = currentVariableManager.getParent();
                     }
 

--- a/packages/trees/backend/sirius-components-collaborative-trees/src/test/java/org/eclipse/sirius/components/collaborative/trees/architecture/handlers/DefaultExpandAllTreePathHandlerTests.java
+++ b/packages/trees/backend/sirius-components-collaborative-trees/src/test/java/org/eclipse/sirius/components/collaborative/trees/architecture/handlers/DefaultExpandAllTreePathHandlerTests.java
@@ -121,7 +121,7 @@ public class DefaultExpandAllTreePathHandlerTests {
                         .elementsProvider(variableManager -> List.of())
                         .hasChildrenProvider(variableManager -> {
                             // Keep the test simple by checking the variable in hasChildren instead of getChildren, so we don't have to mock children.
-                            hasActiveFilterIds.set(variableManager.hasVariable(TreeRenderer.ACTIVE_FILTER_IDS));
+                            hasActiveFilterIds.set(variableManager.hasLocalVariable(TreeRenderer.ACTIVE_FILTER_IDS));
                             return false;
                         })
                         .treeItemIconURLsProvider(variableManager -> List.of())


### PR DESCRIPTION
I hesitated between `hasLocalVariable` and `hasOwnVariable`. "local" seems more natural for what is equivalent to hierarchical scopes.