### PR TITLE
[6200] Prevent list node from being resized smaller than layout size

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -62,6 +62,7 @@ The default tooltip used in the explorer can be reused thanks to `IExplorerToolt
 The resize is still constrained by its inside label
 - https://github.com/eclipse-sirius/sirius-web/issues/6105[#6105] [sirius-web] Fix representation opening in library browser.
 - https://github.com/eclipse-sirius/sirius-web/issues/6141|#6141] [table] Prevent tables in a form to share the same id
+- https://github.com/eclipse-sirius/sirius-web/issues/6200|#6200] [diagram] Prevent list node to be resized to a size smaller than that produced by the layout
 
 
 === New Features

--- a/integration-tests-playwright/playwright/resources/diagramPapayaClassNode.xml
+++ b/integration-tests-playwright/playwright/resources/diagramPapayaClassNode.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<papaya:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:papaya="https://www.eclipse.org/sirius-web/papaya" name="Project">
+  <elements xmi:type="papaya:Component" name="Component">
+    <packages>
+      <types xmi:type="papaya:Class" name="NewClass">
+        <attributes name="Attribute1"/>
+        <attributes name="Attribute2"/>
+        <operations name="OperationA"/>
+        <operations name="OperationB"/>
+      </types>
+    </packages>
+  </elements>
+</papaya:Project>

--- a/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/layout/ListNodeLayoutHandler.ts
+++ b/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/layout/ListNodeLayoutHandler.ts
@@ -34,6 +34,13 @@ import {
   setBorderNodesPosition,
 } from './layoutNode';
 
+const getChildNodeHeightMinFootPrint = (node: Node<NodeData>): number => {
+  if (node.type === 'iconLabelNode') {
+    return node.data.minComputedHeight ?? 0;
+  }
+  return node.data.resizedByUser ? node.height ?? 0 : getDefaultOrMinHeight(node.data.minComputedHeight ?? 0, node);
+};
+
 export class ListNodeLayoutHandler implements INodeLayoutHandler<ListNodeData> {
   public canHandle(node: Node<NodeData, DiagramNodeType>) {
     return node.type === 'listNode';
@@ -260,7 +267,7 @@ export class ListNodeLayoutHandler implements INodeLayoutHandler<ListNodeData> {
       .reduce((max, width) => Math.max(max, width), 0);
     node.data.minComputedWidth = Math.max(minComputeChildrenWidth, labelOnlyWidth) + borderWidth * 2;
     const minComputeChildrenHeight = directNodesChildren
-      .map((node) => (node.data.resizedByUser ? node.height ?? 0 : node.data.minComputedHeight ?? 0))
+      .map((node) => getChildNodeHeightMinFootPrint(node))
       .reduce((sum, height) => sum + height, 0);
     node.data.minComputedHeight = Math.max(
       childrenContentBox.y + minComputeChildrenHeight + borderWidth + node.data.bottomGap,


### PR DESCRIPTION
Bug: https://github.com/eclipse-sirius/sirius-web/issues/6200

# Pull request template

## General purpose
What is the main goal of this pull request?
- [ ] Bug fixes
- [ ] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [ ] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [ ] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?