### PR TITLE
[6346] Ensure forms are read only when opened on a library

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -89,6 +89,8 @@ Add log messages for the manipulation of projects
 - https://github.com/eclipse-sirius/sirius-web/issues/5646[#5646] [diagram] Don't invoke deletion command for empty diagram selection
 - https://github.com/eclipse-sirius/sirius-web/issues/6363[#6363] [test] Add new architecture tests for data fetchers.
 They ensure that each data fetcher is annotated by a data fetcher annotation and has a name matching `<Type><Field>DataFetcher`.
+- https://github.com/eclipse-sirius/sirius-web/issues/6346[#6346] [form] Ensure forms are read-only when opened on a library editing context.
+The backend now sends a `canEdit=false` capability when subscribing to such form.
 
 
 

--- a/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/capability/services/FormCapabilitiesService.java
+++ b/packages/sirius-web/backend/sirius-web-application/src/main/java/org/eclipse/sirius/web/application/capability/services/FormCapabilitiesService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 Obeo.
+ * Copyright (c) 2025, 2026 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -40,7 +40,7 @@ public class FormCapabilitiesService implements IFormCapabilitiesService {
 
     @Override
     public FormCapabilitiesDTO getFormCapabilities(String editingContextId, String formId) {
-        boolean canEdit = true;
+        boolean canEdit = false;
         var optionalProjectId = this.projectEditingContextService.getProjectId(editingContextId);
         if (optionalProjectId.isPresent()) {
             canEdit = this.capabilityEvaluator.hasCapability(SiriusWebCapabilities.PROJECT, optionalProjectId.get(), SiriusWebCapabilities.Project.EDIT);

--- a/packages/sirius-web/backend/sirius-web/src/test/java/org/eclipse/sirius/web/application/controllers/forms/DetailsViewControllerIntegrationTests.java
+++ b/packages/sirius-web/backend/sirius-web/src/test/java/org/eclipse/sirius/web/application/controllers/forms/DetailsViewControllerIntegrationTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024, 2025 Obeo.
+ * Copyright (c) 2024, 2026 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -13,6 +13,7 @@
 package org.eclipse.sirius.web.application.controllers.forms;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.eclipse.sirius.components.forms.tests.FormEventPayloadConsumer.assertRefreshedFormThat;
 
 import java.time.Duration;
@@ -23,6 +24,7 @@ import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
+import org.eclipse.sirius.components.collaborative.forms.dto.FormCapabilitiesRefreshedEventPayload;
 import org.eclipse.sirius.components.collaborative.forms.dto.FormRefreshedEventPayload;
 import org.eclipse.sirius.components.forms.AbstractWidget;
 import org.eclipse.sirius.components.forms.Group;
@@ -90,7 +92,7 @@ public class DetailsViewControllerIntegrationTests extends AbstractIntegrationTe
     @Test
     @GivenSiriusWebServer
     @DisplayName("Given a read only object, when we subscribe to its details view, then the widget of the form are read only")
-    public void givenReadOnlyObjectWhenWeSubscribreToItsDetailsViewThenTheWidgetOfTheFormAreReadOnly() {
+    public void givenReadOnlyObjectWhenWeSubscribeToItsDetailsViewThenTheWidgetOfTheFormAreReadOnly() {
         var detailsRepresentationId = this.representationIdBuilder.buildDetailsRepresentationId(List.of(PapayaIdentifiers.PAPAYA_LIBRARY_OBJECT_SIRIUS_WEB_TESTS_DATA.toString()));
         var input = new DetailsEventInput(UUID.randomUUID(), PapayaIdentifiers.PAPAYA_EDITING_CONTEXT_ID.toString(), detailsRepresentationId);
         var flux = this.detailsEventSubscriptionRunner.run(input)
@@ -108,6 +110,26 @@ public class DetailsViewControllerIntegrationTests extends AbstractIntegrationTe
 
         StepVerifier.create(flux)
                 .consumeNextWith(formContentMatcher)
+                .thenCancel()
+                .verify(Duration.ofSeconds(10));
+    }
+
+    @Test
+    @GivenSiriusWebServer
+    @DisplayName("Given a library editing context, when we subscribe to the details view, then the form is read only")
+    public void givenLibraryEditingContextWhenWeSubscribeToDetailsViewThenFormIsReadOnly() {
+        var detailsRepresentationId = this.representationIdBuilder.buildDetailsRepresentationId(List.of(PapayaIdentifiers.PAPAYA_LIBRARY_JAVA_PACKAGE_ID.toString()));
+        var input = new DetailsEventInput(UUID.randomUUID(), PapayaIdentifiers.PAPAYA_LIBRARY_EDITING_CONTEXT_ID.toString(), detailsRepresentationId);
+        var flux = this.detailsEventSubscriptionRunner.run(input).flux();
+
+        Consumer<Object> formCapabilitiesMatcher = object -> Optional.of(object)
+                .filter(FormCapabilitiesRefreshedEventPayload.class::isInstance)
+                .map(FormCapabilitiesRefreshedEventPayload.class::cast)
+                .map(FormCapabilitiesRefreshedEventPayload::capabilities)
+                .ifPresentOrElse(capabilities -> assertThat(capabilities.canEdit()).isFalse(), () -> fail("Missing form capabilities"));
+
+        StepVerifier.create(flux)
+                .consumeNextWith(formCapabilitiesMatcher)
                 .thenCancel()
                 .verify(Duration.ofSeconds(10));
     }


### PR DESCRIPTION
Bug: https://github.com/eclipse-sirius/sirius-web/issues/6346
Fixes #6346 

# Pull request template

## General purpose
What is the main goal of this pull request?
- [ ] Bug fixes
- [x] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [x] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [x] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [x] Have the relevant issues been added to the pull request?
- [x] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [x] Have the relevant issues been added to the same project and milestone as the pull request?
- [x] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?

Create a studio and publish it.
Open the created library containing the domain model.
Select the diagram representation in the explorer -> the details view is read-only.


- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?