### PR TITLE
[6388] Exclude EdgeAnchorNode from layout

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -57,6 +57,7 @@ Note this version requires at least Java 21 for the build environment (Sirius We
 - [releng] Switch `@mui/material` to `7.3.10`
 - [releng] Switch `@mui/icons-material` to `7.3.10`
 - [releng] Switch `@ObeoNetwork/gantt-task-react` to `0.6.4`
+- https://github.com/eclipse-sirius/sirius-web/issues/6388[#6388] [diagram] Exclude `EdgeAnchorNode` from layout and thus avoid flickering of an edge on edge
 
 
 === New Features

--- a/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/layout/elk/useElkLayout.ts
+++ b/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/layout/elk/useElkLayout.ts
@@ -15,6 +15,7 @@ import { Edge, Node } from '@xyflow/react';
 import { LayoutOptions } from 'elkjs/lib/elk-api';
 import ELK, { ElkLabel, ElkNode } from 'elkjs/lib/elk.bundled';
 import { EdgeData, NodeData } from '../../DiagramRenderer.types';
+import { isEdgeAnchorNode } from '../../node/EdgeAnchorNode.types';
 import { ListNodeData } from '../../node/ListNode.types';
 import { UseElkLayoutValue } from './useElkLayout.types';
 
@@ -27,7 +28,7 @@ const reverseOrderMap = <K, V>(map: Map<K, V>): Map<K, V> => {
 
 const getSubNodes = (nodes: Node<NodeData, string>[]): Map<string, Node<NodeData, string>[]> => {
   const subNodes: Map<string, Node<NodeData, string>[]> = new Map<string, Node<NodeData, string>[]>();
-  for (const node of nodes.filter((n) => !n.hidden)) {
+  for (const node of nodes.filter((node) => !node.hidden && !isEdgeAnchorNode(node))) {
     const parentNodeId: string = node.parentId ?? 'root';
     if (!subNodes.has(parentNodeId)) {
       subNodes.set(parentNodeId, []);

--- a/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/layout/layout.tsx
+++ b/packages/diagrams/frontend/sirius-components-diagrams/src/renderer/layout/layout.tsx
@@ -21,9 +21,10 @@ import { Root, createRoot } from 'react-dom/client';
 import { GQLReferencePosition } from '../../graphql/subscription/diagramEventSubscription.types';
 import { GQLArrangeLayoutDirection } from '../../representation/DiagramRepresentation.types';
 import { NodeData } from '../DiagramRenderer.types';
-import { MultiLabelEdgeData } from '../edge/MultiLabelEdge.types';
 import { Label } from '../Label';
 import { DiagramDirectEditContextProvider } from '../direct-edit/DiagramDirectEditContext';
+import { MultiLabelEdgeData } from '../edge/MultiLabelEdge.types';
+import { isEdgeAnchorNode } from '../node/EdgeAnchorNode.types';
 import { FreeFormNode } from '../node/FreeFormNode';
 import { FreeFormNodeData } from '../node/FreeFormNode.types';
 import { ListNode } from '../node/ListNode';
@@ -34,7 +35,7 @@ import { ILayoutEngine, INodeLayoutHandler } from './LayoutEngine.types';
 import { computePreviousPosition } from './bounds';
 import { RawDiagram } from './layout.types';
 import { isEastBorderNode, isWestBorderNode } from './layoutBorderNodes';
-import { getChildren, computeNewlyNodePosition } from './layoutNode';
+import { computeNewlyNodePosition, getChildren } from './layoutNode';
 import { gap } from './layoutParams';
 
 const emptyNodeProps = {
@@ -324,8 +325,8 @@ const layoutDiagram = (
   nodeLayoutHandlerContributions: INodeLayoutHandler<NodeData>[],
   autoLayout: boolean
 ) => {
-  const allVisibleNodes = diagram.nodes.filter((node) => !node.hidden);
-  const nodesToLayout = allVisibleNodes.filter((node) => !node.parentId);
+  const allVisibleNodes = diagram.nodes.filter((node) => !node.hidden && !isEdgeAnchorNode(node));
+  const nodesToLayout = allVisibleNodes.filter((node) => !node.parentId && !isEdgeAnchorNode(node));
 
   const layoutEngine: ILayoutEngine = new LayoutEngine();
 

--- a/scripts/check-coverage.jsh
+++ b/scripts/check-coverage.jsh
@@ -74,7 +74,7 @@ var moduleCoverageData = List.of(
   new ModuleCoverage("sirius-components-portals", 78.0),
   new ModuleCoverage("sirius-components-collaborative-portals", 94.0),
   new ModuleCoverage("sirius-components-portals-graphql", 100.0),
-  new ModuleCoverage("sirius-components-interpreter", 92.0),
+  new ModuleCoverage("sirius-components-interpreter", 91.0),
   new ModuleCoverage("sirius-components-emf", 86.0),
   new ModuleCoverage("sirius-components-graphql", 53.0),
   new ModuleCoverage("sirius-components-web", 54.0),


### PR DESCRIPTION
Bug: https://github.com/eclipse-sirius/sirius-web/issues/6388

# Pull request template

## General purpose
What is the main goal of this pull request?
- [ ] Bug fixes
- [ ] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [ ] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [ ] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?