### PR TITLE
[releng] Pin the GitHub actions used in our workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,26 +31,26 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         if: env.GITHUB_EVENT_NAME != 'pull_request'
         with:
           fetch-depth: 0
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         if: env.GITHUB_EVENT_NAME == 'pull_request'
         with:
           ref: ${{ env.GITHUB_EVENT_PR_HEAD_SHA }}
           persist-credentials: false
 
       - name: Setup Node SDK
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22.16
           registry-url: https://npm.pkg.github.com/
 
       - name: Cache Node.js modules
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.npm
           key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -59,7 +59,7 @@ jobs:
             ${{ runner.OS }}-
 
       - name: Setup Java SDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
           java-version: 17
           distribution: "temurin"
@@ -69,7 +69,7 @@ jobs:
           echo "git_describe=$(git describe)" >> $GITHUB_ENV
 
       - name: Cache Maven packages
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
@@ -126,7 +126,7 @@ jobs:
         working-directory: vscode-extension
 
       - name: Store the vscode extension
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: vscode
           path: vscode-extension/sirius-web-*.vsix
@@ -136,7 +136,7 @@ jobs:
         run: tar -cf coverage.tar packages/releng/backend/sirius-components-test-coverage/target/site/jacoco-aggregate
 
       - name: Store code coverage results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: jacoco
@@ -144,7 +144,7 @@ jobs:
           retention-days: 5
 
       - name: Store Core frontend code coverage results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: core
@@ -152,7 +152,7 @@ jobs:
           retention-days: 5
 
       - name: Store FormDescriptionEditors frontend code coverage results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: formdescriptioneditors
@@ -160,7 +160,7 @@ jobs:
           retention-days: 5
 
       - name: Store Forms frontend code coverage results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: forms
@@ -168,7 +168,7 @@ jobs:
           retention-days: 5
 
       - name: Store Trees frontend code coverage results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: trees
@@ -202,7 +202,7 @@ jobs:
             type=sha
 
       - name: Set up Docker Buildx to use cache feature
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Build Docker image
         id: build
@@ -239,7 +239,7 @@ jobs:
 
       - name: Store Playwright report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: playwright-report
           path: integration-tests-playwright/playwright-report/
@@ -253,7 +253,7 @@ jobs:
 
       - name: Run Cypress end to end tests against the sirius-web application
         if: startsWith(env.GITHUB_REF, 'refs/tags/v') == false && env.GITHUB_REF != 'refs/heads/master' && env.GITHUB_REF != 'refs/heads/cooldown'
-        uses: cypress-io/github-action@v6
+        uses: cypress-io/github-action@f790eee7a50d9505912f50c2095510be7de06aa7 # v6.10.9
         with:
           build: docker compose -f ../packages/sirius-web/backend/sirius-web/docker-compose.yml up -d
           start: |
@@ -271,7 +271,7 @@ jobs:
 
       - name: Store Cypress screenshots
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: cypress-screenshots
           path: integration-tests-cypress/target/screenshots/**/*.png

--- a/.github/workflows/ip-verify.yml
+++ b/.github/workflows/ip-verify.yml
@@ -9,15 +9,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
 
       - name: Setup Java SDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
           java-version: 11
 
       - name: Cache Maven packages
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -23,12 +23,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
           fetch-depth: 0
 
       - name: Setup Node SDK
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22.16
           registry-url: https://npm.pkg.github.com/
@@ -54,7 +54,7 @@ jobs:
         run: node scripts/check-milestone.js
 
       - name: Retrieve PR metadata
-        uses: octokit/graphql-action@abaeca7ba4f0325d63b8de7ef943c2418d161b93
+        uses: octokit/graphql-action@abaeca7ba4f0325d63b8de7ef943c2418d161b93 # v3.0.0
         id: pr-metadata
         with:
           query: |


### PR DESCRIPTION
Many of the versions we use are not the latest, but this PR voluntarily does not change that. It only pins the versions we currently use to explicit immutable commits instead of floating tags.