### PR TITLE
[5889] In the Search view, make the Ctrl+Enter more visible

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -35,8 +35,7 @@
 === Improvements
 
 - https://github.com/eclipse-sirius/sirius-web/issues/6120[#6120] [sirius-web] Split the business code used to manage projects
-
-
+- https://github.com/eclipse-sirius/sirius-web/issues/5889[#5889] [sirius-web] In the _Search_ view, a placeholder text has been added to indicate that _Ctrl+Enter_ can be used to launch the search directly from the keyboard
 
 == 2026.1.0
 

--- a/packages/sirius-web/backend/sirius-web-application/src/main/resources/i18n/en/sirius-web-application.json
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/resources/i18n/en/sirius-web-application.json
@@ -283,7 +283,8 @@
     "matchCase": "Match Case",
     "matchWholeWord": "Match Whole Word",
     "useRegularExpression": "Use Regular Expression",
-    "clearText": "Clear Text"
+    "clearText": "Clear Text",
+    "launchSearchPlaceholder": "Hit Ctrl+Enter to launch search"
   },
   "searchResults": {
     "searchInProgress": "Search in progress...",

--- a/packages/sirius-web/backend/sirius-web-application/src/main/resources/i18n/fr/sirius-web-application.json
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/resources/i18n/fr/sirius-web-application.json
@@ -283,7 +283,8 @@
     "matchCase": "Respecter la casse",
     "matchWholeWord": "Mot entier",
     "useRegularExpression": "Utiliser une expression régulière",
-    "clearText": "Effacer le texte"
+    "clearText": "Effacer le texte",
+    "launchSearchPlaceholder": "Appuyez sur Ctrl+Entrée pour lancer la recherche"
   },
   "searchResults": {
     "searchInProgress": "Recherche en cours...",

--- a/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/workbench-views/search/SearchQueryInput.tsx
+++ b/packages/sirius-web/frontend/sirius-web-application/src/views/edit-project/workbench-views/search/SearchQueryInput.tsx
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2025 Obeo.
+ * Copyright (c) 2022, 2026 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -85,6 +85,7 @@ export const SearchQueryInput = ({ onLaunchSearch }: SearchQueryInputProps) => {
           size="small"
           fullWidth
           autoFocus
+          placeholder={t('launchSearchPlaceholder')}
           slotProps={{
             input: {
               startAdornment: (


### PR DESCRIPTION

<img width="648" height="324" alt="Capture d’écran du 2026-02-02 14-59-15" src="https://github.com/user-attachments/assets/0c1f67c6-9389-4690-9eb8-6d337a67ae3a" />

Bug: https://github.com/eclipse-sirius/sirius-web/issues/5889
Signed-off-by: Pierre-Charles David <pierre-charles.david@obeo.fr>
