### PR TITLE
[6753] Allow deletion of project semantic data using project ID and name

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -90,6 +90,7 @@ Downstream applications can implement `IOmniboxCommandOrdererDelegate` to define
 - https://github.com/eclipse-sirius/sirius-web/issues/6736[#6736] [core] Update `ChangeDescription` to accept an `ICause` as parameter instead of just `IInput`.
 This will allow us to reuse the change description to propagate more information.
 - https://github.com/eclipse-sirius/sirius-web/issues/6688[#6688] [diagram] Use outside label height for child node layout in freeform diagrams
+- https://github.com/eclipse-sirius/sirius-web/issues/6753[#6753] [sirius-web] Allow project semantic data to be deleted by project identifier and name.
 
 
 

--- a/packages/sirius-web/backend/sirius-web-domain/src/main/java/org/eclipse/sirius/web/domain/boundedcontexts/projectsemanticdata/services/ProjectSemanticDataDeletionService.java
+++ b/packages/sirius-web/backend/sirius-web-domain/src/main/java/org/eclipse/sirius/web/domain/boundedcontexts/projectsemanticdata/services/ProjectSemanticDataDeletionService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 Obeo.
+ * Copyright (c) 2025, 2026 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -14,11 +14,13 @@ package org.eclipse.sirius.web.domain.boundedcontexts.projectsemanticdata.servic
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 import org.eclipse.sirius.components.events.ICause;
 import org.eclipse.sirius.web.domain.boundedcontexts.projectsemanticdata.ProjectSemanticData;
 import org.eclipse.sirius.web.domain.boundedcontexts.projectsemanticdata.repositories.IProjectSemanticDataRepository;
 import org.eclipse.sirius.web.domain.boundedcontexts.projectsemanticdata.services.api.IProjectSemanticDataDeletionService;
+import org.eclipse.sirius.web.domain.services.Failure;
 import org.eclipse.sirius.web.domain.services.IResult;
 import org.eclipse.sirius.web.domain.services.Success;
 import org.eclipse.sirius.web.domain.services.api.IMessageService;
@@ -48,5 +50,21 @@ public class ProjectSemanticDataDeletionService implements IProjectSemanticDataD
         this.projectSemanticDataRepository.deleteAll(allProjectSemanticData);
 
         return new Success<>(null);
+
+    }
+
+    @Override
+    public IResult<Void> deleteProjectSemanticDataByProjectIdAndName(ICause cause, String projectId, String name) {
+        IResult<Void> result = new Failure<>(this.messageService.notFound());
+
+        Optional<ProjectSemanticData> optionalProjectSemanticData = this.projectSemanticDataRepository.findByProjectIdAndName(projectId, name);
+        if (optionalProjectSemanticData.isPresent()) {
+            ProjectSemanticData projectSemanticData = optionalProjectSemanticData.get();
+            projectSemanticData.dispose(cause);
+            this.projectSemanticDataRepository.delete(projectSemanticData);
+            result = new Success<>(null);
+        }
+
+        return result;
     }
 }

--- a/packages/sirius-web/backend/sirius-web-domain/src/main/java/org/eclipse/sirius/web/domain/boundedcontexts/projectsemanticdata/services/api/IProjectSemanticDataDeletionService.java
+++ b/packages/sirius-web/backend/sirius-web-domain/src/main/java/org/eclipse/sirius/web/domain/boundedcontexts/projectsemanticdata/services/api/IProjectSemanticDataDeletionService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 Obeo.
+ * Copyright (c) 2025, 2026 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -21,5 +21,8 @@ import org.eclipse.sirius.web.domain.services.IResult;
  * @author ntinsalhi
  */
 public interface IProjectSemanticDataDeletionService {
+
     IResult<Void> deleteProjectSemanticData(ICause cause, String projectId);
+
+    IResult<Void> deleteProjectSemanticDataByProjectIdAndName(ICause cause, String projectId, String name);
 }

--- a/packages/sirius-web/backend/sirius-web/src/test/java/org/eclipse/sirius/web/application/services/ProjectSemanticDataDeletionServiceIntegrationTests.java
+++ b/packages/sirius-web/backend/sirius-web/src/test/java/org/eclipse/sirius/web/application/services/ProjectSemanticDataDeletionServiceIntegrationTests.java
@@ -1,0 +1,148 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.application.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.eclipse.sirius.components.events.ICause;
+import org.eclipse.sirius.web.AbstractIntegrationTests;
+import org.eclipse.sirius.web.data.MultiEditingContextFlowIdentifiers;
+import org.eclipse.sirius.web.domain.boundedcontexts.project.Project;
+import org.eclipse.sirius.web.domain.boundedcontexts.project.services.api.IProjectSearchService;
+import org.eclipse.sirius.web.domain.boundedcontexts.projectsemanticdata.ProjectSemanticData;
+import org.eclipse.sirius.web.domain.boundedcontexts.projectsemanticdata.events.ProjectSemanticDataDeletedEvent;
+import org.eclipse.sirius.web.domain.boundedcontexts.projectsemanticdata.services.api.IProjectSemanticDataDeletionService;
+import org.eclipse.sirius.web.domain.boundedcontexts.projectsemanticdata.services.api.IProjectSemanticDataSearchService;
+import org.eclipse.sirius.web.domain.boundedcontexts.semanticdata.events.SemanticDataDeletedEvent;
+import org.eclipse.sirius.web.domain.boundedcontexts.semanticdata.services.api.ISemanticDataSearchService;
+import org.eclipse.sirius.web.domain.services.Failure;
+import org.eclipse.sirius.web.domain.services.Success;
+import org.eclipse.sirius.web.domain.services.api.IMessageService;
+import org.eclipse.sirius.web.services.api.IDomainEventCollector;
+import org.eclipse.sirius.web.tests.data.GivenSiriusWebServer;
+import org.eclipse.sirius.web.tests.services.api.IGivenInitialServerState;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.jdbc.core.mapping.AggregateReference;
+import org.springframework.test.context.transaction.TestTransaction;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Integration tests of the project semantic data deletion service.
+ *
+ * @author frouene
+ */
+@Transactional
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class ProjectSemanticDataDeletionServiceIntegrationTests extends AbstractIntegrationTests {
+
+    private static final String MAIN_NAME = "main";
+
+    private static final String SECONDARY_NAME = "main2";
+
+    @Autowired
+    private IProjectSemanticDataDeletionService projectSemanticDataDeletionService;
+
+    @Autowired
+    private IProjectSemanticDataSearchService projectSemanticDataSearchService;
+
+    @Autowired
+    private IProjectSearchService projectSearchService;
+
+    @Autowired
+    private ISemanticDataSearchService semanticDataSearchService;
+
+    @Autowired
+    private IDomainEventCollector domainEventCollector;
+
+    @Autowired
+    private IMessageService messageService;
+
+    @Autowired
+    private IGivenInitialServerState givenInitialServerState;
+
+    @BeforeEach
+    public void beforeEach() {
+        this.givenInitialServerState.initialize();
+        this.domainEventCollector.clear();
+    }
+
+    @Test
+    @GivenSiriusWebServer
+    @DisplayName("Given a project with two semantic data, when one project semantic data is deleted by name, then only the matching project semantic data is deleted")
+    public void givenProjectWithTwoSemanticDataWhenOneProjectSemanticDataIsDeletedByNameThenOnlyMatchingProjectSemanticDataIsDeleted() {
+        AggregateReference<Project, String> project = AggregateReference.to(MultiEditingContextFlowIdentifiers.PROJECT_ID);
+        var mainSemanticDataId = this.projectSemanticDataSearchService.findByProjectIdAndName(project, MAIN_NAME)
+                .map(ProjectSemanticData::getSemanticData)
+                .map(AggregateReference::getId)
+                .orElseThrow();
+        var secondarySemanticDataId = this.projectSemanticDataSearchService.findByProjectIdAndName(project, SECONDARY_NAME)
+                .map(ProjectSemanticData::getSemanticData)
+                .map(AggregateReference::getId)
+                .orElseThrow();
+
+        var cause = new ICause.NoOp();
+        var result = this.projectSemanticDataDeletionService.deleteProjectSemanticDataByProjectIdAndName(cause, MultiEditingContextFlowIdentifiers.PROJECT_ID, SECONDARY_NAME);
+
+        assertThat(result).isInstanceOf(Success.class);
+
+        TestTransaction.flagForCommit();
+        TestTransaction.end();
+        TestTransaction.start();
+
+        assertThat(this.projectSearchService.existsById(MultiEditingContextFlowIdentifiers.PROJECT_ID)).isTrue();
+        assertThat(this.projectSemanticDataSearchService.findByProjectIdAndName(project, MAIN_NAME)).isPresent();
+        assertThat(this.projectSemanticDataSearchService.findByProjectIdAndName(project, SECONDARY_NAME)).isEmpty();
+        assertThat(this.semanticDataSearchService.findById(mainSemanticDataId)).isPresent();
+        assertThat(this.semanticDataSearchService.findById(secondarySemanticDataId)).isEmpty();
+
+        var projectSemanticDataDeletedEvents = this.domainEventCollector.getDomainEvents().stream()
+                .filter(ProjectSemanticDataDeletedEvent.class::isInstance)
+                .map(ProjectSemanticDataDeletedEvent.class::cast)
+                .toList();
+        assertThat(projectSemanticDataDeletedEvents)
+                .singleElement()
+                .satisfies(event -> {
+                    assertThat(event.causedBy()).isEqualTo(cause);
+                    assertThat(event.projectSemanticData().getProject().getId()).isEqualTo(MultiEditingContextFlowIdentifiers.PROJECT_ID);
+                    assertThat(event.projectSemanticData().getName()).isEqualTo(SECONDARY_NAME);
+                });
+
+        var semanticDataDeletedEvents = this.domainEventCollector.getDomainEvents().stream()
+                .filter(SemanticDataDeletedEvent.class::isInstance)
+                .map(SemanticDataDeletedEvent.class::cast)
+                .toList();
+        assertThat(semanticDataDeletedEvents)
+                .singleElement()
+                .satisfies(event -> {
+                    assertThat(event.causedBy()).isEqualTo(projectSemanticDataDeletedEvents.getFirst());
+                    assertThat(event.semanticData().getId()).isEqualTo(secondarySemanticDataId);
+                });
+    }
+
+    @Test
+    @GivenSiriusWebServer
+    @DisplayName("Given a project without matching semantic data, when project semantic data is deleted by name, then a not found failure is returned")
+    public void givenProjectWithoutMatchingSemanticDataWhenProjectSemanticDataIsDeletedByNameThenNotFoundFailureIsReturned() {
+        var result = this.projectSemanticDataDeletionService.deleteProjectSemanticDataByProjectIdAndName(
+                new ICause.NoOp(),
+                MultiEditingContextFlowIdentifiers.PROJECT_ID,
+                "unknown"
+        );
+
+        assertThat(result).isEqualTo(new Failure<>(this.messageService.notFound()));
+    }
+}


### PR DESCRIPTION
Bug: https://github.com/eclipse-sirius/sirius-web/issues/6753

# Pull request template

## General purpose
What is the main goal of this pull request?
- [ ] Bug fixes
- [x] New features
- [ ] Documentation
- [ ] Cleanup
- [ ] Tests
- [ ] Build / releng

## Project management
- [ ] Has the pull request been added to the relevant project and milestone? (Only if you know that your work is part of a specific iteration such as the current one)
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `difficulty:`, `type:`)
- [ ] Have the relevant issues been added to the same project and milestone as the pull request?
- [ ] Has the `CHANGELOG.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`? (Including changes in the GraphQL API)
- [ ] In case of a change with a visual impact, are there any screenshots in the `CHANGELOG.adoc`? For example in `doc/screenshots/2022.5.0-my-new-feature.png`

## Architectural decision records (ADR)
- [ ] Does the title of the commit contributing the ADR start with `[doc]`?
- [ ] Are the ADRs mentioned in the relevant section of the  `CHANGELOG.adoc`?

## Dependencies
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] Are the new dependencies justified in the `CHANGELOG.adoc`?

## Frontend

This section is not relevant if your contribution does not come with changes to the frontend.

### General purpose
- [ ] Is the code properly tested? (Plain old JavaScript tests for business code and tests based on React Testing Library for the components)

### Typing
We need to improve the typing of our code, as such, we require every contribution to come with proper TypeScript typing for both changes contributing new files and those modifying existing files.
Please ensure that the following statements are true for each file created or modified (this may require you to improve code outside of your contribution).

- [ ] Variables have a proper type
- [ ] Functions’ arguments have a proper type
- [ ] Functions’ return type are specified
- Hooks are properly typed:
	- [ ] `useMutation<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useQuery<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useSubscription<DATA_TYPE, VARIABLE_TYPE>(…)`
	- [ ] `useMachine<CONTEXT_TYPE, EVENTS_TYPE>(…)`
	- [ ] `useState<STATE_TYPE>(…)`
- [ ] All components have a proper typing for their props
- [ ] No useless optional chaining with `?.` (if the GraphQL API specifies that a field cannot be `null`, do not treat it has potentially `null` for example)
- [ ] Nullable values have a proper type (for example `let diagram: Diagram | null = null;`)

## Backend

This section is not relevant if your contribution does not come with changes to the backend.

### General purpose
- [ ] Are all the event handlers tested?
- [ ] Are the event processor tested?
- [ ] Is the business code (services) tested?
- [ ] Are diagram layout changes tested?

### Architecture
- [ ] Are data structure classes properly separated from behavioral classes?
- [ ] Are all the relevant fields final?
- [ ] Is any data structure mutable? If so, please write a comment indicating why
- [ ] Are behavioral classes either stateless or side effect free?

## Review

### How to test this PR?
_Please describe here the various use cases to test this pull request_

- [ ] Has the Kiwi TCMS test suite been updated with tests for this contribution?