### PR TITLE
[5683] Decouple library publication from a single IInput type

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -55,6 +55,7 @@ On the frontend, the `ProjectTemplateCard` component has been removed; the `NewP
 - Remove the useless property `WorkbenchEntry#kind` from the GraphQL API and the DTO.
 The `WorkbenchEntry` object has also been transformed into a record
 - https://github.com/eclipse-sirius/sirius-web/issues/4348[#4348] [diagram] The interfaces `ISingleClickOnMultipleDiagramElementHandler` `ISingleClickOnOneDiagramElementHandler` `IPaletteToolsProvider` have been modified to take the `DiagramContext` instead of the `Diagram` as parameter.
+- https://github.com/eclipse-sirius/sirius-web/issues/5683[#5683] All APIs related to library publication now rely on interface `IPublishLibraryInput` instead of record  `PublishLibrariesInput`, making it extensible by downstream applications.
 
 
 === Dependency update
@@ -124,7 +125,6 @@ Downstream projects can provide their own `IFormCapabilitiesService` primary ser
 - https://github.com/eclipse-sirius/sirius-web/issues/5883[#5883] Make `IProxyRemovalService` extensible
 Downstream applications can now implement `IProxyRemovalServiceDelegate` to customize how proxies are removed.
 - https://github.com/eclipse-sirius/sirius-web/issues/4348[#4348] [diagram] Move default quick tools declaration on the backend
-
 
 
 == 2025.12.0

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/library/api/IPublishLibraryInput.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/library/api/IPublishLibraryInput.java
@@ -10,20 +10,22 @@
  * Contributors:
  *     Obeo - initial API and implementation
  *******************************************************************************/
-package org.eclipse.sirius.web.application.library.services.api;
+package org.eclipse.sirius.web.application.library.api;
 
-import org.eclipse.sirius.components.core.api.IPayload;
-import org.eclipse.sirius.web.application.library.api.IPublishLibraryInput;
+import org.eclipse.sirius.components.core.api.IInput;
 
 /**
- * Handles the publication of libraries.
+ * {@link IInput} for publishing a library.
  *
- * @author gdaniel
+ * @author flatombe
  */
-public interface ILibraryPublicationHandler {
+public interface IPublishLibraryInput extends IInput {
 
-    boolean canHandle(IPublishLibraryInput input);
+    String projectId();
 
-    IPayload handle(IPublishLibraryInput input);
+    String publicationKind();
 
+    String version();
+
+    String description();
 }

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/library/controllers/MutationPublishLibrariesDataFetcher.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/library/controllers/MutationPublishLibrariesDataFetcher.java
@@ -19,7 +19,7 @@ import java.util.Objects;
 import org.eclipse.sirius.components.annotations.spring.graphql.QueryDataFetcher;
 import org.eclipse.sirius.components.core.api.IPayload;
 import org.eclipse.sirius.components.graphql.api.IDataFetcherWithFieldCoordinates;
-import org.eclipse.sirius.web.application.library.dto.PublishLibrariesInput;
+import org.eclipse.sirius.web.application.library.api.IPublishLibraryInput;
 import org.eclipse.sirius.web.application.library.services.api.ILibraryApplicationService;
 
 import graphql.schema.DataFetchingEnvironment;
@@ -46,7 +46,7 @@ public class MutationPublishLibrariesDataFetcher implements IDataFetcherWithFiel
     @Override
     public IPayload get(DataFetchingEnvironment environment) throws Exception {
         Object argument = environment.getArgument(INPUT_ARGUMENT);
-        var input = this.objectMapper.convertValue(argument, PublishLibrariesInput.class);
+        var input = this.objectMapper.convertValue(argument, IPublishLibraryInput.class);
 
         return this.libraryApplicationService.publishLibraries(input);
     }

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/library/dto/PublishLibrariesInput.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/library/dto/PublishLibrariesInput.java
@@ -14,7 +14,7 @@ package org.eclipse.sirius.web.application.library.dto;
 
 import java.util.UUID;
 
-import org.eclipse.sirius.components.core.api.IInput;
+import org.eclipse.sirius.web.application.library.api.IPublishLibraryInput;
 
 import jakarta.validation.constraints.NotNull;
 
@@ -23,6 +23,7 @@ import jakarta.validation.constraints.NotNull;
  *
  * @author gdaniel
  */
-public record PublishLibrariesInput(@NotNull UUID id, @NotNull String projectId, @NotNull String publicationKind, @NotNull String version, @NotNull String description) implements IInput {
+public record PublishLibrariesInput(@NotNull UUID id, @NotNull String projectId, @NotNull String publicationKind, @NotNull String version, @NotNull String description)
+        implements IPublishLibraryInput {
 
 }

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/library/services/LibraryApplicationService.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/library/services/LibraryApplicationService.java
@@ -18,8 +18,8 @@ import java.util.Optional;
 
 import org.eclipse.sirius.components.core.api.ErrorPayload;
 import org.eclipse.sirius.components.core.api.IPayload;
+import org.eclipse.sirius.web.application.library.api.IPublishLibraryInput;
 import org.eclipse.sirius.web.application.library.dto.LibraryDTO;
-import org.eclipse.sirius.web.application.library.dto.PublishLibrariesInput;
 import org.eclipse.sirius.web.application.library.services.api.ILibraryApplicationService;
 import org.eclipse.sirius.web.application.library.services.api.ILibraryMapper;
 import org.eclipse.sirius.web.application.library.services.api.ILibraryPublicationHandler;
@@ -77,7 +77,7 @@ public class LibraryApplicationService implements ILibraryApplicationService {
 
     @Override
     @Transactional
-    public IPayload publishLibraries(PublishLibrariesInput input) {
+    public IPayload publishLibraries(IPublishLibraryInput input) {
         IPayload payload = new ErrorPayload(input.id(), this.messageService.unexpectedError());
         Optional<ILibraryPublicationHandler> optionalHandler = this.libraryPublicationHandlers.stream()
             .filter(handler -> handler.canHandle(input))

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/library/services/api/ILibraryApplicationService.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/library/services/api/ILibraryApplicationService.java
@@ -15,8 +15,8 @@ package org.eclipse.sirius.web.application.library.services.api;
 import java.util.Optional;
 
 import org.eclipse.sirius.components.core.api.IPayload;
+import org.eclipse.sirius.web.application.library.api.IPublishLibraryInput;
 import org.eclipse.sirius.web.application.library.dto.LibraryDTO;
-import org.eclipse.sirius.web.application.library.dto.PublishLibrariesInput;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -33,5 +33,5 @@ public interface ILibraryApplicationService {
 
     Page<LibraryDTO> findByNamespaceAndName(String namespace, String name, Pageable pageable);
 
-    IPayload publishLibraries(PublishLibrariesInput input);
+    IPayload publishLibraries(IPublishLibraryInput input);
 }

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/studio/services/library/StudioLibraryPublicationHandler.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/studio/services/library/StudioLibraryPublicationHandler.java
@@ -27,7 +27,7 @@ import org.eclipse.sirius.components.emf.services.JSONResourceFactory;
 import org.eclipse.sirius.components.emf.services.api.IEMFEditingContext;
 import org.eclipse.sirius.components.representations.Message;
 import org.eclipse.sirius.components.representations.MessageLevel;
-import org.eclipse.sirius.web.application.library.dto.PublishLibrariesInput;
+import org.eclipse.sirius.web.application.library.api.IPublishLibraryInput;
 import org.eclipse.sirius.web.application.library.services.api.ILibraryPublicationHandler;
 import org.eclipse.sirius.web.application.studio.services.library.api.DependencyGraph;
 import org.eclipse.sirius.web.application.studio.services.library.api.IStudioLibraryDependencyCollector;
@@ -65,12 +65,12 @@ public class StudioLibraryPublicationHandler implements ILibraryPublicationHandl
     }
 
     @Override
-    public boolean canHandle(PublishLibrariesInput input) {
+    public boolean canHandle(IPublishLibraryInput input) {
         return Objects.equals(input.publicationKind(), "studio-all");
     }
 
     @Override
-    public IPayload handle(PublishLibrariesInput input) {
+    public IPayload handle(IPublishLibraryInput input) {
         IPayload result = new ErrorPayload(input.id(), this.messageService.unexpectedError());
 
         Optional<IEMFEditingContext> optionalEditingContext = this.projectSemanticDataSearchService.findByProjectId(AggregateReference.to(input.projectId()))

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/studio/services/library/StudioLibraryPublicationListener.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/studio/services/library/StudioLibraryPublicationListener.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.sirius.web.application.studio.services.library;
 
-import org.eclipse.sirius.web.application.library.dto.PublishLibrariesInput;
+import org.eclipse.sirius.web.application.library.api.IPublishLibraryInput;
 import org.eclipse.sirius.web.domain.boundedcontexts.library.Library;
 import org.eclipse.sirius.web.domain.boundedcontexts.library.services.api.ILibraryCreationService;
 import org.eclipse.sirius.web.domain.boundedcontexts.semanticdata.events.SemanticDataCreatedEvent;
@@ -39,7 +39,7 @@ public class StudioLibraryPublicationListener {
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     @TransactionalEventListener
     public void onSemanticDataCreatedEvent(SemanticDataCreatedEvent semanticDataCreatedEvent) {
-        if (semanticDataCreatedEvent.causedBy() instanceof StudioLibrarySemanticDataCreationRequested request && request.causedBy() instanceof PublishLibrariesInput publishLibrariesInput) {
+        if (semanticDataCreatedEvent.causedBy() instanceof StudioLibrarySemanticDataCreationRequested request && request.causedBy() instanceof IPublishLibraryInput publishLibrariesInput) {
             var semanticData = semanticDataCreatedEvent.semanticData();
 
             Library library = Library.newLibrary()

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/studio/services/library/StudioLibrarySemanticDataCreationService.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/studio/services/library/StudioLibrarySemanticDataCreationService.java
@@ -34,7 +34,7 @@ import org.eclipse.sirius.components.view.RepresentationDescription;
 import org.eclipse.sirius.web.application.editingcontext.services.DocumentData;
 import org.eclipse.sirius.web.application.editingcontext.services.EPackageEntry;
 import org.eclipse.sirius.web.application.editingcontext.services.api.IResourceToDocumentService;
-import org.eclipse.sirius.web.application.library.dto.PublishLibrariesInput;
+import org.eclipse.sirius.web.application.library.api.IPublishLibraryInput;
 import org.eclipse.sirius.web.application.library.services.LibraryMetadataAdapter;
 import org.eclipse.sirius.web.application.studio.services.library.api.DependencyGraph;
 import org.eclipse.sirius.web.application.studio.services.library.api.IStudioLibrarySemanticDataCreationService;
@@ -71,7 +71,7 @@ public class StudioLibrarySemanticDataCreationService implements IStudioLibraryS
     }
 
     @Override
-    public Collection<SemanticData> createSemanticData(PublishLibrariesInput input, DependencyGraph<EObject> dependencyGraph, ResourceSet resourceSet) {
+    public Collection<SemanticData> createSemanticData(IPublishLibraryInput input, DependencyGraph<EObject> dependencyGraph, ResourceSet resourceSet) {
         // Compute the topological ordering to ensure that all the dependencies of a library have been created before it.
         List<EObject> libraryCandidates = dependencyGraph.computeTopologicalOrdering();
         for (EObject libraryCandidate : libraryCandidates) {

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/studio/services/library/api/IStudioLibrarySemanticDataCreationService.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/studio/services/library/api/IStudioLibrarySemanticDataCreationService.java
@@ -16,7 +16,7 @@ import java.util.Collection;
 
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.resource.ResourceSet;
-import org.eclipse.sirius.web.application.library.dto.PublishLibrariesInput;
+import org.eclipse.sirius.web.application.library.api.IPublishLibraryInput;
 import org.eclipse.sirius.web.domain.boundedcontexts.semanticdata.SemanticData;
 
 /**
@@ -26,6 +26,6 @@ import org.eclipse.sirius.web.domain.boundedcontexts.semanticdata.SemanticData;
  */
 public interface IStudioLibrarySemanticDataCreationService {
 
-    Collection<SemanticData> createSemanticData(PublishLibrariesInput input, DependencyGraph<EObject> dependencyGraph, ResourceSet resourceSet);
+    Collection<SemanticData> createSemanticData(IPublishLibraryInput input, DependencyGraph<EObject> dependencyGraph, ResourceSet resourceSet);
 
 }

--- a/packages/sirius-web/backend/sirius-web-tests/src/main/java/org/eclipse/sirius/web/tests/graphql/PublishLibrariesMutationRunner.java
+++ b/packages/sirius-web/backend/sirius-web-tests/src/main/java/org/eclipse/sirius/web/tests/graphql/PublishLibrariesMutationRunner.java
@@ -16,7 +16,7 @@ import java.util.Objects;
 
 import org.eclipse.sirius.components.graphql.tests.api.IGraphQLRequestor;
 import org.eclipse.sirius.components.graphql.tests.api.IMutationRunner;
-import org.eclipse.sirius.web.application.library.dto.PublishLibrariesInput;
+import org.eclipse.sirius.web.application.library.api.IPublishLibraryInput;
 import org.springframework.stereotype.Service;
 
 /**
@@ -25,7 +25,7 @@ import org.springframework.stereotype.Service;
  * @author gdaniel
  */
 @Service
-public class PublishLibrariesMutationRunner implements IMutationRunner<PublishLibrariesInput> {
+public class PublishLibrariesMutationRunner implements IMutationRunner<IPublishLibraryInput> {
 
     private static final String PUBLISH_LIBRARIES = """
             mutation publishLibraries($input: PublishLibrariesInput!) {
@@ -54,7 +54,7 @@ public class PublishLibrariesMutationRunner implements IMutationRunner<PublishLi
     }
 
     @Override
-    public String run(PublishLibrariesInput input) {
+    public String run(IPublishLibraryInput input) {
         return this.graphQLRequestor.execute(PUBLISH_LIBRARIES, input);
     }
 


### PR DESCRIPTION
Bug: https://github.com/eclipse-sirius/sirius-web/issues/5683

# Pull request template

## General purpose
What is the main goal of this pull request?
- [ ] Bug fixes
- [X] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [ ] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [ ] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

[ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?