### PR TITLE
[5974] Tweak the node actions UI to reduce the risk of invoking them by mistake

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -228,7 +228,8 @@ Downstream applications can now implement `IProxyRemovalServiceDelegate` to cust
 - https://github.com/eclipse-sirius/sirius-web/issues/5946[#5946] [diagram] Prevent the border node label from overlapping the parent node by adjusting its position based on the position of the border node.
 - https://github.com/eclipse-sirius/sirius-web/issues/5969[#5969] [diagram] Prevent label to overflow child node during resize
 - https://github.com/eclipse-sirius/sirius-web/issues/6016[#6016] [diagram] Improve edge handles positioning logic
-
+- https://github.com/eclipse-sirius/sirius-web/issues/5974[#5974] [diagram] Tweak the node actions UI to reduce the risk of invoking them by mistake.
+The node action icons are now a little smaller and only appear after the node has been hovered for 0.5s.
 
 == 2025.12.0
 

--- a/packages/diagrams/frontend/sirius-components-diagrams/src/index.ts
+++ b/packages/diagrams/frontend/sirius-components-diagrams/src/index.ts
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 Obeo.
+ * Copyright (c) 2023, 2026 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -34,8 +34,13 @@ export type { GQLDiagram, GQLHandleLayoutData, GQLNodeLayoutData } from './graph
 export type { GQLEdge } from './graphql/subscription/edgeFragment.types';
 export { GQLViewModifier } from './graphql/subscription/nodeFragment.types';
 export type { GQLNode, GQLNodeStyle } from './graphql/subscription/nodeFragment.types';
+export { Action, ACTION_ICON_SIZE } from './renderer/actions/Action';
+export type { ActionProps } from './renderer/actions/Action.types';
+export { ActionsContainer } from './renderer/actions/ActionsContainer';
+export type { ActionsContainerProps } from './renderer/actions/ActionsContainer.types';
 export { diagramNodeActionOverrideContributionExtensionPoint } from './renderer/actions/DiagramNodeActionExtensionPoints';
 export type { DiagramNodeActionOverrideContribution } from './renderer/actions/DiagramNodeActionExtensionPoints.types';
+export { useActions } from './renderer/actions/useActions';
 export { ManageVisibilityContext } from './renderer/actions/visibility/ManageVisibilityContextProvider';
 export type { ManageVisibilityContextValue } from './renderer/actions/visibility/ManageVisibilityContextProvider.types';
 export { useConnectionLineNodeStyle } from './renderer/connector/useConnectionLineNodeStyle';
@@ -66,12 +71,15 @@ export { NodeContext } from './renderer/node/NodeContext';
 export type { NodeContextValue } from './renderer/node/NodeContext.types';
 export { NodeTypeContribution } from './renderer/node/NodeTypeContribution';
 export type { DiagramNodeType } from './renderer/node/NodeTypes.types';
+export { EdgeAppearanceSection } from './renderer/palette/appearance/edge/EdgeAppearanceSection';
 export type {
   PaletteAppearanceSectionContributionComponentProps,
   PaletteAppearanceSectionContributionProps,
 } from './renderer/palette/appearance/extensions/PaletteAppearanceSectionContribution.types';
 export { paletteAppearanceSectionExtensionPoint } from './renderer/palette/appearance/extensions/PaletteAppearanceSectionExtensionPoints';
+export { ImageNodeAppearanceSection } from './renderer/palette/appearance/ImageNodeAppearanceSection';
 export { LabelAppearancePart } from './renderer/palette/appearance/label/LabelAppearancePart';
+export { RectangularNodeAppearanceSection } from './renderer/palette/appearance/RectangularNodeAppearanceSection';
 export { useResetNodeAppearance } from './renderer/palette/appearance/useResetNodeAppearance';
 export { AppearanceColorPicker } from './renderer/palette/appearance/widget/AppearanceColorPicker';
 export { AppearanceNumberTextfield } from './renderer/palette/appearance/widget/AppearanceNumberTextfield ';
@@ -89,11 +97,3 @@ export { svgExportIElementSVGExportHandlerExtensionPoint } from './renderer/pane
 export type { GQLToolVariable, GQLToolVariableType } from './renderer/tools/useInvokePaletteTool.types';
 export { DiagramRepresentation } from './representation/DiagramRepresentation';
 export type { GQLDiagramDescription } from './representation/DiagramRepresentation.types';
-export { ImageNodeAppearanceSection } from './renderer/palette/appearance/ImageNodeAppearanceSection';
-export { RectangularNodeAppearanceSection } from './renderer/palette/appearance/RectangularNodeAppearanceSection';
-export { EdgeAppearanceSection } from './renderer/palette/appearance/edge/EdgeAppearanceSection';
-export { ActionsContainer } from './renderer/actions/ActionsContainer';
-export type { ActionsContainerProps } from './renderer/actions/ActionsContainer.types';
-export { Action } from './renderer/actions/Action';
-export type { ActionProps } from './renderer/actions/Action.types';
-export { useActions } from './renderer/actions/useActions';

--- a/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/actions/Action.tsx
+++ b/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/actions/Action.tsx
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 Obeo.
+ * Copyright (c) 2025, 2026 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -20,11 +20,14 @@ import { useInvokeAction } from './useInvokeAction';
 
 const useStyles = makeStyles()((theme) => ({
   actionIcon: {
+    alignSelf: 'start',
     '&:hover': {
       backgroundColor: theme.palette.action.selected,
     },
   },
 }));
+
+export const ACTION_ICON_SIZE = 10;
 
 export const Action = ({ action, diagramElementId }: ActionProps) => {
   const { classes } = useStyles();
@@ -45,7 +48,13 @@ export const Action = ({ action, diagramElementId }: ActionProps) => {
   } else {
     return (
       <IconButton className={classes.actionIcon} size="small" onClick={() => invokeAction(action)}>
-        <IconOverlay iconURLs={action.iconURLs} title={action.tooltip} alt={action.tooltip} />
+        <IconOverlay
+          iconURLs={action.iconURLs}
+          customIconWidth={ACTION_ICON_SIZE}
+          customIconHeight={ACTION_ICON_SIZE}
+          title={action.tooltip}
+          alt={action.tooltip}
+        />
       </IconButton>
     );
   }

--- a/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/actions/ActionsContainer.tsx
+++ b/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/actions/ActionsContainer.tsx
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 Obeo.
+ * Copyright (c) 2025, 2026 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -10,14 +10,14 @@
  * Contributors:
  *     Obeo - initial API and implementation
  *******************************************************************************/
-import { useContext } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import { makeStyles } from 'tss-react/mui';
+import { DiagramContext } from '../../contexts/DiagramContext';
+import { DiagramContextValue } from '../../contexts/DiagramContext.types';
 import { Action } from './Action';
 import { ActionsContainerProps } from './ActionsContainer.types';
 import { useActions } from './useActions';
 import { GQLAction } from './useActions.types';
-import { DiagramContextValue } from '../../contexts/DiagramContext.types';
-import { DiagramContext } from '../../contexts/DiagramContext';
 
 const useStyles = makeStyles()((theme) => ({
   actionsContainer: {
@@ -32,13 +32,30 @@ const useStyles = makeStyles()((theme) => ({
   },
 }));
 
+// How long the user has to hover on the element for the actions to be displayed (in ms).
+const REVEAL_DELAY = 500;
+
+const useDelayedToggle = (delay: number): boolean => {
+  const [toggle, setToggle] = useState<boolean>(false);
+  useEffect(() => {
+    const timeoutId = setTimeout(() => {
+      setToggle(true);
+    }, delay);
+    return () => clearTimeout(timeoutId);
+  }, []);
+  return toggle;
+};
+
 export const ActionsContainer = ({ diagramElementId }: ActionsContainerProps) => {
   const { classes } = useStyles();
 
-  const { actions } = useActions(diagramElementId);
   const { readOnly } = useContext<DiagramContextValue>(DiagramContext);
+  const delayPassed = useDelayedToggle(REVEAL_DELAY);
+  const shouldDisplay = delayPassed && !readOnly;
 
-  if (readOnly) {
+  const { actions } = useActions(diagramElementId, !shouldDisplay);
+
+  if (!shouldDisplay) {
     return null;
   }
 

--- a/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/actions/useActions.tsx
+++ b/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/actions/useActions.tsx
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 Obeo.
+ * Copyright (c) 2025, 2026 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -49,7 +49,7 @@ const isDiagramDescription = (
   representationDescription: GQLRepresentationDescription
 ): representationDescription is GQLDiagramDescription => representationDescription.__typename === 'DiagramDescription';
 
-export const useActions = (diagramElementId: string): UseActionsValue => {
+export const useActions = (diagramElementId: string, skip: boolean): UseActionsValue => {
   const { addErrorMessage } = useMultiToast();
   const { diagramId, editingContextId } = useContext<DiagramContextValue>(DiagramContext);
 
@@ -59,6 +59,7 @@ export const useActions = (diagramElementId: string): UseActionsValue => {
       diagramId,
       diagramElementId,
     },
+    skip,
   });
 
   useEffect(() => {

--- a/packages/sirius-web/frontend/sirius-web-application/src/diagrams/nodeaction/SiriusWebManageVisibilityNodeAction.tsx
+++ b/packages/sirius-web/frontend/sirius-web-application/src/diagrams/nodeaction/SiriusWebManageVisibilityNodeAction.tsx
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 Obeo.
+ * Copyright (c) 2025, 2026 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -11,6 +11,7 @@
  *     Obeo - initial API and implementation
  *******************************************************************************/
 import {
+  ACTION_ICON_SIZE,
   ActionProps,
   ManageVisibilityContext,
   ManageVisibilityContextValue,
@@ -24,6 +25,7 @@ import { makeStyles } from 'tss-react/mui';
 
 const useToolStyle = makeStyles()((theme: Theme) => ({
   actionIcon: {
+    alignSelf: 'start',
     '&:hover': {
       backgroundColor: theme.palette.action.selected,
     },
@@ -43,7 +45,7 @@ export const SiriusWebManageVisibilityNodeAction = ({ diagramElementId }: Action
       title={t('manageVisibility')}
       onClick={(event) => openDialog(event, diagramElementId)}
       data-testid="manage-visibility">
-      <VisibilityIcon sx={{ fontSize: 16 }} />
+      <VisibilityIcon sx={{ fontSize: ACTION_ICON_SIZE }} />
     </IconButton>
   );
 };


### PR DESCRIPTION
This also reduces the number of requests sent to the backend when the user moves the cusrors on a diagram, as we now only fetch the actions after a node has been hovered for 0.5s instead of immediately.

Before:

https://github.com/user-attachments/assets/455275a4-e9af-4693-b504-7088a3a38a68

After:


https://github.com/user-attachments/assets/51eddc90-3b1a-476a-8f8f-ffa265c30586

Bug: https://github.com/eclipse-sirius/sirius-web/issues/5974

# Pull request template

## General purpose
What is the main goal of this pull request?
- [ ] Bug fixes
- [x] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [ ] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [ ] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?