### PR TITLE
[3305] Make it possible to have transient Diagram

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -21,6 +21,16 @@
 The `initialSelectedPageId` prop in `FormProps` has been changed to `initialSelectedPageLabel`.
 `DetailsView`, `DiagramFilterForm`, `FormBasedView`, `FormRepresentation`, `RelatedElementsView`, and `RelatedViewsView` have been updated to reflect this change.
 The link produced by the _Share_ action on a project now includes the `selectedPageLabel` instead of the `selectedPageId`.
+- https://github.com/eclipse-sirius/sirius-web/issues/3305[#3305] `IExplorerServices#getDefaultElements` has been removed.
+It has been replaced by a new service named `IExplorerContentService#getElements` which allow downstream application to customize the behavior of the explorer more easily.
+Those who want to customize the behavior of the root elements of the explorer can thus create an instance of `IExplorerContentServiceDelegate` and customize the default value for their editing context.
+The previous behavior has been used for the implementation of the `IDefaultExplorerContentService` to keep the same behavior.
+One key difference between the previous API and the new one is that the previous one in `IExplorerServices#getDefaultElements` made the hypothesis that all the root elements were EMF resources.
+The new API only expect a list of objects, as a result it allows the contribution of representations as root elements in the explorer for example.
+- A new API `org.eclipse.sirius.components.collaborative.api.IRepresentationPersistenceStrategy` has been added to delegate persistence decisions for representations (used to support transient diagrams).
+Several event-processor-related constructors now accept an additional `IRepresentationPersistenceStrategy` parameter (for example: `DiagramEventProcessorFactory`, `PapayaDashboardEventProcessorFactory`, and related `DiagramEventProcessor`/`DiagramEventProcessorParameters` builders).
+If you directly instantiate or extend those factories in downstream code or tests, update the constructors to provide an `IRepresentationPersistenceStrategy` implementation.
+
 
 === Dependency update
 
@@ -48,6 +58,7 @@ When the selection changes, the details view will attempt to re-open the same ta
 If the tab cannot be found the first tab of the form will be opened instead.
 - https://github.com/eclipse-sirius/sirius-web/issues/6040[#6040] [sirius-web] Only propose to select project template or libraries when it is relevant
 - https://github.com/eclipse-sirius/sirius-web/issues/6065[#6065] [sirius-web] Standardize font sizes on the _New Project_ creation page
+- https://github.com/eclipse-sirius/sirius-web/issues/3305[#3305] [diagram] Make it possible to have transient diagrams: delegate the save operation to a new `IRepresentationPersistenceStrategy` service which persists only when the representation exists in the database, and add a transient diagram sample in Papaya.
 
 
 

--- a/packages/charts/backend/sirius-components-collaborative-charts/src/main/java/org/eclipse/sirius/components/collaborative/charts/HierarchyEventProcessorFactory.java
+++ b/packages/charts/backend/sirius-components-collaborative-charts/src/main/java/org/eclipse/sirius/components/collaborative/charts/HierarchyEventProcessorFactory.java
@@ -19,7 +19,7 @@ import java.util.Optional;
 import org.eclipse.sirius.components.charts.hierarchy.Hierarchy;
 import org.eclipse.sirius.components.collaborative.api.IRepresentationEventProcessor;
 import org.eclipse.sirius.components.collaborative.api.IRepresentationEventProcessorFactory;
-import org.eclipse.sirius.components.collaborative.api.IRepresentationPersistenceService;
+import org.eclipse.sirius.components.collaborative.api.IRepresentationPersistenceStrategy;
 import org.eclipse.sirius.components.collaborative.api.IRepresentationSearchService;
 import org.eclipse.sirius.components.collaborative.api.ISubscriptionManagerFactory;
 import org.eclipse.sirius.components.core.api.IEditingContext;
@@ -34,7 +34,7 @@ import org.springframework.stereotype.Service;
 @Service
 public class HierarchyEventProcessorFactory implements IRepresentationEventProcessorFactory {
 
-    private final IRepresentationPersistenceService representationPersistenceService;
+    private final IRepresentationPersistenceStrategy representationPersistenceStrategy;
 
     private final IRepresentationSearchService representationSearchService;
 
@@ -42,9 +42,9 @@ public class HierarchyEventProcessorFactory implements IRepresentationEventProce
 
     private final ISubscriptionManagerFactory subscriptionManagerFactory;
 
-    public HierarchyEventProcessorFactory(IRepresentationPersistenceService representationPersistenceService, IRepresentationSearchService representationSearchService, HierarchyCreationService hierarchyCreationService,
+    public HierarchyEventProcessorFactory(IRepresentationPersistenceStrategy representationPersistenceStrategy, IRepresentationSearchService representationSearchService, HierarchyCreationService hierarchyCreationService,
             ISubscriptionManagerFactory subscriptionManagerFactory) {
-        this.representationPersistenceService = Objects.requireNonNull(representationPersistenceService);
+        this.representationPersistenceStrategy = Objects.requireNonNull(representationPersistenceStrategy);
         this.representationSearchService = Objects.requireNonNull(representationSearchService);
         this.hierarchyCreationService = Objects.requireNonNull(hierarchyCreationService);
         this.subscriptionManagerFactory = Objects.requireNonNull(subscriptionManagerFactory);
@@ -67,7 +67,7 @@ public class HierarchyEventProcessorFactory implements IRepresentationEventProce
 
             HierarchyContext hierarchyContext = new HierarchyContext(hierarchy);
             IRepresentationEventProcessor hierarchyEventProcessor = new HierarchyEventProcessor(editingContext, hierarchyContext,
-                    this.subscriptionManagerFactory.create(), this.hierarchyCreationService, this.representationPersistenceService, this.representationSearchService);
+                    this.subscriptionManagerFactory.create(), this.hierarchyCreationService, this.representationPersistenceStrategy, this.representationSearchService);
 
             return Optional.of(hierarchyEventProcessor);
         }

--- a/packages/core/backend/sirius-components-collaborative/src/main/java/org/eclipse/sirius/components/collaborative/api/IRepresentationPersistenceStrategy.java
+++ b/packages/core/backend/sirius-components-collaborative/src/main/java/org/eclipse/sirius/components/collaborative/api/IRepresentationPersistenceStrategy.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.components.collaborative.api;
+
+import org.eclipse.sirius.components.core.api.IEditingContext;
+import org.eclipse.sirius.components.events.ICause;
+import org.eclipse.sirius.components.representations.IRepresentation;
+
+/**
+ * Common interface used to define a persistence strategy.
+ *
+ * @author fbarbin
+ */
+public interface IRepresentationPersistenceStrategy {
+    void applyPersistenceStrategy(ICause cause, IEditingContext editingContext, IRepresentation representation);
+
+    /**
+     * Empty implementation, used for mocks in unit tests.
+     *
+     * @author fbarbin
+     */
+    class NoOp implements IRepresentationPersistenceStrategy {
+
+        @Override
+        public void applyPersistenceStrategy(ICause cause, IEditingContext editingContext, IRepresentation representation) {
+            // Do nothing
+        }
+
+    }
+}

--- a/packages/deck/backend/sirius-components-collaborative-deck/src/main/java/org/eclipse/sirius/components/collaborative/deck/DeckEventProcessor.java
+++ b/packages/deck/backend/sirius-components-collaborative-deck/src/main/java/org/eclipse/sirius/components/collaborative/deck/DeckEventProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 Obeo.
+ * Copyright (c) 2023, 2026 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -18,7 +18,7 @@ import java.util.Optional;
 
 import org.eclipse.sirius.components.collaborative.api.ChangeDescription;
 import org.eclipse.sirius.components.collaborative.api.ChangeKind;
-import org.eclipse.sirius.components.collaborative.api.IRepresentationPersistenceService;
+import org.eclipse.sirius.components.collaborative.api.IRepresentationPersistenceStrategy;
 import org.eclipse.sirius.components.collaborative.api.IRepresentationSearchService;
 import org.eclipse.sirius.components.collaborative.api.ISubscriptionManager;
 import org.eclipse.sirius.components.collaborative.deck.api.IDeckContext;
@@ -53,7 +53,7 @@ public class DeckEventProcessor implements IDeckEventProcessor {
 
     private final ISubscriptionManager subscriptionManager;
 
-    private final IRepresentationPersistenceService representationPersistenceService;
+    private final IRepresentationPersistenceStrategy representationPersistenceStrategy;
 
     private final IRepresentationSearchService representationSearchService;
 
@@ -66,7 +66,7 @@ public class DeckEventProcessor implements IDeckEventProcessor {
     private final IDeckContext deckContext;
 
     public DeckEventProcessor(IEditingContext editingContext, ISubscriptionManager subscriptionManager, DeckCreationService deckCreationService,
-            List<IDeckEventHandler> deckEventHandlers, IDeckContext deckContext, IRepresentationPersistenceService representationPersistenceService,
+            List<IDeckEventHandler> deckEventHandlers, IDeckContext deckContext, IRepresentationPersistenceStrategy representationPersistenceStrategy,
             IRepresentationSearchService representationSearchService) {
 
         this.editingContext = Objects.requireNonNull(editingContext);
@@ -74,7 +74,7 @@ public class DeckEventProcessor implements IDeckEventProcessor {
         this.deckCreationService = Objects.requireNonNull(deckCreationService);
         this.deckEventHandlers = Objects.requireNonNull(deckEventHandlers);
         this.deckContext = Objects.requireNonNull(deckContext);
-        this.representationPersistenceService = Objects.requireNonNull(representationPersistenceService);
+        this.representationPersistenceStrategy = Objects.requireNonNull(representationPersistenceStrategy);
         this.representationSearchService = Objects.requireNonNull(representationSearchService);
 
         String id = this.deckContext.getDeck().getId();
@@ -122,7 +122,7 @@ public class DeckEventProcessor implements IDeckEventProcessor {
             this.deckContext.reset();
             this.deckContext.update(refreshedDeckRepresentation);
             if (refreshedDeckRepresentation != null) {
-                this.representationPersistenceService.save(changeDescription.getInput(), this.editingContext, refreshedDeckRepresentation);
+                this.representationPersistenceStrategy.applyPersistenceStrategy(changeDescription.getInput(), this.editingContext, refreshedDeckRepresentation);
                 this.logger.trace("Deck refreshed: {}", refreshedDeckRepresentation.getId());
             }
             this.deckEventFlux.deckRefreshed(changeDescription.getInput(), this.deckContext.getDeck());

--- a/packages/deck/backend/sirius-components-collaborative-deck/src/main/java/org/eclipse/sirius/components/collaborative/deck/DeckEventProcessorFactory.java
+++ b/packages/deck/backend/sirius-components-collaborative-deck/src/main/java/org/eclipse/sirius/components/collaborative/deck/DeckEventProcessorFactory.java
@@ -18,7 +18,7 @@ import java.util.Optional;
 
 import org.eclipse.sirius.components.collaborative.api.IRepresentationEventProcessor;
 import org.eclipse.sirius.components.collaborative.api.IRepresentationEventProcessorFactory;
-import org.eclipse.sirius.components.collaborative.api.IRepresentationPersistenceService;
+import org.eclipse.sirius.components.collaborative.api.IRepresentationPersistenceStrategy;
 import org.eclipse.sirius.components.collaborative.api.IRepresentationSearchService;
 import org.eclipse.sirius.components.collaborative.api.ISubscriptionManagerFactory;
 import org.eclipse.sirius.components.collaborative.deck.api.IDeckEventHandler;
@@ -43,15 +43,15 @@ public class DeckEventProcessorFactory implements IRepresentationEventProcessorF
 
     private final List<IDeckEventHandler> deckEventHandlers;
 
-    private final IRepresentationPersistenceService representationPersistenceService;
+    private final IRepresentationPersistenceStrategy representationPersistenceStrategy;
 
     public DeckEventProcessorFactory(IRepresentationSearchService representationSearchService, DeckCreationService deckCreationService, ISubscriptionManagerFactory subscriptionManagerFactory,
-            List<IDeckEventHandler> deckEventHandlers, IRepresentationPersistenceService representationPersistenceService) {
+            List<IDeckEventHandler> deckEventHandlers, IRepresentationPersistenceStrategy representationPersistenceStrategy) {
         this.representationSearchService = Objects.requireNonNull(representationSearchService);
         this.deckCreationService = Objects.requireNonNull(deckCreationService);
         this.subscriptionManagerFactory = Objects.requireNonNull(subscriptionManagerFactory);
         this.deckEventHandlers = Objects.requireNonNull(deckEventHandlers);
-        this.representationPersistenceService = Objects.requireNonNull(representationPersistenceService);
+        this.representationPersistenceStrategy = Objects.requireNonNull(representationPersistenceStrategy);
     }
 
     @Override
@@ -67,7 +67,7 @@ public class DeckEventProcessorFactory implements IRepresentationEventProcessorF
             DeckContext deckContext = new DeckContext(deck);
 
             IRepresentationEventProcessor deckEventProcessor = new DeckEventProcessor(editingContext, this.subscriptionManagerFactory.create(), this.deckCreationService, this.deckEventHandlers,
-                    deckContext, this.representationPersistenceService, this.representationSearchService);
+                    deckContext, this.representationPersistenceStrategy, this.representationSearchService);
 
             return Optional.of(deckEventProcessor);
         }

--- a/packages/diagrams/backend/sirius-components-collaborative-diagrams/src/main/java/org/eclipse/sirius/components/collaborative/diagrams/DiagramCreationService.java
+++ b/packages/diagrams/backend/sirius-components-collaborative-diagrams/src/main/java/org/eclipse/sirius/components/collaborative/diagrams/DiagramCreationService.java
@@ -106,7 +106,7 @@ public class DiagramCreationService implements IDiagramCreationService {
                 .map(DiagramDescription.class::cast)
                 .toList();
 
-        return this.doRender(targetObject, editingContext, diagramDescription, allDiagramDescriptions, Optional.empty());
+        return this.doRender(targetObject, editingContext, diagramDescription, allDiagramDescriptions, null);
     }
 
     @Override
@@ -118,8 +118,7 @@ public class DiagramCreationService implements IDiagramCreationService {
                 .filter(DiagramDescription.class::isInstance)
                 .map(DiagramDescription.class::cast);
 
-        var allDiagramDescriptions = this.representationDescriptionSearchService.findAll(editingContext)
-                .values()
+        var allDiagramDescriptions = this.representationDescriptionSearchService.findAll(editingContext).values()
                 .stream()
                 .filter(DiagramDescription.class::isInstance)
                 .map(DiagramDescription.class::cast)
@@ -128,7 +127,7 @@ public class DiagramCreationService implements IDiagramCreationService {
         if (optionalObject.isPresent() && optionalDiagramDescription.isPresent()) {
             Object object = optionalObject.get();
             DiagramDescription diagramDescription = optionalDiagramDescription.get();
-            Diagram diagram = this.doRender(object, editingContext, diagramDescription, allDiagramDescriptions, Optional.of(diagramContext));
+            Diagram diagram = this.doRender(object, editingContext, diagramDescription, allDiagramDescriptions, diagramContext);
 
             for (var diagramPostProcessor : this.diagramPostProcessors) {
                 DiagramContext currentDiagramContext = new DiagramContext(diagram);
@@ -136,15 +135,14 @@ public class DiagramCreationService implements IDiagramCreationService {
                     diagram = diagramPostProcessor.postProcess(editingContext, currentDiagramContext).orElse(diagram);
                 }
             }
-
             return Optional.of(diagram);
         }
         return Optional.empty();
     }
 
-    private Diagram doRender(Object targetObject, IEditingContext editingContext, DiagramDescription diagramDescription, List<DiagramDescription> allDiagramDescriptions, Optional<DiagramContext> optionalDiagramContext) {
+    private Diagram doRender(Object targetObject, IEditingContext editingContext, DiagramDescription diagramDescription, List<DiagramDescription> allDiagramDescriptions, DiagramContext diagramContext) {
         long start = System.currentTimeMillis();
-
+        var optionalDiagramContext = Optional.ofNullable(diagramContext);
         VariableManager variableManager = new VariableManager();
         variableManager.put(VariableManager.SELF, targetObject);
         variableManager.put(IEditingContext.EDITING_CONTEXT, editingContext);

--- a/packages/diagrams/backend/sirius-components-collaborative-diagrams/src/main/java/org/eclipse/sirius/components/collaborative/diagrams/DiagramEventProcessorParameters.java
+++ b/packages/diagrams/backend/sirius-components-collaborative-diagrams/src/main/java/org/eclipse/sirius/components/collaborative/diagrams/DiagramEventProcessorParameters.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 Obeo.
+ * Copyright (c) 2023, 2026 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -15,7 +15,7 @@ package org.eclipse.sirius.components.collaborative.diagrams;
 import java.util.List;
 import java.util.Objects;
 
-import org.eclipse.sirius.components.collaborative.api.IRepresentationPersistenceService;
+import org.eclipse.sirius.components.collaborative.api.IRepresentationPersistenceStrategy;
 import org.eclipse.sirius.components.collaborative.api.IRepresentationRefreshPolicyRegistry;
 import org.eclipse.sirius.components.collaborative.api.IRepresentationSearchService;
 import org.eclipse.sirius.components.collaborative.api.ISubscriptionManager;
@@ -44,7 +44,7 @@ public record DiagramEventProcessorParameters(
         IDiagramCreationService diagramCreationService,
         IRepresentationDescriptionSearchService representationDescriptionSearchService,
         IRepresentationRefreshPolicyRegistry representationRefreshPolicyRegistry,
-        IRepresentationPersistenceService representationPersistenceService,
+        IRepresentationPersistenceStrategy representationPersistenceStrategy,
         IRepresentationSearchService representationSearchService,
         List<IDiagramInputReferencePositionProvider> diagramInputReferencePositionProviders,
         List<IDiagramEventConsumer> diagramEventConsumers
@@ -57,8 +57,8 @@ public record DiagramEventProcessorParameters(
         Objects.requireNonNull(subscriptionManager);
         Objects.requireNonNull(diagramCreationService);
         Objects.requireNonNull(representationDescriptionSearchService);
+        Objects.requireNonNull(representationPersistenceStrategy);
         Objects.requireNonNull(representationRefreshPolicyRegistry);
-        Objects.requireNonNull(representationPersistenceService);
         Objects.requireNonNull(representationSearchService);
         Objects.requireNonNull(diagramInputReferencePositionProviders);
         Objects.requireNonNull(diagramEventConsumers);
@@ -91,7 +91,7 @@ public record DiagramEventProcessorParameters(
 
         private IRepresentationRefreshPolicyRegistry representationRefreshPolicyRegistry;
 
-        private IRepresentationPersistenceService representationPersistenceService;
+        private IRepresentationPersistenceStrategy representationPersistenceStrategy;
 
         private IRepresentationSearchService representationSearchService;
 
@@ -138,8 +138,8 @@ public record DiagramEventProcessorParameters(
             return this;
         }
 
-        public Builder representationPersistenceService(IRepresentationPersistenceService representationPersistenceService) {
-            this.representationPersistenceService = Objects.requireNonNull(representationPersistenceService);
+        public Builder representationPersistenceStrategy(IRepresentationPersistenceStrategy representationPersistenceStrategy) {
+            this.representationPersistenceStrategy = Objects.requireNonNull(representationPersistenceStrategy);
             return this;
         }
 
@@ -167,7 +167,7 @@ public record DiagramEventProcessorParameters(
                     this.diagramCreationService,
                     this.representationDescriptionSearchService,
                     this.representationRefreshPolicyRegistry,
-                    this.representationPersistenceService,
+                    this.representationPersistenceStrategy,
                     this.representationSearchService,
                     this.diagramInputReferencePositionProviders,
                     this.diagramEventConsumers

--- a/packages/diagrams/backend/sirius-components-collaborative-diagrams/src/test/java/org/eclipse/sirius/components/collaborative/diagrams/DiagramEventProcessorTests.java
+++ b/packages/diagrams/backend/sirius-components-collaborative-diagrams/src/test/java/org/eclipse/sirius/components/collaborative/diagrams/DiagramEventProcessorTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2025 Obeo.
+ * Copyright (c) 2022, 2026 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -18,7 +18,7 @@ import java.util.function.Predicate;
 
 import org.eclipse.sirius.components.collaborative.api.ChangeDescription;
 import org.eclipse.sirius.components.collaborative.api.ChangeKind;
-import org.eclipse.sirius.components.collaborative.api.IRepresentationPersistenceService;
+import org.eclipse.sirius.components.collaborative.api.IRepresentationPersistenceStrategy;
 import org.eclipse.sirius.components.collaborative.api.IRepresentationRefreshPolicyRegistry;
 import org.eclipse.sirius.components.collaborative.api.IRepresentationSearchService;
 import org.eclipse.sirius.components.collaborative.diagrams.api.IDiagramCreationService;
@@ -148,7 +148,7 @@ public class DiagramEventProcessorTests {
                 .representationDescriptionSearchService(new IRepresentationDescriptionSearchService.NoOp())
                 .representationRefreshPolicyRegistry(new IRepresentationRefreshPolicyRegistry.NoOp())
                 .representationSearchService(new IRepresentationSearchService.NoOp())
-                .representationPersistenceService(new IRepresentationPersistenceService.NoOp())
+                .representationPersistenceStrategy(new IRepresentationPersistenceStrategy.NoOp())
                 .diagramEventConsumers(List.of())
                 .diagramInputReferencePositionProviders(List.of())
                 .build();

--- a/packages/gantt/backend/sirius-components-collaborative-gantt/src/main/java/org/eclipse/sirius/components/collaborative/gantt/GanttEventProcessor.java
+++ b/packages/gantt/backend/sirius-components-collaborative-gantt/src/main/java/org/eclipse/sirius/components/collaborative/gantt/GanttEventProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 Obeo.
+ * Copyright (c) 2023, 2026 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -18,7 +18,7 @@ import java.util.Optional;
 
 import org.eclipse.sirius.components.collaborative.api.ChangeDescription;
 import org.eclipse.sirius.components.collaborative.api.ChangeKind;
-import org.eclipse.sirius.components.collaborative.api.IRepresentationPersistenceService;
+import org.eclipse.sirius.components.collaborative.api.IRepresentationPersistenceStrategy;
 import org.eclipse.sirius.components.collaborative.api.IRepresentationSearchService;
 import org.eclipse.sirius.components.collaborative.api.ISubscriptionManager;
 import org.eclipse.sirius.components.collaborative.gantt.api.IGanttEventHandler;
@@ -54,7 +54,7 @@ public class GanttEventProcessor implements IGanttEventProcessor {
 
     private final GanttCreationService ganttCreationService;
 
-    private final IRepresentationPersistenceService representationPersistenceService;
+    private final IRepresentationPersistenceStrategy representationPersistenceStrategy;
 
     private final GanttContext ganttContext;
 
@@ -66,7 +66,7 @@ public class GanttEventProcessor implements IGanttEventProcessor {
 
     public GanttEventProcessor(IEditingContext editingContext, ISubscriptionManager subscriptionManager, GanttCreationService ganttCreationService,
             IRepresentationSearchService representationSearchService, List<IGanttEventHandler> ganttEventHandlers, GanttContext ganttContext,
-            IRepresentationPersistenceService representationPersistenceService) {
+            IRepresentationPersistenceStrategy representationPersistenceStrategy) {
         this.logger.trace("Creating the gantt event processor {}", ganttContext.getGantt().getId());
 
         this.editingContext = Objects.requireNonNull(editingContext);
@@ -74,7 +74,7 @@ public class GanttEventProcessor implements IGanttEventProcessor {
         this.ganttCreationService = Objects.requireNonNull(ganttCreationService);
         this.ganttEventHandlers = Objects.requireNonNull(ganttEventHandlers);
         this.ganttContext = Objects.requireNonNull(ganttContext);
-        this.representationPersistenceService = Objects.requireNonNull(representationPersistenceService);
+        this.representationPersistenceStrategy = Objects.requireNonNull(representationPersistenceStrategy);
         this.representationSearchService = Objects.requireNonNull(representationSearchService);
 
         // We automatically refresh the representation before using it since things may have changed since the moment it
@@ -122,7 +122,7 @@ public class GanttEventProcessor implements IGanttEventProcessor {
             this.ganttContext.update(refreshedGanttRepresentation);
 
             if (refreshedGanttRepresentation != null) {
-                this.representationPersistenceService.save(changeDescription.getInput(), this.editingContext, refreshedGanttRepresentation);
+                this.representationPersistenceStrategy.applyPersistenceStrategy(changeDescription.getInput(), this.editingContext, refreshedGanttRepresentation);
                 this.logger.trace("Gantt refreshed: {}", ganttId);
             } else {
                 this.logger.warn("Gantt refresh failed: {}", ganttId);

--- a/packages/gantt/backend/sirius-components-collaborative-gantt/src/main/java/org/eclipse/sirius/components/collaborative/gantt/GanttEventProcessorFactory.java
+++ b/packages/gantt/backend/sirius-components-collaborative-gantt/src/main/java/org/eclipse/sirius/components/collaborative/gantt/GanttEventProcessorFactory.java
@@ -18,7 +18,7 @@ import java.util.Optional;
 
 import org.eclipse.sirius.components.collaborative.api.IRepresentationEventProcessor;
 import org.eclipse.sirius.components.collaborative.api.IRepresentationEventProcessorFactory;
-import org.eclipse.sirius.components.collaborative.api.IRepresentationPersistenceService;
+import org.eclipse.sirius.components.collaborative.api.IRepresentationPersistenceStrategy;
 import org.eclipse.sirius.components.collaborative.api.IRepresentationSearchService;
 import org.eclipse.sirius.components.collaborative.api.ISubscriptionManagerFactory;
 import org.eclipse.sirius.components.collaborative.gantt.api.IGanttEventHandler;
@@ -43,15 +43,15 @@ public class GanttEventProcessorFactory implements IRepresentationEventProcessor
 
     private final List<IGanttEventHandler> ganttEventHandlers;
 
-    private final IRepresentationPersistenceService representationPersistenceService;
+    private final IRepresentationPersistenceStrategy representationPersistenceStrategy;
 
     public GanttEventProcessorFactory(IRepresentationSearchService representationSearchService, GanttCreationService ganttCreationService, ISubscriptionManagerFactory subscriptionManagerFactory,
-            List<IGanttEventHandler> ganttEventHandlers, IRepresentationPersistenceService representationPersistenceService) {
+            List<IGanttEventHandler> ganttEventHandlers, IRepresentationPersistenceStrategy representationPersistenceStrategy) {
         this.representationSearchService = Objects.requireNonNull(representationSearchService);
         this.ganttCreationService = Objects.requireNonNull(ganttCreationService);
         this.subscriptionManagerFactory = Objects.requireNonNull(subscriptionManagerFactory);
         this.ganttEventHandlers = Objects.requireNonNull(ganttEventHandlers);
-        this.representationPersistenceService = Objects.requireNonNull(representationPersistenceService);
+        this.representationPersistenceStrategy = Objects.requireNonNull(representationPersistenceStrategy);
     }
 
     @Override
@@ -66,7 +66,7 @@ public class GanttEventProcessorFactory implements IRepresentationEventProcessor
             GanttContext ganttContext = new GanttContext(optionalGantt.get());
 
             IRepresentationEventProcessor ganttEventProcessor = new GanttEventProcessor(editingContext, this.subscriptionManagerFactory.create(), this.ganttCreationService,
-                    this.representationSearchService, this.ganttEventHandlers, ganttContext, this.representationPersistenceService);
+                    this.representationSearchService, this.ganttEventHandlers, ganttContext, this.representationPersistenceStrategy);
 
             return Optional.of(ganttEventProcessor);
         }

--- a/packages/portals/backend/sirius-components-collaborative-portals/src/main/java/org/eclipse/sirius/components/collaborative/portals/PortalEventProcessor.java
+++ b/packages/portals/backend/sirius-components-collaborative-portals/src/main/java/org/eclipse/sirius/components/collaborative/portals/PortalEventProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 Obeo.
+ * Copyright (c) 2023, 2026 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -19,7 +19,7 @@ import java.util.Optional;
 import org.eclipse.sirius.components.collaborative.api.ChangeDescription;
 import org.eclipse.sirius.components.collaborative.api.ChangeDescriptionParameters;
 import org.eclipse.sirius.components.collaborative.api.ChangeKind;
-import org.eclipse.sirius.components.collaborative.api.IRepresentationPersistenceService;
+import org.eclipse.sirius.components.collaborative.api.IRepresentationPersistenceStrategy;
 import org.eclipse.sirius.components.collaborative.api.IRepresentationSearchService;
 import org.eclipse.sirius.components.collaborative.api.ISubscriptionManager;
 import org.eclipse.sirius.components.collaborative.portals.api.IPortalEventHandler;
@@ -35,6 +35,7 @@ import org.eclipse.sirius.components.portals.Portal;
 import org.eclipse.sirius.components.representations.IRepresentation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.Sinks;
@@ -55,7 +56,7 @@ public class PortalEventProcessor implements IPortalEventProcessor {
 
     private final IRepresentationSearchService representationSearchService;
 
-    private final IRepresentationPersistenceService representationPersistenceService;
+    private final IRepresentationPersistenceStrategy representationPersistenceStrategy;
 
     private final List<IPortalEventHandler> portalEventHandlers;
 
@@ -65,11 +66,11 @@ public class PortalEventProcessor implements IPortalEventProcessor {
 
     private final Many<IPayload> sink = Sinks.many().multicast().directBestEffort();
 
-    public PortalEventProcessor(IEditingContext editingContext, IRepresentationSearchService representationSearchService, IRepresentationPersistenceService representationPersistenceService,
+    public PortalEventProcessor(IEditingContext editingContext, IRepresentationSearchService representationSearchService, IRepresentationPersistenceStrategy representationPersistenceStrategy,
             List<IPortalEventHandler> portalEventHandlers, ISubscriptionManager subscriptionManager, Portal portal) {
         this.editingContext = Objects.requireNonNull(editingContext);
         this.representationSearchService = Objects.requireNonNull(representationSearchService);
-        this.representationPersistenceService = Objects.requireNonNull(representationPersistenceService);
+        this.representationPersistenceStrategy = Objects.requireNonNull(representationPersistenceStrategy);
         this.portalEventHandlers = Objects.requireNonNull(portalEventHandlers);
         this.subscriptionManager = Objects.requireNonNull(subscriptionManager);
         this.currentPortal = Objects.requireNonNull(portal);
@@ -103,7 +104,7 @@ public class PortalEventProcessor implements IPortalEventProcessor {
 
     private void updatePortal(IInput input, Portal newPortal) {
         this.currentPortal = newPortal;
-        this.representationPersistenceService.save(input, this.editingContext, this.currentPortal);
+        this.representationPersistenceStrategy.applyPersistenceStrategy(input, this.editingContext, this.currentPortal);
         this.emitNewPortal(input);
     }
 

--- a/packages/portals/backend/sirius-components-collaborative-portals/src/main/java/org/eclipse/sirius/components/collaborative/portals/PortalEventProcessorFactory.java
+++ b/packages/portals/backend/sirius-components-collaborative-portals/src/main/java/org/eclipse/sirius/components/collaborative/portals/PortalEventProcessorFactory.java
@@ -18,7 +18,7 @@ import java.util.Optional;
 
 import org.eclipse.sirius.components.collaborative.api.IRepresentationEventProcessor;
 import org.eclipse.sirius.components.collaborative.api.IRepresentationEventProcessorFactory;
-import org.eclipse.sirius.components.collaborative.api.IRepresentationPersistenceService;
+import org.eclipse.sirius.components.collaborative.api.IRepresentationPersistenceStrategy;
 import org.eclipse.sirius.components.collaborative.api.IRepresentationSearchService;
 import org.eclipse.sirius.components.collaborative.api.ISubscriptionManagerFactory;
 import org.eclipse.sirius.components.collaborative.portals.api.IPortalEventHandler;
@@ -35,16 +35,16 @@ import org.springframework.stereotype.Service;
 public class PortalEventProcessorFactory implements IRepresentationEventProcessorFactory {
     private final IRepresentationSearchService representationSearchService;
 
-    private final IRepresentationPersistenceService representationPersistenceService;
+    private final IRepresentationPersistenceStrategy representationPersistenceStrategy;
 
     private final ISubscriptionManagerFactory subscriptionManagerFactory;
 
     private final List<IPortalEventHandler> portalEventHandlers;
 
-    public PortalEventProcessorFactory(IRepresentationSearchService representationSearchService, IRepresentationPersistenceService representationPersistenceService,
+    public PortalEventProcessorFactory(IRepresentationSearchService representationSearchService, IRepresentationPersistenceStrategy representationPersistenceStrategy,
             ISubscriptionManagerFactory subscriptionManagerFactory, List<IPortalEventHandler> portalEventHandlers) {
         this.representationSearchService = Objects.requireNonNull(representationSearchService);
-        this.representationPersistenceService = Objects.requireNonNull(representationPersistenceService);
+        this.representationPersistenceStrategy = Objects.requireNonNull(representationPersistenceStrategy);
         this.subscriptionManagerFactory = Objects.requireNonNull(subscriptionManagerFactory);
         this.portalEventHandlers = Objects.requireNonNull(portalEventHandlers);
     }
@@ -59,7 +59,7 @@ public class PortalEventProcessorFactory implements IRepresentationEventProcesso
         var optionalPortal = this.representationSearchService.findById(editingContext, representationId, Portal.class);
         if (optionalPortal.isPresent()) {
             Portal portal = optionalPortal.get();
-            var portalEventProcessor = new PortalEventProcessor(editingContext, this.representationSearchService, this.representationPersistenceService, this.portalEventHandlers, this.subscriptionManagerFactory.create(), portal);
+            var portalEventProcessor = new PortalEventProcessor(editingContext, this.representationSearchService, this.representationPersistenceStrategy, this.portalEventHandlers, this.subscriptionManagerFactory.create(), portal);
             return Optional.of(portalEventProcessor);
         }
 

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/object/services/DefaultContentService.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/object/services/DefaultContentService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024, 2025 Obeo.
+ * Copyright (c) 2024, 2026 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -15,19 +15,24 @@ package org.eclipse.sirius.web.application.object.services;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 import org.eclipse.emf.common.notify.Adapter;
 import org.eclipse.emf.common.notify.AdapterFactory;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.eclipse.emf.edit.domain.EditingDomain;
 import org.eclipse.emf.edit.provider.ComposedAdapterFactory;
 import org.eclipse.emf.edit.provider.ComposedAdapterFactory.Descriptor;
 import org.eclipse.emf.edit.provider.IEditingDomainItemProvider;
 import org.eclipse.sirius.components.core.api.IDefaultContentService;
+import org.eclipse.sirius.components.core.api.IEditingContext;
+import org.eclipse.sirius.components.emf.services.api.IEMFEditingContext;
 import org.springframework.stereotype.Service;
 
 /**
- * Default implementation of {@link IDefaultContentService}.
+ * Default implementation of {@link IDefaultContentService}. 
  *
  * @author mcharfadi
  */
@@ -59,6 +64,14 @@ public class DefaultContentService implements IDefaultContentService {
         else if (object instanceof Resource resource) {
             // The object may be a document
             contents.addAll(resource.getContents());
+        } else if (object instanceof IEditingContext editingContext) {
+            Optional.of(editingContext)
+                    .filter(IEMFEditingContext.class::isInstance)
+                    .map(IEMFEditingContext.class::cast)
+                    .map(IEMFEditingContext::getDomain)
+                    .map(EditingDomain::getResourceSet)
+                    .map(ResourceSet::getResources)
+                    .ifPresent(contents::addAll);
         }
         return contents;
     }

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/project/services/DiagramImporterUpdateService.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/project/services/DiagramImporterUpdateService.java
@@ -133,13 +133,13 @@ public class DiagramImporterUpdateService implements IRepresentationImporterUpda
         Diagram oldRepresentation = (Diagram) representationImportData.representation();
         var editingContext = this.editingContextSearchService.findById(editingContextId);
         if (editingContext.isPresent()) {
-            var newRepresentation = this.representationSearchService.findById(editingContext.get(), newRepresentationId, Diagram.class);
+            var optionalNewRepresentation = this.representationSearchService.findById(editingContext.get(), newRepresentationId, Diagram.class);
             var diagramDescription = this.representationDescriptionSearchService.findById(editingContext.get(), oldRepresentation.getDescriptionId())
                     .filter(DiagramDescription.class::isInstance)
                     .map(DiagramDescription.class::cast);
 
-            if (diagramDescription.isPresent() && newRepresentation.isPresent()) {
-                var diagramContext = new DiagramContext(newRepresentation.get());
+            if (diagramDescription.isPresent() && optionalNewRepresentation.isPresent()) {
+                var diagramContext = new DiagramContext(optionalNewRepresentation.get());
                 Map<String, String> nodeElementOldNewIds = new HashMap<>();
                 Map<String, String> edgeElementOldNewIds = new HashMap<>();
                 Map<String, String> labelElementOldNewIds = new HashMap<>();

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/representation/services/RepresentationPersistenceStrategy.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/representation/services/RepresentationPersistenceStrategy.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.application.representation.services;
+
+import java.util.Objects;
+
+import org.eclipse.sirius.components.collaborative.api.IRepresentationPersistenceStrategy;
+import org.eclipse.sirius.components.core.api.IEditingContext;
+import org.eclipse.sirius.components.events.ICause;
+import org.eclipse.sirius.components.representations.IRepresentation;
+import org.eclipse.sirius.web.application.UUIDParser;
+import org.eclipse.sirius.web.domain.boundedcontexts.representationdata.services.api.IRepresentationContentSearchService;
+import org.springframework.data.jdbc.core.mapping.AggregateReference;
+import org.springframework.stereotype.Service;
+
+/**
+ * Default implementation of {@link org.eclipse.sirius.components.collaborative.api.IRepresentationPersistenceStrategy}.
+ *
+ * @author fbarbin
+ */
+@Service
+public class RepresentationPersistenceStrategy implements IRepresentationPersistenceStrategy {
+
+    private final IRepresentationContentSearchService representationContentSearchService;
+
+    private final RepresentationPersistenceService representationPersistenceService;
+
+    public RepresentationPersistenceStrategy(IRepresentationContentSearchService representationContentSearchService, RepresentationPersistenceService representationPersistenceService) {
+        this.representationContentSearchService = Objects.requireNonNull(representationContentSearchService);
+        this.representationPersistenceService = Objects.requireNonNull(representationPersistenceService);
+    }
+
+    @Override
+    public void applyPersistenceStrategy(ICause cause, IEditingContext editingContext, IRepresentation representation) {
+        var optionalSemanticDataId = new UUIDParser().parse(editingContext.getId());
+        var optionalRepresentationId = new UUIDParser().parse(representation.getId());
+        if (optionalSemanticDataId.isPresent() && optionalRepresentationId.isPresent()) {
+            var semanticDataId = optionalSemanticDataId.get();
+            var representationId = optionalRepresentationId.get();
+            var exists = this.representationContentSearchService.existsById(AggregateReference.to(semanticDataId), AggregateReference.to(representationId));
+            if (exists) {
+                // Delegate to the real persistence service which will perform the save.
+                this.representationPersistenceService.save(cause, editingContext, representation);
+            }
+        }
+    }
+
+}

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/studio/services/representations/DomainExplorerServices.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/studio/services/representations/DomainExplorerServices.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024, 2025 Obeo.
+ * Copyright (c) 2024, 2026 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -101,9 +101,13 @@ public class DomainExplorerServices {
 
     public List<Object> getElements(IEditingContext editingContext) {
         List<Object> elements = new ArrayList<>();
-        this.explorerServices.getDefaultElements(editingContext).stream()
+        this.contentService.getContents(editingContext).stream()
+                .filter(Resource.class::isInstance)
+                .map(Resource.class::cast)
                 .filter(resource -> resource.getContents().stream().anyMatch(Domain.class::isInstance))
                 .forEach(elements::add);
+        //We sort the elements as it was done by the former IExplorerServices#getDefaultElements service.
+        elements.sort(Comparator.nullsLast(Comparator.comparing(resource -> this.labelService.getStyledLabel(resource).toString(), String.CASE_INSENSITIVE_ORDER)));
         return elements;
     }
 

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/views/explorer/services/ComposedExplorerContentService.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/views/explorer/services/ComposedExplorerContentService.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.application.views.explorer.services;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.eclipse.sirius.components.core.api.IEditingContext;
+import org.eclipse.sirius.web.application.views.explorer.services.api.IDefaultExplorerContentService;
+import org.eclipse.sirius.web.application.views.explorer.services.api.IExplorerContentService;
+import org.eclipse.sirius.web.application.views.explorer.services.api.IExplorerContentServiceDelegate;
+import org.springframework.stereotype.Service;
+
+/**
+ * Used to compute the content of the explorer.
+ *
+ * @author sbegaudeau
+ */
+@Service
+public class ComposedExplorerContentService implements IExplorerContentService {
+
+    private final IDefaultExplorerContentService defaultExplorerContentService;
+
+    private final List<IExplorerContentServiceDelegate> explorerContentServiceDelegates;
+
+    public ComposedExplorerContentService(IDefaultExplorerContentService defaultExplorerContentService, List<IExplorerContentServiceDelegate> explorerContentServiceDelegates) {
+        this.defaultExplorerContentService = Objects.requireNonNull(defaultExplorerContentService);
+        this.explorerContentServiceDelegates = Objects.requireNonNull(explorerContentServiceDelegates);
+    }
+
+    @Override
+    public List<Object> getContents(IEditingContext editingContext) {
+        return this.explorerContentServiceDelegates.stream()
+                .filter(delegate -> delegate.canHandle(editingContext))
+                .findFirst()
+                .map(delegate -> delegate.getContents(editingContext))
+                .orElseGet(() -> this.defaultExplorerContentService.getContents(editingContext));
+    }
+}

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/views/explorer/services/DefaultExplorerContentService.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/views/explorer/services/DefaultExplorerContentService.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.application.views.explorer.services;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.eclipse.emf.edit.domain.EditingDomain;
+import org.eclipse.sirius.components.core.api.IEditingContext;
+import org.eclipse.sirius.components.core.api.ILabelService;
+import org.eclipse.sirius.components.emf.services.api.IEMFEditingContext;
+import org.eclipse.sirius.web.application.views.explorer.services.api.IDefaultExplorerContentService;
+import org.springframework.stereotype.Service;
+
+/**
+ * The default implementation used to compute the content of the explorer.
+ *
+ * @author sbegaudeau
+ */
+@Service
+public class DefaultExplorerContentService implements IDefaultExplorerContentService {
+
+    private final ILabelService labelService;
+
+    public DefaultExplorerContentService(ILabelService labelService) {
+        this.labelService = Objects.requireNonNull(labelService);
+    }
+
+    @Override
+    public List<Object> getContents(IEditingContext editingContext) {
+        var optionalResourceSet = Optional.ofNullable(editingContext)
+                .filter(IEMFEditingContext.class::isInstance)
+                .map(IEMFEditingContext.class::cast)
+                .map(IEMFEditingContext::getDomain)
+                .map(EditingDomain::getResourceSet);
+
+        return optionalResourceSet
+                .map(resourceSet -> resourceSet.getResources().stream()
+                        .sorted(Comparator.nullsLast(Comparator.comparing(resource -> this.labelService.getStyledLabel(resource).toString(), String.CASE_INSENSITIVE_ORDER)))
+                        .map(Object.class::cast)
+                        .toList())
+                .orElseGet(ArrayList::new);
+    }
+}

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/views/explorer/services/ExplorerElementsProvider.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/views/explorer/services/ExplorerElementsProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Obeo.
+ * Copyright (c) 2024, 2026 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -17,12 +17,11 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
-import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.sirius.components.core.api.IEditingContext;
 import org.eclipse.sirius.components.representations.VariableManager;
 import org.eclipse.sirius.components.trees.renderer.TreeRenderer;
+import org.eclipse.sirius.web.application.views.explorer.services.api.IExplorerContentService;
 import org.eclipse.sirius.web.application.views.explorer.services.api.IExplorerElementsProvider;
-import org.eclipse.sirius.web.application.views.explorer.services.api.IExplorerServices;
 import org.eclipse.sirius.web.application.views.explorer.services.api.IExplorerTreeAlteredContentProvider;
 import org.springframework.stereotype.Service;
 
@@ -36,11 +35,11 @@ public class ExplorerElementsProvider implements IExplorerElementsProvider {
 
     private final List<IExplorerTreeAlteredContentProvider> alteredContentProviders;
 
-    private final IExplorerServices explorerServices;
+    private final IExplorerContentService explorerContentService;
 
-    public ExplorerElementsProvider(List<IExplorerTreeAlteredContentProvider> alteredContentProviders, IExplorerServices explorerServices) {
+    public ExplorerElementsProvider(List<IExplorerTreeAlteredContentProvider> alteredContentProviders, IExplorerContentService explorerContentService) {
         this.alteredContentProviders = Objects.requireNonNull(alteredContentProviders);
-        this.explorerServices = Objects.requireNonNull(explorerServices);
+        this.explorerContentService = Objects.requireNonNull(explorerContentService);
     }
 
     @Override
@@ -62,9 +61,13 @@ public class ExplorerElementsProvider implements IExplorerElementsProvider {
         return elements;
     }
 
-    private List<Resource> getDefaultElements(VariableManager variableManager) {
+    private List<Object> getDefaultElements(VariableManager variableManager) {
         Optional<IEditingContext> optionalEditingContext = variableManager.get(IEditingContext.EDITING_CONTEXT, IEditingContext.class);
-        return this.explorerServices.getDefaultElements(optionalEditingContext.orElse(null));
+        if (optionalEditingContext.isPresent()) {
+            var editingContext = optionalEditingContext.get();
+            return this.explorerContentService.getContents(editingContext);
+        }
+        return List.of();
     }
 
     private List<String> getActiveFilterIds(VariableManager variableManager) {

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/views/explorer/services/ExplorerServices.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/views/explorer/services/ExplorerServices.java
@@ -23,12 +23,10 @@ import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.ResourceSet;
-import org.eclipse.emf.edit.domain.EditingDomain;
 import org.eclipse.sirius.components.core.api.IContentService;
 import org.eclipse.sirius.components.core.api.IDefaultObjectSearchService;
 import org.eclipse.sirius.components.core.api.IEditingContext;
 import org.eclipse.sirius.components.core.api.IIdentityService;
-import org.eclipse.sirius.components.core.api.ILabelService;
 import org.eclipse.sirius.components.core.api.IObjectSearchService;
 import org.eclipse.sirius.components.core.api.IReadOnlyObjectPredicate;
 import org.eclipse.sirius.components.emf.services.JSONResourceFactory;
@@ -54,18 +52,15 @@ public class ExplorerServices implements IExplorerServices {
 
     private final IContentService contentService;
 
-    private final ILabelService labelService;
-
     private final IRepresentationMetadataSearchService representationMetadataSearchService;
 
     private final IReadOnlyObjectPredicate readOnlyObjectPredicate;
 
     private final IDefaultObjectSearchService defaultObjectSearchService;
 
-    public ExplorerServices(IIdentityService identityService, IObjectSearchService objectSearchService, ILabelService labelService, IContentService contentService, IRepresentationMetadataSearchService representationMetadataSearchService, IReadOnlyObjectPredicate readOnlyObjectPredicate, IDefaultObjectSearchService defaultObjectSearchService) {
+    public ExplorerServices(IIdentityService identityService, IObjectSearchService objectSearchService, IContentService contentService, IRepresentationMetadataSearchService representationMetadataSearchService, IReadOnlyObjectPredicate readOnlyObjectPredicate, IDefaultObjectSearchService defaultObjectSearchService) {
         this.identityService = Objects.requireNonNull(identityService);
         this.objectSearchService = Objects.requireNonNull(objectSearchService);
-        this.labelService = Objects.requireNonNull(labelService);
         this.contentService = Objects.requireNonNull(contentService);
         this.representationMetadataSearchService = Objects.requireNonNull(representationMetadataSearchService);
         this.readOnlyObjectPredicate = Objects.requireNonNull(readOnlyObjectPredicate);
@@ -210,21 +205,4 @@ public class ExplorerServices implements IExplorerServices {
     private Stream<RepresentationMetadata> findRepresentationsForTargetObjectId(List<RepresentationMetadata> existingRepresentations, String targetObjectd) {
         return existingRepresentations.stream().filter(representationMetadata -> representationMetadata.getTargetObjectId().equals(targetObjectd));
     }
-
-    @Override
-    public List<Resource> getDefaultElements(IEditingContext editingContext) {
-        var optionalResourceSet = Optional.ofNullable(editingContext)
-                .filter(IEMFEditingContext.class::isInstance)
-                .map(IEMFEditingContext.class::cast)
-                .map(IEMFEditingContext::getDomain)
-                .map(EditingDomain::getResourceSet);
-
-        return optionalResourceSet
-                .map(resourceSet -> resourceSet.getResources().stream()
-                        .sorted(Comparator.nullsLast(Comparator.comparing(resource -> this.labelService.getStyledLabel(resource).toString(), String.CASE_INSENSITIVE_ORDER)))
-                        .toList())
-                .orElseGet(ArrayList::new);
-    }
-
-
 }

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/views/explorer/services/api/IDefaultExplorerContentService.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/views/explorer/services/api/IDefaultExplorerContentService.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.application.views.explorer.services.api;
+
+import java.util.List;
+
+import org.eclipse.sirius.components.core.api.IEditingContext;
+
+/**
+ * The default implementation used to compute the content of the explorer.
+ *
+ * @author sbegaudeau
+ * @since v2026.3.0
+ */
+public interface IDefaultExplorerContentService {
+    List<Object> getContents(IEditingContext editingContext);
+}

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/views/explorer/services/api/IExplorerContentService.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/views/explorer/services/api/IExplorerContentService.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.application.views.explorer.services.api;
+
+import java.util.List;
+
+import org.eclipse.sirius.components.core.api.IEditingContext;
+
+/**
+ * Used to compute the content of the explorer.
+ *
+ * @author sbegaudeau
+ * @since v2026.3.0
+ */
+public interface IExplorerContentService {
+    List<Object> getContents(IEditingContext editingContext);
+}

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/views/explorer/services/api/IExplorerContentServiceDelegate.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/views/explorer/services/api/IExplorerContentServiceDelegate.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.application.views.explorer.services.api;
+
+import java.util.List;
+
+import org.eclipse.sirius.components.core.api.IEditingContext;
+
+/**
+ * Used to customize the retrieval of the content of the explorer.
+ *
+ * @author sbegaudeau
+ * @since v2026.3.0
+ */
+public interface IExplorerContentServiceDelegate {
+
+    boolean canHandle(IEditingContext editingContext);
+
+    List<Object> getContents(IEditingContext editingContext);
+}

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/views/explorer/services/api/IExplorerServices.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/views/explorer/services/api/IExplorerServices.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024, 2025 Obeo.
+ * Copyright (c) 2024, 2026 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -14,7 +14,6 @@ package org.eclipse.sirius.web.application.views.explorer.services.api;
 
 import java.util.List;
 
-import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.sirius.components.core.api.IEditingContext;
 import org.eclipse.sirius.web.domain.boundedcontexts.representationdata.RepresentationMetadata;
 
@@ -53,13 +52,4 @@ public interface IExplorerServices {
      * @return the list of children
      */
     List<Object> getDefaultChildren(Object self, IEditingContext editingContext, List<String> expandedIds, List<RepresentationMetadata> existingRepresentations);
-
-    /**
-     * Returns the un-filtered list of root elements.
-     *
-     * @param editingContext
-     *            the editing context
-     * @return the list of root elements
-     */
-    List<Resource> getDefaultElements(IEditingContext editingContext);
 }

--- a/packages/sirius-web/backend/sirius-web-papaya/src/main/java/org/eclipse/sirius/web/papaya/representations/dashboarddiagram/PapayaDashboardDiagramDescriptionProvider.java
+++ b/packages/sirius-web/backend/sirius-web-papaya/src/main/java/org/eclipse/sirius/web/papaya/representations/dashboarddiagram/PapayaDashboardDiagramDescriptionProvider.java
@@ -1,0 +1,166 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.papaya.representations.dashboarddiagram;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.eclipse.emf.edit.domain.EditingDomain;
+import org.eclipse.sirius.components.core.api.IEditingContext;
+import org.eclipse.sirius.components.core.api.IEditingContextRepresentationDescriptionProvider;
+import org.eclipse.sirius.components.core.api.IIdentityService;
+import org.eclipse.sirius.components.diagrams.FreeFormLayoutStrategy;
+import org.eclipse.sirius.components.diagrams.HeaderSeparatorDisplayMode;
+import org.eclipse.sirius.components.diagrams.InsideLabelLocation;
+import org.eclipse.sirius.components.diagrams.LabelOverflowStrategy;
+import org.eclipse.sirius.components.diagrams.LabelTextAlign;
+import org.eclipse.sirius.components.diagrams.LabelVisibility;
+import org.eclipse.sirius.components.diagrams.LineStyle;
+import org.eclipse.sirius.components.diagrams.RectangularNodeStyle;
+import org.eclipse.sirius.components.diagrams.description.DiagramDescription;
+import org.eclipse.sirius.components.diagrams.description.InsideLabelDescription;
+import org.eclipse.sirius.components.diagrams.description.LabelStyleDescription;
+import org.eclipse.sirius.components.diagrams.description.NodeDescription;
+import org.eclipse.sirius.components.emf.services.api.IEMFEditingContext;
+import org.eclipse.sirius.components.papaya.Project;
+import org.eclipse.sirius.components.representations.Failure;
+import org.eclipse.sirius.components.representations.IRepresentationDescription;
+import org.eclipse.sirius.components.representations.VariableManager;
+import org.eclipse.sirius.components.view.emf.diagram.IDiagramIdProvider;
+import org.springframework.stereotype.Service;
+
+/**
+ * Used to provide the view model used to create dashboard diagrams.
+ * The Dashboard diagram is intended to be transient. It can be opened from the specific Dashboard node from the model explorer.
+ *
+ * @author fbarbin
+ */
+@Service
+public class PapayaDashboardDiagramDescriptionProvider implements IEditingContextRepresentationDescriptionProvider {
+
+    public static final String NAME = "PapayaDashboardDiagram";
+
+    public static final String DASHBOARD_REPRESENTATION_ID = UUID.nameUUIDFromBytes("papaya-dashboard-diagram".getBytes()).toString();;
+
+    public static final String DASHBOARD_DESCRIPTION_ID = IDiagramIdProvider.DIAGRAM_DESCRIPTION_KIND + "papaya-dashboard-diagram-description";
+
+    public static final String PROJECT_NODE_DESCRIPTION_ID = UUID.nameUUIDFromBytes("papaya-dashboard-project-node-description".getBytes()).toString();
+
+    private final IIdentityService identityService;
+
+    public PapayaDashboardDiagramDescriptionProvider(IIdentityService identityService) {
+        this.identityService = Objects.requireNonNull(identityService);
+    }
+
+    @Override
+    public List<IRepresentationDescription> getRepresentationDescriptions(IEditingContext editingContext) {
+        var dashboardDescription = DiagramDescription.newDiagramDescription(DASHBOARD_DESCRIPTION_ID)
+            .label("Papaya Dashboard Diagram")
+            .iconURLsProvider(variableManager -> List.of())
+            .nodeDescriptions(List.of(createProjectNodeDescription()))
+            .edgeDescriptions(List.of())
+            .dropHandler(variableManager -> new Failure(""))
+            .canCreatePredicate(variableManager -> false)
+            .labelProvider(variableManager -> "Papaya Dashboard Diagram")
+            .targetObjectIdProvider(this::getDiagramTargetObjectId)
+            .build();
+        return List.of(dashboardDescription);
+    }
+
+    private String getDiagramTargetObjectId(VariableManager variableManager) {
+        return variableManager.get(VariableManager.SELF, IEditingContext.class)
+                .map(IEditingContext::getId)
+                .orElse("");
+    }
+
+    private NodeDescription createProjectNodeDescription() {
+        var nodeStyle = RectangularNodeStyle.newRectangularNodeStyle()
+                .background("#FFFFFF")
+                .borderColor("#000000")
+                .borderSize(1)
+                .borderStyle(LineStyle.Solid)
+                .childrenLayoutStrategy(new FreeFormLayoutStrategy())
+                .build();
+
+        LabelStyleDescription labelStyleDescription = LabelStyleDescription.newLabelStyleDescription()
+                .colorProvider(variableManager -> "#000000")
+                .fontSizeProvider(variableManager -> 16)
+                .boldProvider(variableManager -> false)
+                .italicProvider(variableManager -> false)
+                .underlineProvider(variableManager -> false)
+                .strikeThroughProvider(variableManager -> false)
+                .iconURLProvider(variableManager -> List.of())
+                .backgroundProvider(variableManager -> "transparent")
+                .borderColorProvider(variableManager -> "black")
+                .borderRadiusProvider(variableManager -> 0)
+                .borderSizeProvider(variableManager -> 0)
+                .borderStyleProvider(variableManager -> LineStyle.Solid)
+                .maxWidthProvider(variableManager -> null)
+                .visibilityProvider(variableManager -> LabelVisibility.visible)
+                .build();
+
+        var insideLabelDescription = InsideLabelDescription.newInsideLabelDescription("projectLabel")
+                .textProvider(this::projectNodeTextProvider)
+                .styleDescriptionProvider(variableManager -> labelStyleDescription)
+                .isHeaderProvider(vm -> false)
+                .headerSeparatorDisplayModeProvider(vm -> HeaderSeparatorDisplayMode.NEVER)
+                .insideLabelLocation(InsideLabelLocation.TOP_CENTER)
+                .overflowStrategy(LabelOverflowStrategy.NONE)
+                .textAlign(LabelTextAlign.CENTER)
+                .build();
+
+        return NodeDescription.newNodeDescription(PROJECT_NODE_DESCRIPTION_ID)
+                .typeProvider(variableManager -> "")
+                .semanticElementsProvider(this::projectNodeSemanticElementsProvider)
+                .targetObjectIdProvider(variableManager -> variableManager.get(VariableManager.SELF, Object.class).map(this.identityService::getId).orElse(null))
+                .targetObjectKindProvider(variableManager -> "")
+                .targetObjectLabelProvider(variableManager -> "")
+                .styleProvider(variableManager -> nodeStyle)
+                .insideLabelDescription(insideLabelDescription)
+                .borderNodeDescriptions(new ArrayList<>())
+                .childNodeDescriptions(new ArrayList<>())
+                .initialChildBorderNodePositions(Map.of())
+                .build();
+    }
+
+    private String projectNodeTextProvider(VariableManager variableManager) {
+        return variableManager.get(VariableManager.SELF, Object.class)
+                .filter(Project.class::isInstance)
+                .map(Project.class::cast)
+                .map(Project::getName)
+                .orElse("");
+    }
+
+    private List<?> projectNodeSemanticElementsProvider(VariableManager variableManager) {
+        return variableManager.get(VariableManager.SELF, Object.class)
+                .filter(IEMFEditingContext.class::isInstance)
+                .map(IEMFEditingContext.class::cast)
+                .map(IEMFEditingContext::getDomain)
+                .map(EditingDomain::getResourceSet)
+                .map(ResourceSet::getResources)
+                .stream()
+                .flatMap(Collection::stream)
+                .map(Resource::getContents)
+                .flatMap(Collection::stream)
+                .filter(Project.class::isInstance)
+                .map(Project.class::cast)
+                .toList();
+
+    }
+}

--- a/packages/sirius-web/backend/sirius-web-papaya/src/main/java/org/eclipse/sirius/web/papaya/representations/dashboarddiagram/nodedescriptions/ProjectNodeDescriptionProvider.java
+++ b/packages/sirius-web/backend/sirius-web-papaya/src/main/java/org/eclipse/sirius/web/papaya/representations/dashboarddiagram/nodedescriptions/ProjectNodeDescriptionProvider.java
@@ -1,0 +1,90 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.papaya.representations.dashboarddiagram.nodedescriptions;
+
+import java.util.Objects;
+
+import org.eclipse.sirius.components.view.builder.IViewDiagramElementFinder;
+import org.eclipse.sirius.components.view.builder.generated.diagram.DiagramBuilders;
+import org.eclipse.sirius.components.view.builder.generated.diagram.InsideLabelDescriptionBuilder;
+import org.eclipse.sirius.components.view.builder.providers.IColorProvider;
+import org.eclipse.sirius.components.view.builder.providers.INodeDescriptionProvider;
+import org.eclipse.sirius.components.view.diagram.DiagramDescription;
+import org.eclipse.sirius.components.view.diagram.DiagramFactory;
+import org.eclipse.sirius.components.view.diagram.InsideLabelPosition;
+import org.eclipse.sirius.components.view.diagram.LineStyle;
+import org.eclipse.sirius.components.view.diagram.NodeDescription;
+import org.eclipse.sirius.components.view.diagram.SynchronizationPolicy;
+import org.eclipse.sirius.web.papaya.representations.classdiagram.tools.interfacenode.InterfaceNodePaletteProvider;
+import org.eclipse.sirius.web.papaya.services.PapayaColorPaletteProvider;
+
+/**
+ * Used to create the project node description.
+ *
+ * @author fbarbin
+ */
+public class ProjectNodeDescriptionProvider implements INodeDescriptionProvider {
+
+    public static final String NAME = "ProjectNode";
+
+    private final IColorProvider colorProvider;
+
+    public ProjectNodeDescriptionProvider(IColorProvider colorProvider) {
+        this.colorProvider = Objects.requireNonNull(colorProvider);
+    }
+
+    @Override
+    public NodeDescription create() {
+        var insideLabel = new InsideLabelDescriptionBuilder()
+                .labelExpression("aql:self.name")
+                .style(DiagramFactory.eINSTANCE.createInsideLabelStyle())
+                .position(InsideLabelPosition.TOP_CENTER)
+                .build();
+
+        var childrenLayoutStrategy = new DiagramBuilders().newListLayoutStrategyDescription()
+                .areChildNodesDraggableExpression("aql:false")
+                .build();
+
+        var interfaceNodeStyle = new DiagramBuilders().newRectangularNodeStyleDescription()
+                .background(this.colorProvider.getColor(PapayaColorPaletteProvider.BACKGROUND))
+                .borderColor(this.colorProvider.getColor(PapayaColorPaletteProvider.PRIMARY))
+                .borderSize(1)
+                .borderRadius(0)
+                .borderLineStyle(LineStyle.SOLID)
+                .childrenLayoutStrategy(childrenLayoutStrategy)
+                .build();
+
+        return new DiagramBuilders().newNodeDescription()
+                .name(NAME)
+                .domainType("papaya::Project")
+                .semanticCandidatesExpression("aql:editingContext.getSynchronizedObjects(semanticElementIds)")
+                .insideLabel(insideLabel)
+                .style(interfaceNodeStyle)
+                .synchronizationPolicy(SynchronizationPolicy.UNSYNCHRONIZED)
+                .build();
+    }
+
+    @Override
+    public void link(DiagramDescription diagramDescription, IViewDiagramElementFinder cache) {
+        var optionalInterfaceNodeDescription = cache.getNodeDescription(NAME);
+        if (optionalInterfaceNodeDescription.isPresent()) {
+            var interfaceNodeDescription = optionalInterfaceNodeDescription.get();
+
+            var palette = new InterfaceNodePaletteProvider().getNodePalette(cache);
+            interfaceNodeDescription.setPalette(palette);
+
+            diagramDescription.getNodeDescriptions().add(interfaceNodeDescription);
+        }
+    }
+
+}

--- a/packages/sirius-web/backend/sirius-web-papaya/src/main/java/org/eclipse/sirius/web/papaya/representations/dashboarddiagram/services/PapayaDashboardRepresentationMetadataProvider.java
+++ b/packages/sirius-web/backend/sirius-web-papaya/src/main/java/org/eclipse/sirius/web/papaya/representations/dashboarddiagram/services/PapayaDashboardRepresentationMetadataProvider.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.papaya.representations.dashboarddiagram.services;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.eclipse.sirius.components.core.RepresentationMetadata;
+import org.eclipse.sirius.components.core.api.IRepresentationMetadataProvider;
+import org.eclipse.sirius.components.diagrams.Diagram;
+import org.eclipse.sirius.web.papaya.representations.dashboarddiagram.PapayaDashboardDiagramDescriptionProvider;
+import org.springframework.stereotype.Service;
+
+/**
+ * Provides the Metadata for the transient Papaya dashboard diagram.
+ *
+ * @author fbarbin
+ */
+@Service
+public class PapayaDashboardRepresentationMetadataProvider implements IRepresentationMetadataProvider {
+    @Override
+    public Optional<RepresentationMetadata> getMetadata(String editingContextId, String representationId) {
+        if (PapayaDashboardDiagramDescriptionProvider.DASHBOARD_REPRESENTATION_ID.equals(representationId)) {
+            var representationMetadata = RepresentationMetadata.newRepresentationMetadata(PapayaDashboardDiagramDescriptionProvider.DASHBOARD_REPRESENTATION_ID)
+                    .descriptionId(PapayaDashboardDiagramDescriptionProvider.DASHBOARD_DESCRIPTION_ID)
+                    .kind(Diagram.KIND)
+                    .label(PapayaDashboardDiagramDescriptionProvider.NAME)
+                    .iconURLs(List.of())
+                    .build();
+            return Optional.of(representationMetadata);
+        }
+        return Optional.empty();
+    }
+}

--- a/packages/sirius-web/backend/sirius-web-papaya/src/main/java/org/eclipse/sirius/web/papaya/representations/dashboarddiagram/services/PapayaPaletteProvider.java
+++ b/packages/sirius-web/backend/sirius-web-papaya/src/main/java/org/eclipse/sirius/web/papaya/representations/dashboarddiagram/services/PapayaPaletteProvider.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.papaya.representations.dashboarddiagram.services;
+
+import java.util.List;
+
+import org.eclipse.sirius.components.collaborative.diagrams.DiagramContext;
+import org.eclipse.sirius.components.collaborative.diagrams.api.IPaletteProvider;
+import org.eclipse.sirius.components.collaborative.diagrams.dto.Palette;
+import org.eclipse.sirius.components.core.api.IEditingContext;
+import org.eclipse.sirius.components.diagrams.description.DiagramDescription;
+import org.eclipse.sirius.web.papaya.representations.dashboarddiagram.PapayaDashboardDiagramDescriptionProvider;
+import org.springframework.stereotype.Service;
+
+/**
+ * A specific Palette provider for the Papaya Dashboard diagram.
+ *
+ * @author fbarbin
+ */
+@Service
+public class PapayaPaletteProvider implements IPaletteProvider {
+    @Override
+    public boolean canHandle(IEditingContext editingContext, DiagramContext diagramContext, DiagramDescription diagramDescription, List<String> diagramElementIds) {
+        return PapayaDashboardDiagramDescriptionProvider.DASHBOARD_DESCRIPTION_ID.equals(diagramDescription.getId());
+    }
+
+    @Override
+    public Palette handle(IEditingContext editingContext, DiagramContext diagramContext, DiagramDescription diagramDescription, List<Object> diagramElements) {
+        return Palette.newPalette("papayaPalette")
+                .quickAccessTools(List.of())
+                .paletteEntries(List.of())
+                .build();
+    }
+}

--- a/packages/sirius-web/backend/sirius-web-papaya/src/main/java/org/eclipse/sirius/web/papaya/services/PapayaExplorerContentServiceDelegate.java
+++ b/packages/sirius-web/backend/sirius-web-papaya/src/main/java/org/eclipse/sirius/web/papaya/services/PapayaExplorerContentServiceDelegate.java
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.papaya.services;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.eclipse.sirius.components.core.api.IDefaultContentService;
+import org.eclipse.sirius.components.core.api.IEditingContext;
+import org.eclipse.sirius.components.diagrams.Diagram;
+import org.eclipse.sirius.web.application.UUIDParser;
+import org.eclipse.sirius.web.application.views.explorer.services.api.IExplorerContentServiceDelegate;
+import org.eclipse.sirius.web.domain.boundedcontexts.representationdata.RepresentationMetadata;
+import org.eclipse.sirius.web.papaya.representations.dashboarddiagram.PapayaDashboardDiagramDescriptionProvider;
+import org.eclipse.sirius.web.papaya.services.api.IPapayaCapableEditingContextPredicate;
+import org.springframework.data.jdbc.core.mapping.AggregateReference;
+import org.springframework.stereotype.Service;
+
+/**
+ * A specific Papaya Content Service to provide the Dashboard diagram item in Papaya projects.
+ *
+ * @author fbarbin
+ */
+@Service
+public class PapayaExplorerContentServiceDelegate implements IExplorerContentServiceDelegate {
+
+    public static final String PAPAYA_DASHBOARD_DIAGRAM = "Papaya Dashboard Diagram";
+
+    private final IPapayaCapableEditingContextPredicate papayaCapableEditingContextPredicate;
+
+    private final IDefaultContentService defaultContentService;
+
+    public PapayaExplorerContentServiceDelegate(IPapayaCapableEditingContextPredicate papayaCapableEditingContextPredicate, IDefaultContentService defaultContentService) {
+        this.papayaCapableEditingContextPredicate = Objects.requireNonNull(papayaCapableEditingContextPredicate);
+        this.defaultContentService = Objects.requireNonNull(defaultContentService);
+    }
+
+    @Override
+    public boolean canHandle(IEditingContext editingContext) {
+        return this.papayaCapableEditingContextPredicate.test(editingContext.getId());
+    }
+
+    @Override
+    public List<Object> getContents(IEditingContext editingContext) {
+        var content = new ArrayList<>();
+        this.getDashboardDiagramMetadata(editingContext).ifPresent(content::add);
+        content.addAll(this.defaultContentService.getContents(editingContext));
+        return content;
+    }
+
+    private Optional<RepresentationMetadata> getDashboardDiagramMetadata(IEditingContext editingContext) {
+        var optionalSemanticDataId = new UUIDParser().parse(editingContext.getId());
+        if (optionalSemanticDataId.isPresent()) {
+            var causeID = UUID.randomUUID();
+            var dashboardRepresentationMetadata = RepresentationMetadata.newRepresentationMetadata(PapayaDashboardDiagramDescriptionProvider.DASHBOARD_REPRESENTATION_ID)
+                    .representationMetadataId(UUID.fromString(PapayaDashboardDiagramDescriptionProvider.DASHBOARD_REPRESENTATION_ID))
+                    .semanticData(AggregateReference.to(optionalSemanticDataId.get()))
+                    .targetObjectId(editingContext.getId())
+                    .descriptionId(PapayaDashboardDiagramDescriptionProvider.DASHBOARD_DESCRIPTION_ID)
+                    .label(PAPAYA_DASHBOARD_DIAGRAM)
+                    .kind(Diagram.KIND)
+                    .documentation("")
+                    .iconURLs(List.of()).build(() -> causeID);
+
+            return Optional.of(dashboardRepresentationMetadata);
+        }
+        return Optional.empty();
+    }
+}

--- a/packages/sirius-web/backend/sirius-web/src/test/java/org/eclipse/sirius/web/application/controllers/diagrams/PapayaDashboardDiagramControllerTests.java
+++ b/packages/sirius-web/backend/sirius-web/src/test/java/org/eclipse/sirius/web/application/controllers/diagrams/PapayaDashboardDiagramControllerTests.java
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.application.controllers.diagrams;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.sirius.components.diagrams.tests.DiagramEventPayloadConsumer.assertRefreshedDiagramThat;
+
+import java.time.Duration;
+import java.util.UUID;
+import java.util.function.Consumer;
+
+import org.eclipse.sirius.components.collaborative.diagrams.dto.DiagramEventInput;
+import org.eclipse.sirius.components.diagrams.tests.graphql.DiagramEventSubscriptionRunner;
+import org.eclipse.sirius.web.AbstractIntegrationTests;
+import org.eclipse.sirius.web.data.PapayaIdentifiers;
+import org.eclipse.sirius.web.papaya.representations.dashboarddiagram.PapayaDashboardDiagramDescriptionProvider;
+import org.eclipse.sirius.web.tests.data.GivenSiriusWebServer;
+import org.eclipse.sirius.web.tests.services.api.IGivenInitialServerState;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.transaction.TestTransaction;
+import org.springframework.transaction.annotation.Transactional;
+
+import reactor.test.StepVerifier;
+
+/**
+ * Integration test to verify if we can open the Papaya Dashboard transient diagram.
+ *
+ * @author fbarbin
+ */
+@Transactional
+@SuppressWarnings("checkstyle:MultipleStringLiterals")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = { "sirius.web.test.enabled=studio" })
+public class PapayaDashboardDiagramControllerTests extends AbstractIntegrationTests {
+
+    @Autowired
+    private IGivenInitialServerState givenInitialServerState;
+
+    @Autowired
+    private DiagramEventSubscriptionRunner diagramEventSubscriptionRunner;
+
+    @BeforeEach
+    public void beforeEach() {
+        this.givenInitialServerState.initialize();
+    }
+
+    @Test
+    @GivenSiriusWebServer
+    @DisplayName("Given a server, when we subscribe to the dashboard diagram, then we can receive its content")
+    public void givenServerWhenWeSubscribeToTheDashboardDiagramThenWeCanReceiveItsContent() {
+        Consumer<Object> initialDiagramContentConsumer = assertRefreshedDiagramThat(diagram -> {
+            // Five projects are displayed : one from the library and 4 from the documents in the sample papaya project.
+            assertThat(diagram.getNodes()).hasSize(5);
+        });
+
+        var diagramEventInput = new DiagramEventInput(UUID.randomUUID(), PapayaIdentifiers.PAPAYA_EDITING_CONTEXT_ID.toString(), PapayaDashboardDiagramDescriptionProvider.DASHBOARD_REPRESENTATION_ID);
+        var result = this.diagramEventSubscriptionRunner.run(diagramEventInput);
+
+        TestTransaction.flagForCommit();
+        TestTransaction.end();
+        TestTransaction.start();
+
+        var flux = result.flux();
+        StepVerifier.create(flux).consumeNextWith(initialDiagramContentConsumer).thenCancel().verify(Duration.ofSeconds(10));
+    }
+}

--- a/packages/tables/backend/sirius-components-collaborative-tables/src/main/java/org/eclipse/sirius/components/collaborative/tables/TableEventProcessorFactory.java
+++ b/packages/tables/backend/sirius-components-collaborative-tables/src/main/java/org/eclipse/sirius/components/collaborative/tables/TableEventProcessorFactory.java
@@ -18,7 +18,7 @@ import java.util.Optional;
 
 import org.eclipse.sirius.components.collaborative.api.IRepresentationEventProcessor;
 import org.eclipse.sirius.components.collaborative.api.IRepresentationEventProcessorFactory;
-import org.eclipse.sirius.components.collaborative.api.IRepresentationPersistenceService;
+import org.eclipse.sirius.components.collaborative.api.IRepresentationPersistenceStrategy;
 import org.eclipse.sirius.components.collaborative.api.IRepresentationRefreshPolicyRegistry;
 import org.eclipse.sirius.components.collaborative.api.IRepresentationSearchService;
 import org.eclipse.sirius.components.collaborative.api.ISubscriptionManagerFactory;
@@ -60,7 +60,7 @@ public class TableEventProcessorFactory implements IRepresentationEventProcessor
 
     private final IRepresentationDescriptionSearchService representationDescriptionSearchService;
 
-    private final IRepresentationPersistenceService representationPersistenceService;
+    private final IRepresentationPersistenceStrategy representationPersistenceStrategy;
 
     private final IObjectSearchService objectSearchService;
 
@@ -74,11 +74,11 @@ public class TableEventProcessorFactory implements IRepresentationEventProcessor
 
     private final List<ICustomCellDescriptor> customCellDescriptors;
 
-    public TableEventProcessorFactory(RepresentationEventProcessorFactoryConfiguration configuration, IRepresentationPersistenceService representationPersistenceService,
+    public TableEventProcessorFactory(RepresentationEventProcessorFactoryConfiguration configuration, IRepresentationPersistenceStrategy representationPersistenceStrategy,
             IObjectSearchService objectSearchService, List<ITableEventHandler> tableEventHandlers, IURLParser urlParser, List<ICustomCellDescriptor> customCellDescriptors) {
         this.representationSearchService = Objects.requireNonNull(configuration.getRepresentationSearchService());
         this.representationDescriptionSearchService = Objects.requireNonNull(configuration.getRepresentationDescriptionSearchService());
-        this.representationPersistenceService = Objects.requireNonNull(representationPersistenceService);
+        this.representationPersistenceStrategy = Objects.requireNonNull(representationPersistenceStrategy);
         this.objectSearchService = Objects.requireNonNull(objectSearchService);
         this.tableEventHandlers = Objects.requireNonNull(tableEventHandlers);
         this.subscriptionManagerFactory = Objects.requireNonNull(configuration.getSubscriptionManagerFactory());
@@ -121,7 +121,7 @@ public class TableEventProcessorFactory implements IRepresentationEventProcessor
                         .build();
 
                 IRepresentationEventProcessor tableEventProcessor = new TableEventProcessor(tableCreationParameters, this.tableEventHandlers, new TableContext(table),
-                        this.subscriptionManagerFactory.create(), new SimpleMeterRegistry(), this.representationRefreshPolicyRegistry, this.representationPersistenceService);
+                        this.subscriptionManagerFactory.create(), new SimpleMeterRegistry(), this.representationRefreshPolicyRegistry, this.representationPersistenceStrategy);
                 return Optional.of(tableEventProcessor);
             }
         }


### PR DESCRIPTION
- We delegate the save operation to a new IRepresentationPersitenceStrategy service. It saves only if the representation exists in the database.
- We add a transient diagram sample in Papaya.

Bug: https://github.com/eclipse-sirius/sirius-web/issues/3305

# Pull request template

## General purpose
What is the main goal of this pull request?
- [ ] Bug fixes
- [x] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [x] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [x] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [x] Have the relevant issues been added to the pull request?
- [x] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [x] Have the relevant issues been added to the same project and milestone as the pull request?
- [x] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [X] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?