### PR TITLE
[6209] Add support for i18n for the selection dialog

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -112,6 +112,7 @@ Trees defined via the view DSL can alternatively provide a tooltip expression vi
 - https://github.com/eclipse-sirius/sirius-web/issues/6065[#6065] [sirius-web] Rework the _New Project_ creation page to improve the UX
 - https://github.com/eclipse-sirius/sirius-web/issues/6110[#6110] [diagram] Preserve custom position for the handle during edge reconnection
 - https://github.com/eclipse-sirius/sirius-web/issues/6057[#6057] [diagram] Retrieve the label size from data rather than dom element for elk layout
+- https://github.com/eclipse-sirius/sirius-web/issues/6209[#6209] [selection] Add support for i18n for the selection dialog
 
 
 

--- a/packages/selection/backend/sirius-components-collaborative-selection/src/main/resources/i18n/en/sirius-components-selection.json
+++ b/packages/selection/backend/sirius-components-collaborative-selection/src/main/resources/i18n/en/sirius-components-selection.json
@@ -1,0 +1,7 @@
+{
+  "selectionDialog": {
+    "noSelectionOptionDescription": "Proceed without selecting an existing element",
+    "dialogTitle": "Element Selection",
+    "dialogConfirm": "Confirm"
+  }
+}

--- a/packages/selection/backend/sirius-components-collaborative-selection/src/main/resources/i18n/fr/sirius-components-selection.json
+++ b/packages/selection/backend/sirius-components-collaborative-selection/src/main/resources/i18n/fr/sirius-components-selection.json
@@ -1,0 +1,7 @@
+{
+  "selectionDialog": {
+    "noSelectionOptionDescription": "Poursuivre sans sélectionner d'élément(s) existant",
+    "dialogTitle": "Sélection d'élement(s)",
+    "dialogConfirm": "Confirmer"
+  }
+}

--- a/packages/selection/frontend/sirius-components-selection/src/SelectionDialog.tsx
+++ b/packages/selection/frontend/sirius-components-selection/src/SelectionDialog.tsx
@@ -22,6 +22,7 @@ import DialogTitle from '@mui/material/DialogTitle';
 import Radio from '@mui/material/Radio';
 import Typography from '@mui/material/Typography';
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { makeStyles } from 'tss-react/mui';
 import { SelectionDialogState } from './SelectionDialog.types';
 import { SelectionDialogTreeView } from './SelectionDialogTreeView';
@@ -46,6 +47,8 @@ export const SelectionDialog = ({
   onFinish,
 }: DiagramDialogComponentProps) => {
   const { classes } = useSelectionDialogStyles();
+  const { t } = useTranslation('sirius-components-selection', { keyPrefix: 'selectionDialog' });
+
   const [state, setState] = useState<SelectionDialogState>({
     selectedObjectIds: [],
     noSelectionOptionSelected: false,
@@ -129,7 +132,7 @@ export const SelectionDialog = ({
                   {noSelectionLabel}
                 </Typography>
                 <Typography className={classes.noSelectionSecondaryText}>
-                  Proceed without selecting an existing element
+                  {t('noSelectionOptionDescription')}
                 </Typography>
               </Box>
             </ButtonBase>
@@ -159,7 +162,7 @@ export const SelectionDialog = ({
       maxWidth="md"
       fullWidth
       data-testid="selection-dialog">
-      <DialogTitle id="selection-dialog-title">Element Selection</DialogTitle>
+      <DialogTitle id="selection-dialog-title">{t('dialogTitle')}</DialogTitle>
       <DialogContent
         dividers={true}
         sx={(theme) => ({ display: 'flex', flexDirection: 'column', gap: theme.spacing(1) })}>
@@ -172,7 +175,7 @@ export const SelectionDialog = ({
           data-testid="finish-action"
           color="primary"
           onClick={handleClick}>
-          Confirm
+          {t('dialogConfirm')}
         </Button>
       </DialogActions>
     </Dialog>

--- a/packages/selection/frontend/sirius-components-selection/src/SelectionDialog.types.ts
+++ b/packages/selection/frontend/sirius-components-selection/src/SelectionDialog.types.ts
@@ -11,14 +11,6 @@
  *     Obeo - initial API and implementation
  *******************************************************************************/
 
-export interface SelectionDialogProps {
-  editingContextId: string;
-  selectionRepresentationId: string;
-  targetObjectId: string;
-  onClose: () => void;
-  onFinish: (selectedObjectId: string) => void;
-}
-
 export interface SelectionDialogState {
   selectedObjectIds: string[];
   noSelectionOptionSelected: boolean;

--- a/packages/view/backend/sirius-components-view-emf/src/main/java/org/eclipse/sirius/components/view/emf/diagram/SelectionDialogDescriptionConverter.java
+++ b/packages/view/backend/sirius-components-view-emf/src/main/java/org/eclipse/sirius/components/view/emf/diagram/SelectionDialogDescriptionConverter.java
@@ -46,6 +46,7 @@ import org.eclipse.sirius.components.view.diagram.DialogDescription;
 import org.eclipse.sirius.components.view.diagram.SelectionDialogDescription;
 import org.eclipse.sirius.components.view.diagram.SelectionDialogTreeDescription;
 import org.eclipse.sirius.components.view.emf.api.IDialogDescriptionConverter;
+import org.eclipse.sirius.components.view.emf.messages.IViewEMFMessageService;
 import org.springframework.stereotype.Service;
 
 /**
@@ -82,12 +83,16 @@ public class SelectionDialogDescriptionConverter implements IDialogDescriptionCo
 
     private final IURLParser urlParser;
 
-    public SelectionDialogDescriptionConverter(IIdentityService identityService, IObjectSearchService objectSearchService, ILabelService labelService, IDiagramIdProvider diagramIdProvider, IURLParser urlParser) {
+    private final IViewEMFMessageService messageService;
+
+    public SelectionDialogDescriptionConverter(IIdentityService identityService, IObjectSearchService objectSearchService, ILabelService labelService, IDiagramIdProvider diagramIdProvider, IURLParser urlParser,
+            IViewEMFMessageService messageService) {
         this.identityService = Objects.requireNonNull(identityService);
         this.objectSearchService = Objects.requireNonNull(objectSearchService);
         this.labelService = Objects.requireNonNull(labelService);
         this.diagramIdProvider = Objects.requireNonNull(diagramIdProvider);
         this.urlParser = Objects.requireNonNull(urlParser);
+        this.messageService = Objects.requireNonNull(messageService);
     }
 
     @Override
@@ -119,14 +124,14 @@ public class SelectionDialogDescriptionConverter implements IDialogDescriptionCo
                 .messageProvider(variableManager -> {
                     String message = Optional.ofNullable(selectionDescription.getSelectionMessage()).orElse("");
                     if (message.isBlank()) {
-                        message = "Use an existing element";
+                        message = this.messageService.defaultSelectionMessage();
                     }
                     return message;
                 })
                 .noSelectionLabelProvider(variableManager -> {
                     String noSelectionLabel = Optional.ofNullable(selectionDescription.getNoSelectionLabel()).orElse("");
                     if (noSelectionLabel.isBlank()) {
-                        noSelectionLabel = "Confirm without selection";
+                        noSelectionLabel = this.messageService.defaultNoSelectionLabel();
                     }
                     return noSelectionLabel;
                 })

--- a/packages/view/backend/sirius-components-view-emf/src/main/java/org/eclipse/sirius/components/view/emf/messages/IViewEMFMessageService.java
+++ b/packages/view/backend/sirius-components-view-emf/src/main/java/org/eclipse/sirius/components/view/emf/messages/IViewEMFMessageService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 CEA LIST.
+ * Copyright (c) 2025, 2026 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -55,6 +55,10 @@ public interface IViewEMFMessageService {
     String defaultQuickToolUnPin();
 
     String defaultQuickToolEdit();
+
+    String defaultSelectionMessage();
+
+    String defaultNoSelectionLabel();
 
     /**
      * Implementation which does nothing, used for mocks in unit tests.
@@ -149,6 +153,16 @@ public interface IViewEMFMessageService {
 
         @Override
         public String defaultQuickToolEdit() {
+            return "";
+        }
+
+        @Override
+        public String defaultSelectionMessage() {
+            return "";
+        }
+
+        @Override
+        public String defaultNoSelectionLabel() {
             return "";
         }
     }

--- a/packages/view/backend/sirius-components-view-emf/src/main/java/org/eclipse/sirius/components/view/emf/messages/ViewEMFMessageService.java
+++ b/packages/view/backend/sirius-components-view-emf/src/main/java/org/eclipse/sirius/components/view/emf/messages/ViewEMFMessageService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 CEA LIST.
+ * Copyright (c) 2025, 2026 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -120,5 +120,15 @@ public class ViewEMFMessageService implements IViewEMFMessageService {
     @Override
     public String defaultQuickToolEdit() {
         return this.messageSourceAccessor.getMessage("EDIT");
+    }
+
+    @Override
+    public String defaultSelectionMessage() {
+        return this.messageSourceAccessor.getMessage("SELECTION_DIALOG__DEFAULT_MESSAGE");
+    }
+
+    @Override
+    public String defaultNoSelectionLabel() {
+        return this.messageSourceAccessor.getMessage("SELECTION_DIALOG__DEFAULT_NO_SELECTION_LABEL");
     }
 }

--- a/packages/view/backend/sirius-components-view-emf/src/main/resources/messages/sirius-components-view-emf.properties
+++ b/packages/view/backend/sirius-components-view-emf/src/main/resources/messages/sirius-components-view-emf.properties
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2025 Obeo.
+# Copyright (c) 2025, 2026 Obeo.
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v2.0
 # which accompanies this distribution, and is available at
@@ -28,3 +28,5 @@ HIDE=Hide
 PIN=Pin
 UNPIN=Unpin
 EDIT=Edit
+SELECTION_DIALOG__DEFAULT_MESSAGE=Use an existing element
+SELECTION_DIALOG__DEFAULT_NO_SELECTION_LABEL=Confirm without selection

--- a/packages/view/backend/sirius-components-view-emf/src/main/resources/messages/sirius-components-view-emf_fr.properties
+++ b/packages/view/backend/sirius-components-view-emf/src/main/resources/messages/sirius-components-view-emf_fr.properties
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2025 Obeo.
+# Copyright (c) 2025, 2026 Obeo.
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v2.0
 # which accompanies this distribution, and is available at
@@ -16,7 +16,7 @@ INVOKE_ACTION_ERROR=Une erreur s'est produite lors de l'exécution de l'action "
 CORE_PROPERTIES=Propriétés de base
 ADJUST_SIZE=Ajuster taille
 RESET_OUTSIDE_LABEL_POSITION=Réinitialiser label position
-RESET_LABEL_SIZE=R�initialiser la taille du label
+RESET_LABEL_SIZE=Réinitialiser la taille du label
 RESET_HANDLES_POSITION=Réinitialiser label position position
 RESET_BENDING_POINTS=Réinitialiser points d'encrage
 COLLAPSE=Minimiser
@@ -28,3 +28,5 @@ HIDE=Cacher
 PIN=Attacher
 UNPIN=Détacher
 EDIT=Editer
+SELECTION_DIALOG__DEFAULT_MESSAGE=Utiliser un élément existant
+SELECTION_DIALOG__DEFAULT_NO_SELECTION_LABEL=Confirmer sans sélection


### PR DESCRIPTION
- **[6209] Add support for i18n for the selection dialog**

# Pull request template

## General purpose
What is the main goal of this pull request?
- [ ] Bug fixes
- [ ] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [ ] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [ ] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?