### PR TITLE
[6029] Fix a potential infitine loop when exporting some diagrams as SVG

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -176,7 +176,7 @@ Note that the impact analysis dialog may contain error messages _and_ partial im
 - https://github.com/eclipse-sirius/sirius-web/issues/6045[#6045] [diagram] Prevent misplacement of a subnode after hiding another list subnode
 - https://github.com/eclipse-sirius/sirius-web/issues/6073[#6073] [sirius-web] Fix typo in library publication and import commands.
 - https://github.com/eclipse-sirius/sirius-web/issues/6083[#6083] [diagram] Prevent border node labels from being too close to their node
-
+- https://github.com/eclipse-sirius/sirius-web/issues/6029[#6029] [diagram] Fix a potential infitine loop when exporting some diagrams as SVG
 
 === New Features
 

--- a/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/panel/experimental-svg-export/TextElementSVGExportHandler.ts
+++ b/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/panel/experimental-svg-export/TextElementSVGExportHandler.ts
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 Obeo.
+ * Copyright (c) 2026 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -121,7 +121,9 @@ export class TextElementSVGExportHandler implements IElementSVGExportHandler {
         const lineBounds: DOMRect = lineRange.getBoundingClientRect();
         if (lineBounds.height > oneCharHeight) {
           // We have a line break, update the range end to the previous character
-          lineRange.setEnd(textElement, --j);
+          if (j > i + 1) {
+            lineRange.setEnd(textElement, --j);
+          }
           shouldSwitchLine = true;
         } else if (j >= textContent.length) {
           // We reached the end of the text content


### PR DESCRIPTION
I'm not entirely sure about the fix, as I was only ever able to reproduce the issue inside SysON.

Bug: https://github.com/eclipse-sirius/sirius-web/issues/6029
Signed-off-by: Pierre-Charles David <pierre-charles.david@obeo.fr>
